### PR TITLE
add case '0' to switch statement

### DIFF
--- a/app/core/router.php
+++ b/app/core/router.php
@@ -134,6 +134,9 @@ class Router
 
                             //call method and pass any extra parameters to the method
                             switch ($params) {
+                                case '0':
+                                    $controller->$segments[1]();
+                                    break;
                                 case '1':
                                     $controller->$segments[1]($matched[0]);
                                     break;


### PR DESCRIPTION
If $params is equal to 0 he has no case and doesn't fit into the switch statement and causes a blank page
