### PR TITLE
Update database.php fixed multiple instances

### DIFF
--- a/app/helpers/database.php
+++ b/app/helpers/database.php
@@ -23,7 +23,7 @@ class Database extends PDO{
 	 */
 	function __construct ($group = FALSE) {
 		// Determining if exists or it's not empty, then use default group defined in config
-		$group = !$group || !is_array($group) ? array (
+		$group = !$group ? array (
 			'type' => DB_TYPE,
 			'host' => DB_HOST,
 			'name' => DB_NAME,


### PR DESCRIPTION
Fixed the problem with using multiple database instances and reusing them. This bug caused the PDO::prepare() error.
