### PR TITLE
Update view.php to make possible send HTTP headers

### DIFF
--- a/app/core/view.php
+++ b/app/core/view.php
@@ -8,7 +8,11 @@
  * @date June 27, 2014
  */
 class View {
-
+	
+	/**
+	 * @var array Array of HTTP headers
+	 */
+	private static headers = array();
 	/**
 	 * include template file
 	 * @param  string  $path  path to file from views folder
@@ -16,6 +20,11 @@ class View {
 	 * @param  array $error array of errors
 	 */
 	public static function render($path,$data = false, $error = false){
+		if (!headers_sent()) {
+			foreach (self::headers as $header) {
+				header($header, true);
+			}
+		}
 		require "app/views/$path.php";
 	}
 
@@ -25,7 +34,19 @@ class View {
 	 * @param  array $data  array of data
 	 */
 	public static function rendertemplate($path,$data = false){
+		if (!headers_sent()) {
+			foreach (self::headers as $header) {
+				header($header, true);
+			}
+		}
 		require "app/templates/". \helpers\Session::get('template') ."/$path.php";
 	}
 	
+	/**
+	 * add HTTP header to headers array 
+	 * @param  string  $header HTTP header text
+	 */
+	public function addheader($header) {
+		self::headers[] = $header;
+	}
 }


### PR DESCRIPTION
Added function `addheader($header)` to add headers in `view::headers` array and makes possible send header before template render via `rendertemplate()` or `render()` functions. Sorry for bad English.
