### PR TITLE
Add the support for multi-method Route Match

### DIFF
--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -14,14 +14,14 @@ namespace Core;
 class Route
 {
     /**
-     * @var string HTTP method or 'ANY'
+     * @var array Supported HTTP methods
      */
     private $methods = array();
 
     /**
      * @var string URL pattern
      */
-    private $pattern;
+    private $pattern = null;
 
     /**
      * @var callable Callback
@@ -29,7 +29,12 @@ class Route
     private $callback = null;
 
     /**
-     * @var array Route parameters
+     * @var string The matched HTTP method
+     */
+    private $method = null;
+
+    /**
+     * @var array The matched Route parameters
      */
     private $params = array();
 
@@ -41,13 +46,13 @@ class Route
     /**
      * Constructor.
      *
-     * @param string $methods HTTP methods
+     * @param string|array $method HTTP method(s)
      * @param string $pattern URL pattern
      * @param callable $callback Callback function
      */
-    public function __construct(array $methods, $pattern, $callback)
+    public function __construct($method, $pattern, $callback)
     {
-        $this->methods = $methods;
+        $this->methods = array_map('strtoupper', is_array($method) ? $method : array($method));
 
         $this->pattern = ! empty($pattern) ? $pattern : '/';
 
@@ -58,16 +63,19 @@ class Route
      * Checks if a URL and HTTP method matches the Route pattern.
      *
      * @param string $uri Requested URL
-     * @param $method
-     * @param bool $optionals
+     * @param $method Current HTTP method
+     * @param bool $optionals Use, or not, the support for the optional parameters
      * @return bool Match status
      * @internal param string $pattern URL pattern
      */
     public function match($uri, $method, $optionals = true)
     {
-        if (! in_array($method, $this->methods) && ! in_array('ANY', $this->methods)) {
+        if (! in_array('ANY', $this->methods) && ! in_array($method, $this->methods)) {
             return false;
         }
+
+        // Have a valid HTTP method for this Route; store it for later usage.
+        $this->method = $method;
 
         // Exact match Route.
         if ($this->pattern == $uri) {
@@ -104,11 +112,11 @@ class Route
     // Some Getters
 
     /**
-     * @return string
+     * @return array
      */
-    public function method()
+    public function methods()
     {
-        return $this->method;
+        return $this->methods;
     }
 
     /**
@@ -125,6 +133,14 @@ class Route
     public function callback()
     {
         return $this->callback;
+    }
+
+    /**
+     * @return string
+     */
+    public function method()
+    {
+        return $this->method;
     }
 
     /**

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -16,7 +16,7 @@ class Route
     /**
      * @var string HTTP method or 'ANY'
      */
-    private $method;
+    private $methods = array();
 
     /**
      * @var string URL pattern
@@ -41,13 +41,13 @@ class Route
     /**
      * Constructor.
      *
-     * @param string $method HTTP method
+     * @param string $methods HTTP methods
      * @param string $pattern URL pattern
      * @param callable $callback Callback function
      */
-    public function __construct($method, $pattern, $callback)
+    public function __construct(array $methods, $pattern, $callback)
     {
-        $this->method = strtoupper($method);
+        $this->methods = $methods;
 
         $this->pattern = ! empty($pattern) ? $pattern : '/';
 
@@ -65,7 +65,7 @@ class Route
      */
     public function match($uri, $method, $optionals = true)
     {
-        if (($this->method != $method) && ($this->method != 'ANY')) {
+        if (! in_array($method, $this->methods) && ! in_array('ANY', $this->methods)) {
             return false;
         }
 

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -119,12 +119,7 @@ class Router
     {
         $router =& self::getInstance();
 
-        // Ensure that the methods parameter is always an array.
-        $methods = is_array($methods) ? $methods : array($methods);
-
-        foreach ($methods as $method) {
-            $router->addRoute($method, $route, $callback);
-        }
+        $router->addRoute($methods, $route, $callback);
     }
 
     /**
@@ -164,13 +159,13 @@ class Router
     /**
      * Maps a Method and URL pattern to a Callback.
      *
-     * @param string $method HTTP metod to match
+     * @param string $methods HTTP metods to match
      * @param string $route URL pattern to match
      * @param callback $callback Callback object
      */
-    public function addRoute($method, $route, $callback = null)
+    public function addRoute($methods, $route, $callback = null)
     {
-        $method = strtoupper($method);
+        $methods = array_map('strtoupper', is_array($methods) ? $methods : array($methods));
 
         $pattern = ltrim($route, '/');
 
@@ -178,7 +173,7 @@ class Router
             $pattern = implode('/', self::$routeGroups) .'/' .$pattern;
         }
 
-        $route = new Route($method, $pattern, $callback);
+        $route = new Route($methods, $pattern, $callback);
 
         // Add the current Route instance to the known Routes list.
         array_push($this->routes, $route);

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -105,21 +105,21 @@ class Router
     {
         $router =& self::getInstance();
 
-        $router->defaultRoute = new Route('ANY', '(:all)', $callback);
+        $router->defaultRoute = new Route('any', '(:all)', $callback);
     }
 
     /**
      * Defines a multi-method Route Match.
      *
-     * @param array|string $methods The Route's method(s).
+     * @param array|string $method The Route's method(s).
      * @param string $route The Route definition.
      * @param callback $callback Callback object called to define the Routes.
      */
-    public static function match($methods, $route, $callback = null)
+    public static function match($method, $route, $callback = null)
     {
         $router =& self::getInstance();
 
-        $router->addRoute($methods, $route, $callback);
+        $router->addRoute($method, $route, $callback);
     }
 
     /**
@@ -141,7 +141,8 @@ class Router
     }
 
     /**
-     * Router callback
+     * Router Error Callback
+     *
      * @param null $callback
      * @return callback|null
      */
@@ -159,13 +160,13 @@ class Router
     /**
      * Maps a Method and URL pattern to a Callback.
      *
-     * @param string $methods HTTP metods to match
+     * @param string $method HTTP metod(s) to match
      * @param string $route URL pattern to match
      * @param callback $callback Callback object
      */
-    public function addRoute($methods, $route, $callback = null)
+    public function addRoute($method, $route, $callback = null)
     {
-        $methods = array_map('strtoupper', is_array($methods) ? $methods : array($methods));
+        $methods = array_map('strtoupper', is_array($method) ? $method : array($method));
 
         $pattern = ltrim($route, '/');
 

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -109,6 +109,25 @@ class Router
     }
 
     /**
+     * Defines a multi-method Route Match.
+     *
+     * @param array|string $methods The Route's method(s).
+     * @param string $route The Route definition.
+     * @param callback $callback Callback object called to define the Routes.
+     */
+    public static function match($methods, $route, $callback = null)
+    {
+        $router =& self::getInstance();
+
+        // Ensure that the methods parameter is always an array.
+        $methods = is_array($methods) ? $methods : array($methods);
+
+        foreach ($methods as $method) {
+            $router->addRoute($method, $route, $callback);
+        }
+    }
+
+    /**
      * Defines a Route Group.
      *
      * @param string $group The scope of the current Routes Group

--- a/system/Helpers/Response.php
+++ b/system/Helpers/Response.php
@@ -78,13 +78,11 @@ class Response
      */
     public static function addStatus($code)
     {
-        if (! isset(self::$status[$code])) {
-            return;
+        if (isset(self::$status[$code])) {
+            $httpProtocol = $_SERVER['SERVER_PROTOCOL'];
+
+            self::addHeader("$httpProtocol $code " . self::$status[$code]);
         }
-
-        $httpProtocol = $_SERVER['SERVER_PROTOCOL'];
-
-        self::addHeader("$httpProtocol $code " . self::$status[$code]);
     }
 
     /**
@@ -112,7 +110,7 @@ class Response
      */
     public static function sendHeaders()
     {
-        if (!headers_sent()) {
+        if (! headers_sent()) {
             foreach (self::$headers as $header) {
                 header($header, true);
             }


### PR DESCRIPTION
This last minute PR introduce a **Multi-Method Route Match**, extremely useful when dealing with CRUD forms, while is wanted to specify punctually the valid request methods.

Usage:

```php
Router::match(['get', 'post'], 'admin/users/(:num)/edit', 'App\Controllers\Admin\Users@edit');
```

Or, in the **ClassicRouter** case can be:

```php
Router::match(['get', 'post'], 'admin/users/(:num)/edit', 'admin/users/edit/$1');
```