### PR TITLE
Improve the Routes Groups and implement the Resource(ful) Routes groups

### DIFF
--- a/system/Net/Router.php
+++ b/system/Net/Router.php
@@ -142,14 +142,55 @@ class Router
      */
     public static function group($group, $callback)
     {
+        if(is_array($group)) {
+            $prefix    = $group['prefix'];
+            $namespace = $group['namespace'];
+        } else {
+            $prefix    = trim($group, '/');
+            $namespace = '';
+        }
+
         // Add the Route Group to the array.
-        array_push(self::$routeGroups, trim($group, '/'));
+        array_push(self::$routeGroups, array('prefix' => $prefix, 'namespace' => $namespace));
 
         // Call the Callback, to define the Routes on the current Group.
         call_user_func($callback);
 
         // Removes the last Route Group from the array.
         array_pop(self::$routeGroups);
+    }
+
+    /* The Resourcefull Routes in the Laravel Style.
+
+    Method     |  Path                 |  Action   |
+    -----------|-----------------------|-----------|
+    GET        |  /photo               |  index    |
+    GET        |  /photo/create        |  create   |
+    POST       |  /photo               |  store    |
+    GET        |  /photo/{photo}       |  show     |
+    GET        |  /photo/{photo}/edit  |  edit     |
+    PUT/PATCH  |  /photo/{photo}       |  update   |
+    DELETE     |  /photo/{photo}       |  destroy  |
+
+    */
+
+    /**
+     * Defines a Resourcefull Routes Group to a target Controller.
+     *
+     * @param string $basePath The base path of the resourcefull routes group
+     * @param string $controller The target Resourcefull Controller's name.
+     */
+    public static function resource($basePath, $controller)
+    {
+        $router =& self::getInstance();
+
+        $router->addRoute('get',                 $basePath,                 $controller .'@index');
+        $router->addRoute('get',                 $basePath .'/create',      $controller .'@create');
+        $router->addRoute('post',                $basePath,                 $controller .'@store');
+        $router->addRoute('get',                 $basePath .'/(:any)',      $controller .'@show');
+        $router->addRoute('get',                 $basePath .'/(:any)/edit', $controller .'@edit');
+        $router->addRoute(array('put', 'patch'), $basePath .'/(:any)',      $controller .'@update');
+        $router->addRoute('delete',              $basePath .'/(:any)',      $controller .'@delete');
     }
 
     /**
@@ -183,7 +224,25 @@ class Router
         $pattern = ltrim($route, '/');
 
         if (! empty(self::$routeGroups)) {
-            $pattern = implode('/', self::$routeGroups) .'/' .$pattern;
+            $prefixes  = array();
+            $namespace = '';
+
+            foreach (self::$routeGroups as $group) {
+                // Add the current prefix to the prefixes list.
+                array_push($prefixes, $group['prefix']);
+                // Keep always the last Controller's namespace.
+                $namespace = $group['namespace'];
+            }
+
+            // Adjust the Route PATTERN.
+            if(! empty($prefixes)) {
+                $pattern = implode('/', $prefixes) .'/' .$pattern;
+            }
+
+            // Adjust the Route CALLBACK, when it is not a Closure.
+            if(! empty($namespace) && ! is_object($callback)) {
+                $callback = $namespace .'\\' .$callback;
+            }
         }
 
         $route = new Route($methods, $pattern, $callback);


### PR DESCRIPTION
This PR introduce the ability to specify the Prefix and Namespace for the Route Groups and Resource(full) Routes.

The new **Router::group()** accept an array as first parameter and permit commands like:

```php
Router::group(['prefix' => 'admin', 'namespace' => 'App\Controllers\Admin'], function() {
    Router::match('get',            'users',             'Users@index');
    Router::match('get',            'users/create',      'Users@create');
    Router::match('post',           'users',             'Users@store');
    Router::match('get',            'users/(:any)',      'Users@show');
    Router::match('get',            'users/(:any)/edit', 'Users@edit');
    Router::match(['put', 'patch'], 'users/(:any)',      'Users@update');
    Router::match('delete',         'users/(:any)',      'Users@destroy');

    Router::match('get',            'categories',             'Categories@index');
    Router::match('get',            'categories/create',      'Categories@create');
    Router::match('post',           'categories',             'Categories@store');
    Router::match('get',            'categories/(:any)',      'Categories@show');
    Router::match('get',            'categories/(:any)/edit', 'Categories@edit');
    Router::match(['put', 'patch'], 'categories/(:any)',      'Categories@update');
    Router::match('delete',         'categories/(:any)',      'Categories@destroy');

    Router::match('get',            'articles',             'Articles@index');
    Router::match('get',            'articles/create',      'Articles@create');
    Router::match('post',           'articles',             'Articles@store');
    Router::match('get',            'articles/(:any)',      'Articles@show');
    Router::match('get',            'articles/(:any)/edit', 'Articles@edit');
    Router::match(['put', 'patch'], 'articles/(:any)',      'Articles@update');
    Router::match('delete',         'articles/(:any)',      'Articles@destroy');
});
```

The new method **Router::resource()** introduce the ability to write in one command a group of resourceful routes, in the Laravel style, with the following specifications:

|  HTTP Method     |  Route                  |  Controller Method   |
|  ---------- |  ----------------  |  ----------  |
|  GET        |  /photo               |  index    |
|  GET        |  /photo/create        |  create   |
|  POST       |  /photo               |  store    |
|  GET        |  /photo/(:any)       |  show     |
|  GET        |  /photo/(:any)/edit  |  edit     |
|  PUT/PATCH  |  /photo/(:any)       |  update   |
|  DELETE     |  /photo/(:any)       |  destroy  |


Practically,the previous code snippet can be written also as:

```php
Router::group(['prefix' => 'admin', 'namespace' => 'App\Controllers\Admin'], function() {
    Router::resource('users', 'Users');
    Router::resource('categories', 'Categories');
    Router::resource('articles', 'Articles');
});
```

OR

```php
Router::resource('admin/users', 'App\Controllers\Admin\Users');
Router::resource('admin/categories', 'App\Controllers\Admin\Categories');
Router::resource('admin/articles', 'App\Controllers\Admin\Articles');
```
