### PR TITLE
Support the Deep Grouping into Routing

### DIFF
--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -222,23 +222,27 @@ class Router
         $pattern = ltrim($route, '/');
 
         if (! empty(self::$routeGroups)) {
-            $prefixes  = array();
+            $parts     = array();
             $namespace = '';
 
             foreach (self::$routeGroups as $group) {
                 // Add the current prefix to the prefixes list.
-                array_push($prefixes, $group['prefix']);
+                array_push($parts, $group['prefix']);
                 // Keep always the last Controller's namespace.
                 $namespace = $group['namespace'];
             }
 
+            if (! empty($pattern)) {
+                array_push($parts, $pattern);
+            }
+
             // Adjust the Route PATTERN.
-            if(! empty($prefixes)) {
-                $pattern = implode('/', $prefixes) .'/' .$pattern;
+            if (! empty($parts)) {
+                $pattern = implode('/', $parts);
             }
 
             // Adjust the Route CALLBACK, when it is not a Closure.
-            if(! empty($namespace) && ! is_object($callback)) {
+            if (! empty($namespace) && ! is_object($callback)) {
                 $callback = $namespace .'\\' .$callback;
             }
         }


### PR DESCRIPTION
Associated with the case presented by #715, right now the Routing doesn't support **Deep Grouping**, aka grouping the Routes until one of them come to have an empty "route" parameter. For example:

```php
Router::group('admin', function() {
    Router::any('', 'App\Controllers\Admin\Dashboard@index');
    ...
});
``` 

This PR fix the behavior and permit to have that Deep Grouping.