### PR TITLE
Consolidate the Framework's bootstrap

### DIFF
--- a/app/Routes.php
+++ b/app/Routes.php
@@ -10,9 +10,6 @@
 use Core\Router;
 use Helpers\Hooks;
 
-/** Get the Router instance. */
-$router = Router::getInstance();
-
 /** Define static routes. */
 
 // Default Routing
@@ -28,6 +25,3 @@ $hooks->run('routes');
 
 /** If no route found. */
 Router::error('Core\Error@index');
-
-/** Execute matched routes. */
-$router->dispatch();

--- a/public/index.php
+++ b/public/index.php
@@ -64,11 +64,5 @@ if (defined('ENVIRONMENT')) {
 
 }
 
-/** initiate Alias */
-new Core\Alias();
-
-/** initiate config */
-new \App\Config();
-
-/** load routes */
-require APPDIR.'Routes.php';
+/** Boot the Framework */
+require SYSTEMDIR.'bootstrap.php';

--- a/public/index.php
+++ b/public/index.php
@@ -64,5 +64,5 @@ if (defined('ENVIRONMENT')) {
 
 }
 
-/** Boot the Framework */
+/** Bootstrap the Framework */
 require SYSTEMDIR.'bootstrap.php';

--- a/public/index.php
+++ b/public/index.php
@@ -4,10 +4,10 @@ defined('DS') || define('DS', DIRECTORY_SEPARATOR);
 
 /** Define the absolute paths for configured directories */
 
-define('APPDIR', realpath(__DIR__.'/../app/').'/');
-define('SYSTEMDIR', realpath(__DIR__.'/../system/').'/');
-define('PUBLICDIR', realpath(__DIR__).'/');
-define('ROOTDIR', realpath(__DIR__.'/../').'/');
+define('APPDIR', realpath(__DIR__.'/../app/') .DS);
+define('SYSTEMDIR', realpath(__DIR__.'/../system/') .DS);
+define('PUBLICDIR', realpath(__DIR__) .DS);
+define('ROOTDIR', realpath(__DIR__.'/../') .DS);
 
 /** load composer autoloader */
 if (file_exists(ROOTDIR.'vendor/autoload.php')) {
@@ -65,4 +65,4 @@ if (defined('ENVIRONMENT')) {
 }
 
 /** Bootstrap the Framework */
-require SYSTEMDIR.'bootstrap.php';
+require SYSTEMDIR .'bootstrap.php';

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Bootstrap handler - perform the Nova Framework's bootstrap stage.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ * @date April 10th, 2016
+ */
+
+use Core\Router;
+
+/** initiate Alias */
+new \Core\Alias();
+
+/** initiate config */
+new \App\Config();
+
+/** Get the Router instance. */
+$router = Router::getInstance();
+
+/** load routes */
+require APPDIR.'Routes.php';
+
+/** Execute matched routes. */
+$router->dispatch();


### PR DESCRIPTION
Rationale:

Right now, the Framework's bootstrap is divided in two files: **public/index,php** and **APPDIR.Routes.php**

This design permit using a unique file for bootstrapping the Framework and isolation between Routes definition and execution.

As collateral advantage, permit the creation, eventually, of a console command to **dump the Routes**, an very useful thing when the **Router::resource()**s are used.