### PR TITLE
Improve the boostrap stage

### DIFF
--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -11,16 +11,15 @@ use Core\Aliases;
 use Core\Router;
 use Helpers\Session;
 
+/** Turn on the custom error handling. */
+set_exception_handler('Core\Logger::ExceptionHandler');
+set_error_handler('Core\Logger::ErrorHandler');
 
 /** Turn on output buffering. */
 ob_start();
 
 /** Load the Configuration. */
 require APPDIR .'Config.php';
-
-/** Turn on the custom error handling. */
-set_exception_handler('Core\Logger::ExceptionHandler');
-set_error_handler('Core\Logger::ErrorHandler');
 
 /** Set the Default Timezone. */
 date_default_timezone_set(DEFAULT_TIMEZONE);


### PR DESCRIPTION
Yet another small PR. Rationale:

If someone seriously mess with **app/Config.php** file, because our custom error handler is not yet active, the errors will be dumped to user into ol'good php way.

Solution? To move the setup of the error handler before everything into bootstrap stage run. 