### PR TITLE
Split the Core\Error Controller part to App\Controllers\Error

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -11,7 +11,6 @@ use Helpers\Url;
 */
 class Demo extends Controller
 {
-
     /**
      * Call the parent construct
      */

--- a/app/Controllers/Error.php
+++ b/app/Controllers/Error.php
@@ -1,0 +1,34 @@
+<?php
+namespace App\Controllers;
+
+use Core\Controller;
+use Core\View;
+
+/**
+ * Error controller to generate 404 pages.
+ */
+class Error extends Controller
+{
+    /**
+     * Call the parent construct.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Load a 404 page with the Error message.
+     */
+    public function index($error)
+    {
+        $data['title'] = '404';
+        $data['error'] = $error;
+
+        View::addHeader("HTTP/1.0 404 Not Found");
+
+        View::renderTemplate('header', $data);
+        View::render('Error/404', $data);
+        View::renderTemplate('footer', $data);
+    }
+}

--- a/app/Controllers/Language.php
+++ b/app/Controllers/Language.php
@@ -1,14 +1,26 @@
 <?php
 namespace App\Controllers;
 
+use Core\Controller;
 use Core\Language as CoreLanguage;
 use Helpers\Url;
 use Helpers\Cookie;
 use Helpers\Session;
 
 
-class Language
+class Language extends Controller
 {
+    /**
+     * Call the parent construct.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Change the Framework Language.
+     */
     public function change($language)
     {
         // Only set language if it's in the Languages array

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -6,9 +6,9 @@
  * @version 3.0
  */
 
-/** Create alias for Router. */
 use Core\Router;
 use Helpers\Hooks;
+
 
 /** Define static routes. */
 
@@ -19,12 +19,13 @@ Router::any('admin/(:any)(/(:any)(/(:any)(/(:any))))', 'App\Controllers\Demo@tes
 
 // The Framework's Language Changer.
 Router::any('language/(:any)', 'App\Controllers\Language@change');
-/** End default routes */
+/** End default Routes */
 
-/** Module routes. */
+/** Module Routes. */
 $hooks = Hooks::get();
-$hooks->run('routes');
-/** End Module routes. */
 
-/** If no route found. */
-Router::error('Core\Error@index');
+$hooks->run('routes');
+/** End Module Routes. */
+
+/** If no Route found. */
+Router::error('App\Controllers\Error@index');

--- a/app/Views/Error/404.php
+++ b/app/Views/Error/404.php
@@ -1,15 +1,10 @@
-<?php
-
-use Core\Error;
-
-?>
 <div class="container content">
 	<div class="row">
 		<div class="col-md-12">
 
 			<h1>404</h1>
 
-			<?php echo $data['error'];?>
+			<?= $error; ?>
 
 			<hr />
 

--- a/system/Core/Error.php
+++ b/system/Core/Error.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Error class - calls a 404 page.
+ * Error class.
  *
  * @author David Carr - dave@novaframework.com
  * @version 3.0
@@ -8,47 +8,11 @@
 
 namespace Core;
 
-use Core\Controller;
-use Core\View;
-
 /**
- * Error class to generate 404 pages.
+ * Error class.
  */
-class Error extends Controller
+class Error
 {
-    /**
-     * $error holder.
-     *
-     * @var string
-     */
-    private $error = null;
-
-    /**
-     * Save error to $this->error.
-     *
-     * @param string $error
-     */
-    public function __construct($error = null)
-    {
-        parent::__construct();
-        $this->error = $error;
-    }
-
-    /**
-     * Load a 404 page with the error message.
-     */
-    public function index($error = null)
-    {
-        header("HTTP/1.0 404 Not Found");
-
-        $data['title'] = '404';
-        $data['error'] = $error ? $error : $this->error;
-
-        View::renderTemplate('header', $data);
-        View::render('Error/404', $data);
-        View::renderTemplate('footer', $data);
-    }
-
     /**
      * Display errors.
      *

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -46,7 +46,7 @@ class Router
      *
      * @var null $errorCallback
      */
-    private $errorCallback = '\Core\Error@index';
+    private $errorCallback = '\App\Controllers\Error@index';
 
 
     /**


### PR DESCRIPTION
###  Rationale

Right now Core\Error behave as Error fallback Controller for Routing and also as processor of errors.

Yet, I believe that is better to give to end-user the ability to customize as he wish the **Error Controller** and as he need (e.g. with custom templating), without to touch the System files and the associated View is already living into App/Views.

 Spliting the **Core\Error**'s Controller part to **App\Controllers\Error** make, in my opinion, the framework to be more consistent and versatile, while not making the Routing to call system classes. After all, the Routing should call its App's Controllers, right?

In other hand, this PR adjust the **App\Controllers\Language** to become a real Controller and the associated Routing configuration affected by Error Controller change are updated.