### PR TITLE
Make the third parameter of View::render() to be an (optional) Module name

### DIFF
--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -80,7 +80,7 @@ class View
      */
     public static function renderModule($path, $data = false, $error = false)
     {
-        if($error !== false) {
+        if(($error !== false) && isset($data['error'])) {
             // Adjust the errors data handling, injecting it into $data.
             $data['error'] = $error;
         }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -48,8 +48,6 @@ class View
      */
     public static function render($path, $data = false, $module = false)
     {
-        self::sendHeaders();
-
         // Pass data to check and store it.
         $data = self::prepareData($data);
 
@@ -66,6 +64,8 @@ class View
         }
 
         // Render the View.
+        self::sendHeaders();
+
         require APPDIR .$filePath;
     }
 
@@ -99,8 +99,6 @@ class View
      */
     public static function renderTemplate($path, $data = false, $custom = TEMPLATE)
     {
-        self::sendHeaders();
-
         // Pass data to check and store it.
         $data = self::prepareData($data);
 
@@ -111,6 +109,9 @@ class View
         foreach ($data as $name => $value) {
             ${$name} = $value;
         }
+
+        // Render the Template.
+        self::sendHeaders();
 
         require APPDIR .$filePath;
     }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -81,7 +81,7 @@ class View
     public static function renderModule($path, $data = false, $error = false)
     {
         if(($error !== false) && ! isset($data['error'])) {
-            // Adjust the errors data handling, injecting it into $data.
+            // Adjust the $error parameter handling, injecting it into $data.
             $data['error'] = $error;
         }
 

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -87,7 +87,7 @@ class View
 
         if (preg_match('#^(.+)/Views/(.*)$#i', $path, $matches)) {
             // Render the Module's View using the standard 'render' way.
-            self::render($matches[1], $data, $matches[0]);
+            self::render($matches[2], $data, $matches[1]);
         }
     }
 

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -33,7 +33,7 @@ class View
         ob_start();
 
         // Render the requested View.
-        self::render($path, $data, $module);
+        self::render($path, $data, $module, false);
 
         // Return the captured output.
         return ob_get_clean();
@@ -46,7 +46,7 @@ class View
      * @param  array  $data  array of data
      * @param  string|false  $module module name or false
      */
-    public static function render($path, $data = false, $module = false)
+    public static function render($path, $data = false, $module = false, $withHeaders = true)
     {
         // Pass data to check and store it.
         $data = self::prepareData($data);
@@ -64,7 +64,9 @@ class View
         }
 
         // Render the View.
-        self::sendHeaders();
+        if($withHeaders) {
+            self::sendHeaders();
+        }
 
         require APPDIR .$filePath;
     }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -45,6 +45,7 @@ class View
      * @param  string $path  path to file from views folder
      * @param  array  $data  array of data
      * @param  string|false  $module module name or false
+     * @param  bool   $withHeaders send or not the stored Headers
      */
     public static function render($path, $data = false, $module = false, $withHeaders = true)
     {

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -72,6 +72,26 @@ class View
     }
 
     /**
+     * Include template file.
+     *
+     * @param  string  $path  path to file from Modules folder
+     * @param  array $data  array of data
+     * @param  array $error array of errors
+     */
+    public static function renderModule($path, $data = false, $error = false)
+    {
+        if($error !== false) {
+            // Adjust the errors data handling, injecting it into $data.
+            $data['error'] = $error;
+        }
+
+        if (preg_match('#^(.+)/Views/(.*)$#i', $path, $matches)) {
+            // Render the Module's View using the standard 'render' way.
+            self::render($matches[1], $data, $matches[0]);
+        }
+    }
+
+    /**
      * Return absolute path to selected template directory.
      *
      * @param  string  $path  path to file from views folder

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -80,7 +80,7 @@ class View
      */
     public static function renderModule($path, $data = false, $error = false)
     {
-        if(($error !== false) && isset($data['error'])) {
+        if(($error !== false) && ! isset($data['error'])) {
             // Adjust the errors data handling, injecting it into $data.
             $data['error'] = $error;
         }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -70,27 +70,6 @@ class View
     }
 
     /**
-     * Include template file.
-     *
-     * @param  string  $path  path to file from Modules folder
-     * @param  array $data  array of data
-     * @param  array $error array of errors
-     */
-    public static function renderModule($path, $data = false, $error = false)
-    {
-        self::sendHeaders();
-
-        // Pass data to check and store it.
-        $data = self::prepareData($data);
-
-        foreach ($data as $name => $value) {
-            ${$name} = $value;
-        }
-
-        require APPDIR."Modules/$path.php";
-    }
-
-    /**
      * Return absolute path to selected template directory.
      *
      * @param  string  $path  path to file from views folder


### PR DESCRIPTION
#### Rationale

Right now, **View::render()** use to have as third parameter an (legacy?) array of errors, while that parameter is not really necesary now, while the View rendering extract the parameters from the second parameter $data. 

In fact, if **$data** contains an element called "error", it will override the array passed as third parameter, logic prone to generate mysterious rendering errors per-se.

In other hand, passing as third parameter the optional name of the Module, just like into **View::fetch()** is of nature to simplify the View class design (literally making obsolete the **View::renderModule()**), to offer a consistent API with **View::fetch()** and **View::renderTemplate()** and, why not? to offer an alternative to writing **View::renderTemplate()**'s long commands.

Then, instead of:
```php
View::renderModule('Pages/Views/Page/Index', $data);
```
we can use directly:
```php
View::render('Page/Index', $data, 'Pages');
```

Which is directly consistent with:
```php
$content = View::fetch('Page/Index', $data, 'Pages');
```
and similar to:
```php
View::renderTemplate('header', $data, 'Admin');
```

To note that pull request introduce a very small API incompatibility, about the **View::render()** third parameter, when the $error is passed this way, which can be resolved very simple (and in a more safe way) integrating the **$error** into **$data**, with:
```php
$data['error'] = $error;
``` 