### PR TITLE
Implementation of Route Filters support into Routing and other improvements

### DIFF
--- a/app/Filters.php
+++ b/app/Filters.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Routing Filters - all standard Routing Filters are defined here.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ * @date April 19th, 2016
+ */
+
+use Core\Route;
+
+
+/** Define Route Filters. */
+
+// A Testing Filter which dump the matched Route.
+Route::filter('test', function($route) {
+    echo '<pre>' .var_export($route, true) .'</pre>';
+});

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -15,7 +15,11 @@ use Helpers\Hooks;
 // Default Routing
 Router::any('', 'App\Controllers\Welcome@index');
 Router::any('subpage', 'App\Controllers\Welcome@subPage');
-Router::any('admin/(:any)(/(:any)(/(:any)(/(:any))))', 'App\Controllers\Demo@test');
+
+Router::any('admin/(:any)(/(:any)(/(:any)(/(:all))))', array(
+    'filters' => 'test',
+    'uses'    => 'App\Controllers\Demo@test'
+));
 
 // The Framework's Language Changer.
 Router::any('language/(:any)', 'App\Controllers\Language@change');

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -70,7 +70,7 @@ class Route
      */
     public function match($uri, $method, $optionals = true)
     {
-        if (! in_array('ANY', $this->methods) && ! in_array($method, $this->methods)) {
+        if (! in_array($method, $this->methods)) {
             return false;
         }
 

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -156,7 +156,7 @@ class Route
         $object = new $className();
 
         if (method_exists($object, $method)) {
-            // Execute the object's method without arguments and return the result.
+            // Execute the object's method with this Route instance as argument.
             return call_user_func(array($object, $method), $this);
         }
 

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -153,11 +153,11 @@ class Route
         }
 
         // The Filter Class receive on Constructor the Route instance as parameter.
-        $object = new $className($this);
+        $object = new $className();
 
         if (method_exists($object, $method)) {
             // Execute the object's method without arguments and return the result.
-            return call_user_func(array($object, $method));
+            return call_user_func(array($object, $method), $this);
         }
 
         return false;

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -71,10 +71,10 @@ class Route
 
         $this->pattern = ! empty($pattern) ? $pattern : '/';
 
-        if(is_array($callback)) {
+        if (is_array($callback)) {
             $this->callback = isset($callback['uses']) ? $callback['uses'] : null;
 
-            if(isset($callback['filters']) && ! empty($callback['filters'])) {
+            if (isset($callback['filters']) && ! empty($callback['filters'])) {
                 // Explode the filters string using the '|' delimiter.
                 $filters = array_filter(explode('|', $callback['filters']), 'strlen');
 
@@ -111,14 +111,14 @@ class Route
         $result = true;
 
         foreach ($this->filters as $filter) {
-            if(array_key_exists($filter, self::$availFilters)) {
+            if (array_key_exists($filter, self::$availFilters)) {
                 // Get the current Filter Callback.
                 $callback = self::$availFilters[$filter];
 
                 // Execute the current Filter's callback with the current matched Route as argument.
                 //
                 // When the Filter returns false, the filtering is considered being globally failed.
-                if($callback !== null) {
+                if ($callback !== null) {
                     $result = $this->invokeCallback($callback);
                 }
             } else {
@@ -126,7 +126,7 @@ class Route
                 $result = false;
             }
 
-            if($result === false) {
+            if ($result === false) {
                 // Failure of the current Filter; stop the loop.
                 break;
             }

--- a/system/Core/Route.php
+++ b/system/Core/Route.php
@@ -39,6 +39,11 @@ class Route
     private $callback = null;
 
     /**
+     * @var string The current matched URI
+     */
+    private $currentUri = null;
+
+    /**
      * @var string The matched HTTP method
      */
     private $method = null;
@@ -178,6 +183,9 @@ class Route
 
         // Exact match Route.
         if ($this->pattern == $uri) {
+            // Store the current matched URI.
+            $this->currentUri = $uri;
+
             return true;
         }
 
@@ -196,8 +204,13 @@ class Route
         if (preg_match('#^' .$regex .'(?:\?.*)?$#i', $uri, $matches)) {
             // Remove $matched[0] as [1] is the first parameter.
             array_shift($matches);
+
+            // Store the current matched URI.
+            $this->currentUri = $uri;
+
             // Store the extracted parameters.
             $this->params = $matches;
+
             // Also, store the compiled regex.
             $this->regex = $regex;
 
@@ -240,6 +253,14 @@ class Route
     public function callback()
     {
         return $this->callback;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function currentUri()
+    {
+        return $this->currentUri;
     }
 
     /**

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -88,7 +88,7 @@ class Router
     {
         $method = strtoupper($method);
 
-        if(($method == 'ANY') || in_array($method, static::$methods)) {
+        if (($method == 'ANY') || in_array($method, static::$methods)) {
             $route    = array_shift($params);
             $callback = array_shift($params);
 
@@ -177,7 +177,7 @@ class Router
      */
     public static function group($group, $callback)
     {
-        if(is_array($group)) {
+        if (is_array($group)) {
             $prefix    = trim($group['prefix'], '/');
             $namespace = isset($group['namespace']) ? trim($group['namespace'], '\\') : '';
         } else {
@@ -256,7 +256,7 @@ class Router
         $router =& self::getInstance();
 
         // Prepare the route Methods.
-        if(is_string($method) && (strtolower($method) == 'any')) {
+        if (is_string($method) && (strtolower($method) == 'any')) {
             $methods = static::$methods;
         } else {
             $methods = array_map('strtoupper', is_array($method) ? $method : array($method));
@@ -274,7 +274,7 @@ class Router
         $pattern = ltrim($route, '/');
 
         // If $callback is an options array, extract the Filters and Callback.
-        if(is_array($callback)) {
+        if (is_array($callback)) {
             $filters = isset($callback['filters']) ? trim($callback['filters'], '|') : '';
 
             $callback = isset($callback['uses']) ? $callback['uses'] : null;
@@ -306,7 +306,7 @@ class Router
             }
 
             // Adjust the Route CALLBACK, when it is not a Closure.
-            if(! empty($namespace) && ! is_object($callback)) {
+            if (! empty($namespace) && ! is_object($callback)) {
                 $callback = sprintf('%s\%s', $namespace,  trim($callback, '\\'));
             }
         }
@@ -339,7 +339,7 @@ class Router
     protected function invokeController($className, $method, $params)
     {
         // The Controller's the Execution Flow Methods cannot be called via Router.
-        if(($method == 'execute')) {
+        if (($method == 'execute')) {
             return false;
         }
 
@@ -422,7 +422,7 @@ class Router
                 // Apply the (specified) Filters on matched Route.
                 $result = $route->applyFilters();
 
-                if($result === false) {
+                if ($result === false) {
                     // Matched Route filtering failed; we should go to (404) Error.
                     break;
                 }

--- a/system/Helpers/Response.php
+++ b/system/Helpers/Response.php
@@ -159,9 +159,6 @@ class Response
             case 'js':
                 $contentType = 'application/javascript';
                 break;
-            case 'svg':
-                $contentType = 'image/svg+xml';
-                break;
             default:
                 break;
         }

--- a/system/Helpers/Response.php
+++ b/system/Helpers/Response.php
@@ -159,6 +159,9 @@ class Response
             case 'js':
                 $contentType = 'application/javascript';
                 break;
+            case 'svg':
+                $contentType = 'image/svg+xml';
+                break;
             default:
                 break;
         }

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -28,6 +28,9 @@ date_default_timezone_set(DEFAULT_TIMEZONE);
 /** Load the Framework wide functions. */
 require dirname(__FILE__) .DS .'functions.php';
 
+/** Load the Route Filters */
+require APPDIR .'Filters.php';
+
 /** Initialize the Aliases. */
 Aliases::init();
 


### PR DESCRIPTION
### Rationale

After the implementation of **Controller's Middleware**, the current pull request introduce the **Routing Middleware**, implemented using the concept of the **Route Filters**.

For what they are good for, comparative with Controller's **before()** and **after()** ?

The Controller's Middleware, aka **Controller Execution Flow** represents a High Level processing API, **executed by the requested Controller**, when it is instantiated, its requested Method is know as being valid and callable, and working in the same flow as your wanted Method.

The graph of **The Controller Execution Flow** is as follow:

**before() -> action() -> after()**

While very efficient and accurate, sometimes this design is not the best. For example, to instantiate a Controller and start its Execution Flow, only to obtain an redirect from a **CSRF** fault, can be costly as resources and response speed. 

Better is to have a solution for Routing to handle the CSRF fault, before to even instantiate the requested Controller, right after the Route was identified; this was the used resources will be lower and response speed will be better.

Enter the **Route Filters**: a method to execute specified callbacks right after the correct Route was identified and before starting the execution of associated Controller. 

### Route Filters

How they works? Let's say that we want a CSRF filter. In the (new) file **app/Filters.php** we define it as following:

```php
Route::filter('csrf', function($route) {
    if (! Csrf::isTokenValid()) {
        Url::redirect();
    }
});
```

We'll see that a **Route Filter** definition have a **name** as first parameter and secondly, an callback which receive a **Core\Route** instance, which is just current matched Route, from where being available into callback information about HTTP method, URI, captured parameters, Route callback, etc.

**ATTENTION: WHEN one of Filters return boolean FALSE, the Routing will generate an "404 Error" for the matched Route even it is a valid matched one.**

This is useful to "hide" parts of your website for non authenticated use or to redirect to a custom "404 Error" page, for example.

#### Note that Route Filters are defined using "Route::filter()"

How to use this Filter? We use a new style of defining Routes:

```php
Router::post('contact', array(
    'filters' => 'csrf',
    'uses' => 'App\Controllers\Contact@store'
));
```

WHERE the Route definition accept an array as second parameter and where the keys name are obviously. The key '**filters**' assign to the value of a '**|**' separated string of used Route Filters, and the key '**uses**' assign the associated Callback for the Route.

Running this Route definition, the Routing will known to apply the the Filter with the name '**csrf**' before the Controller execution, then on CSRF fault, the Filter's callback will be executed and we go very fast into redirect.

Like I said, it is possible to apply multiple Filters to a Route, using a string containing their name separated by character '**|**' (pipe).

Usually we will want to add another two Route Filters and there is a more complex example:

```php
Route::filter('csrf', function($route) {
    if (($route->method() == 'POST') && ! Csrf::isTokenValid()) {
        Url::redirect();
    }
});

Route::filter('auth', function($route) {
    if (Session::get('loggedIn') == false) {
        Url::redirect('login');
    }
});

Route::filter('guest', function($route) {
    if (Session::get('loggedIn') != false) {
        Url::redirect();
    }
});
```

And an example of their usage can be:
```php
Router::any('contact', array(
    'filters' => 'guest|csrf',
    'uses' => 'App\Controllers\Contact@index'
));

Router::any('login',  array(
    'filters' => 'guest|csrf',
    'uses' => 'App\Controllers\Auth@login'
));

Router::get('logout', array(
    'filters' => 'auth',
    'uses' => 'App\Controllers\Auth@logout'
));
```

WHERE only the only Guest Users can access the Contact and Login page, with CSRF validation, while only the Authenticated Users can access the Logout action.

The alternative usage of Route Filters registering is to use a Class instead of callback, where the called method will receive the matched Route instance as parameter. For example:

```php
Route::filter('auth', 'App\Helpers\Filters\User@isLoggedIn');
Route::filter('guest', 'App\Helpers\Filters\User@isGuest');
```

### Improvements

In other hand, this pull-request introduce a improved Method handling when the Routes are registered and a new Router command called **share()**, which permit to register multiple Routes all pointing to the same Controller. For example: 

```php
Router::share(array(
    array('GET', '/'),
    array('POST', '/home')
), 'App\Controllers\Home@index');
```
