### PR TITLE
Introducing Core\Template, a View specialized to handle Template files

### DIFF
--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -10,6 +10,7 @@ namespace Core;
 
 use Core\Language;
 use Core\View;
+use Core\Template;
 use Helpers\Hooks;
 
 /**
@@ -126,9 +127,9 @@ abstract class Controller
         //
         // Execute the default Template-based rendering of the given View instance.
 
-        if (! $data->isTemplate() && ($this->layout !== false)) {
-            // The View instance is NOT a Template, but have a Layout is specified.
-            View::makeTemplate($this->layout, array(), $this->template)
+        if ((! $data instanceof Template) && ($this->layout !== false)) {
+            // The View instance is NOT a Template, but we have a Layout specified.
+            Template::make($this->layout, array(), $this->template)
                 ->withContent($data)
                 ->display();
         } else {

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Template - a View specialized for handling the Template files.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Core;
+
+use Core\View;
+
+
+class Template extends View
+{
+    /**
+     * Constructor
+     * @param mixed $path
+     * @param array $data
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function __construct($path, array $data = array())
+    {
+        parent::__construct($path, $data);
+    }
+
+    /**
+     * Create a Template instance
+     *
+     * @param string $path
+     * @param array $data
+     * @param string $custom
+     * @return Template
+     */
+    public static function make($path, array $data = array(), $custom = TEMPLATE)
+    {
+        // Prepare the file path.
+        $filePath = str_replace('/', DS, "Templates/$custom/$path.php");
+
+        return new Template(APPDIR .$filePath, $data);
+    }
+
+    /**
+     * Magic Method for handling dynamic functions.
+     *
+     * This method handles calls to dynamic with helpers.
+     */
+    public static function __callStatic($method, $params)
+    {
+        // No Compatibility Layer exists there; nothing to do.
+    }
+
+    /**
+     * Compat Layer - Render a Module View file.
+     *
+     * @param  string  $path  path to file from Modules folder
+     * @param  array $data  array of data
+     * @param  array $error array of errors
+     *
+     * @throws \Exception
+     */
+    public static function renderModule($path, $data = false, $error = false)
+    {
+        throw new \Exception('renderModule is not available on ' .static::class);
+    }
+}

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -362,7 +362,7 @@ class View implements ArrayAccess
             // Render the object and return the captured output.
             return $object->fetch();
         } else if ($withHeaders) {
-            // Render the object, with Headers sending before.
+            // Render the object with sending the Headers first.
             return $object->display();
         }
 

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -330,9 +330,6 @@ class View implements ArrayAccess
             case 'sendHeaders':
                 return call_user_func_array(array(Response::class, $method), $params);
 
-            case 'makeTemplate':
-                return call_user_func_array(array(Template::class, 'make'), $params);
-
             default:
                 break;
         }
@@ -379,6 +376,8 @@ class View implements ArrayAccess
      */
     public static function renderModule($path, $data = false, $error = false)
     {
+        echo '<p>Please use <b>View::render()</b> instead of <b>View::renderModule()</b></p>';
+
         if (($error !== false) && ! isset($data['error'])) {
             // Adjust the $error parameter handling, injecting it into $data.
             $data['error'] = $error;

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -359,8 +359,10 @@ class View implements ArrayAccess
         $object = call_user_func_array(array($className, 'make'), $params);
 
         if ($method == 'fetch') {
+            // Render the object and return the captured output.
             return $object->fetch();
         } else if ($withHeaders) {
+            // Render the object, with Headers sending before.
             return $object->display();
         }
 


### PR DESCRIPTION
### Rationale

In almost any of Big Houses of frameworks, the **View** Class deal with a single **VIEWS PATH**. 

Under Nova, behind **Views**, we have also the concept of **Templates**, which have their own design and concept. 

Dealing with Template files in the same **View** class make us to complicate its design an can be confusing for end-users some of them looking to have problems to understand the inherited difference between a **View file** associated to a Controller and its Method, and a Template file, who give you (parts of) Layouts, even when using the ol'good **Triplet Style Rendering**.  

I consider that is not better to continue this confusion maker situation even into the New Style Rendering API and it better to have a dedicated class who deal with the Template Files.

Enter the **Core\Template**, a View specialized to handle Template files; basically identical with (its parent) View, but with its own **make()** builder and no Compatibility Layer, being destined to be used New Style API only.

### Usage

The usage of **Core\Template** is very simple. Instead to execute:
```php
$template = View::makeTemplate('default', $data, 'Admin');
```
You can simply do:
```php
$template = Template::make('default', $data, 'Admin');
```

From there, you can process it as usual, but the code will be much more clear and non confusional, **Template** dealing with the files from **app/Templates**, while the **View** deal **only** with the files from **app/Views**, and Modules based Views.

### Notes

Before to merge this pull request, I have two questions for you, @daveismyname .

**1** Is there a need for real to introduce into Compatibility Layer the support for **View::makeTemplate()**, previously introduced into last merged pull request? 

**2** It there a need for real to continue to support into Compatibility Layer the method **View::renderModule()**, (which complicate the code per-sè), considering that since **v3.6.0** the method **View::render()** have a native support for Modules based Views ?

The changes are trivial to port the existent code to **View::render()** modular rendering, as in specifying the third parameter, instead of doing:
```php
View::renderModule('Blog/Views/Blogs/Index', $data);
```
Yo have to change to:
```php
View::render('Blogs/Index', $data, 'Blog');
```

If you agree to not introduce into Compatibility Layer the **View::makeTemplate()** and to remove support for **View::renderModule()**, I will add another patch, capable to simplify both **Core\View** and **Core\Template**.