### PR TITLE
Consolidate Core\View

### DIFF
--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -172,7 +172,7 @@ class View implements ArrayAccess
      */
     public function nest($key, $view, array $data = array(), $module = null)
     {
-        return $this->with($key, static::make($view, $data, $module));
+        return $this->with($key, View::make($view, $data, $module));
     }
 
     /**


### PR DESCRIPTION
It is supposed that **View::nest()** and **Template::nest()** always will nest a local generated **View instance**.

This very simple patch ensure that logic.