### PR TITLE
Remove the Core\View@renderModule support, improve the logic on Core\View@offsetGet and the properties getter

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -35,8 +35,7 @@ class Demo extends Controller
             'param3' => $param3,
             'param4' => $param4
         );
-        echo '<pre>';
-        print_r($params);
-        echo '</pre>';
+
+        echo '<pre>' .var_export($params, true) .'</pre>';
     }
 }

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -11,7 +11,6 @@ namespace Core;
 
 use Helpers\Inflector;
 use Helpers\Response;
-use Core\Template;
 use Core\View;
 
 use ArrayAccess;

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -111,7 +111,7 @@ abstract class BaseView implements ArrayAccess
 
         // All nested Views are evaluated before the main View.
         foreach ($data as $key => $value) {
-            if ($value instanceof View) {
+            if ($value instanceof BaseView) {
                 $data[$key] = $value->fetch();
             }
         }

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * View - load template pages
+ *
+ * @author David Carr - dave@novaframework.com
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Core;
+
+use Helpers\Inflector;
+use Helpers\Response;
+use Core\Template;
+use Core\View;
+
+use ArrayAccess;
+
+
+/**
+ * View class to load template and views files.
+ */
+abstract class BaseView implements ArrayAccess
+{
+    /**
+     * @var array Array of shared data
+     */
+    protected static $shared = array();
+
+    /**
+     * @var string The path to the View file on disk.
+     */
+    protected $path = null;
+
+    /**
+     * @var array Array of local data.
+     */
+    protected $data = array();
+
+    /**
+     * Constructor
+     * @param mixed $path
+     * @param array $data
+     *
+     * @throws \UnexpectedValueException
+     */
+    protected function __construct($path, array $data = array())
+    {
+        if (! is_readable($path)) {
+            throw new \UnexpectedValueException('File not found: ' .$path);
+        }
+
+        $this->path = $path;
+        $this->data = $data;
+    }
+
+    /**
+     * Render the View and return the result.
+     *
+     * @return string
+     */
+    protected function fetch()
+    {
+        ob_start();
+
+        $this->render();
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render the View and output the result.
+     *
+     * @return void
+     */
+    protected function render()
+    {
+        // Get a local copy of the prepared data.
+        $data = $this->data();
+
+        // Extract the rendering variables from the local data copy.
+        foreach ($data as $variable => $value) {
+            ${$variable} = $value;
+        }
+
+        require $this->path;
+    }
+
+    /**
+     * Render the View and display the result.
+     *
+     * @return void
+     */
+    public function display()
+    {
+        Response::sendHeaders();
+
+        $this->render();
+    }
+
+    /**
+     * Return all variables stored on local and shared data.
+     *
+     * @return array
+     */
+    public function data()
+    {
+        $data =& $this->data;
+
+        // Make a local copy of the shared data.
+        $shared = static::$shared;
+
+        // All nested Views are evaluated before the main View.
+        foreach ($data as $key => $value) {
+            if ($value instanceof View) {
+                $data[$key] = $value->fetch();
+            }
+        }
+
+        // Merge the local and shared data using two steps.
+        foreach (array('afterBody', 'css', 'js') as $key) {
+            $value = isset($data[$key]) ? $data[$key] : '';
+
+            if (isset($shared[$key])) {
+                $value .= $shared[$key];
+            }
+
+            $data[$key] = $value;
+
+            // Remove that key from shared data.
+            unset($shared[$key]);
+        }
+
+        return array_merge($data, $shared);
+    }
+
+    /**
+     * Add a view instance to the view data.
+     *
+     * <code>
+     *     // Add a View instance to a View's data
+     *     $view = View::make('foo')->nest('footer', 'Partials/Footer');
+     *
+     *     // Equivalent functionality using the "with" method
+     *     $view = View::make('foo')->with('footer', View::make('Partials/Footer'));
+     * </code>
+     *
+     * @param  string  $key
+     * @param  string  $view
+     * @param  array   $data
+     * @param  string|null  $module
+     * @return View
+     */
+    public function nest($key, $view, array $data = array(), $module = null)
+    {
+        return $this->with($key, View::make($view, $data, $module));
+    }
+
+    /**
+     * Add a key / value pair to the view data.
+     *
+     * Bound data will be available to the view as variables.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return View
+     */
+    public function with($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->data = array_merge($this->data, $key);
+        } else {
+            $this->data[$key] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a key / value pair to the shared view data.
+     *
+     * Shared view data is accessible to every view created by the application.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return View
+     */
+    public function shares($key, $value)
+    {
+        static::share($key, $value);
+
+        return $this;
+    }
+
+    /**
+     * Add a key / value pair to the shared View data.
+     *
+     * Shared View data is accessible to every View created by the application.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public static function share($key, $value)
+    {
+        static::$shared[$key] = $value;
+    }
+
+    /**
+     * Implementation of the ArrayAccess offsetExists method.
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->data);
+    }
+
+    /**
+     * Implementation of the ArrayAccess offsetGet method.
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->data[$offset]) ? $this->data[$offset] : null;
+    }
+
+    /**
+      * Implementation of the ArrayAccess offsetSet method.
+      */
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * Implementation of the ArrayAccess offsetUnset method.
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
+    /**
+     * Magic Method for handling dynamic data access.
+     */
+    public function __get($key)
+    {
+        return isset($this->data[$key]) ? $this->data[$key] : null;
+    }
+
+    /**
+     * Magic Method for handling the dynamic setting of data.
+     */
+    public function __set($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+
+    /**
+     * Magic Method for checking dynamically-set data.
+     */
+    public function __isset($key)
+    {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * Get the evaluated string content of the View.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->fetch();
+    }
+
+     /**
+     * Magic Method for handling dynamic functions.
+     *
+     * This method handles calls to dynamic with helpers.
+     */
+    public function __call($method, $params)
+    {
+        // The 'fetch' and 'render' Methods are protected; expose them.
+        switch ($method) {
+            case 'fetch':
+            case 'render':
+                return call_user_func_array(array($this, $method), $params);
+
+            default:
+                break;
+        }
+
+        // Add the support for the dynamic with* Methods.
+        if (strpos($method, 'with') === 0) {
+            $name = lcfirst(substr($method, 4));
+
+            return $this->with($name, array_shift($params));
+        }
+
+        return null;
+    }
+}

--- a/system/Core/ClassicRouter.php
+++ b/system/Core/ClassicRouter.php
@@ -22,7 +22,7 @@ class ClassicRouter extends Router
     /**
      * ClassicRouter constructor.
      */
-    public function __construct()
+    protected function __construct()
     {
         parent::__construct();
     }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -119,7 +119,7 @@ abstract class Controller
             header('Content-Type: application/json', true);
 
             echo json_encode($data);
-        } else if (! $data instanceof View) {
+        } else if (! $data instanceof BaseView) {
             // The data is not a View instance; no further processing required.
             return;
         }

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -99,13 +99,20 @@ class Router
     {
         $method = strtoupper($method);
 
-        if (($method == 'ANY') || in_array($method, static::$methods)) {
-            $route    = array_shift($params);
-            $callback = array_shift($params);
-
-            // Register the route.
-            static::register($method, $route, $callback);
+        if (($method != 'ANY') && ! in_array($method, static::$methods)) {
+            throw new \Exception('Invalid Route method');
+        } else if (empty($params)) {
+            throw new \Exception('Invalid Route parameters');
         }
+
+        // Get the Route.
+        $route = array_shift($params);
+
+        // Get the Callback, if any.
+        $callback = ! empty($params) ? array_shift($params) : null;
+
+        // Register the Route.
+        static::register($method, $route, $callback);
     }
 
     /**

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -62,20 +62,17 @@ class Router
      */
     public function __construct()
     {
-        self::$instance =& $this;
     }
 
     public static function &getInstance()
     {
-        $appRouter = APPROUTER;
+        if (self::$instance === null) {
+            $appRouter = APPROUTER;
 
-        if (! self::$instance) {
-            $router = new $appRouter();
-        } else {
-            $router =& self::$instance;
+            self::$instance = new $appRouter();
         }
 
-        return $router;
+        return self::$instance;
     }
 
     /**
@@ -448,6 +445,10 @@ class Router
         return false;
     }
 
+    /**
+     * Dispatch/Serve a file
+     * @return bool
+     */
     protected function dispatchFile($uri)
     {
         // For properly Assets serving, the file URI should be as following:

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -60,7 +60,7 @@ class Router
      *
      * @codeCoverageIgnore
      */
-    public function __construct()
+    protected function __construct()
     {
     }
 

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -20,8 +20,18 @@ use Helpers\Url;
  */
 class Router
 {
+    /**
+     * The Router instance.
+     *
+     * @var Router $instance
+     */
     private static $instance;
 
+    /**
+     * Array of Route Groups
+     *
+     * @var array $routeGroups
+     */
     private static $routeGroups = array();
 
     /**
@@ -33,11 +43,15 @@ class Router
 
     /**
      * Default Route, usualy the Catch-All one.
+     *
+     * @var Route $defaultRoute
      */
     private $defaultRoute = null;
 
     /**
      * Matched Route, the current found Route, if any.
+     *
+     * @var Route|null $matchedRoute
      */
     protected $matchedRoute = null;
 
@@ -51,7 +65,7 @@ class Router
     /**
      * An array of HTTP request Methods.
      *
-     * @var array
+     * @var array $methods
      */
     public static $methods = array('GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS');
 
@@ -460,12 +474,12 @@ class Router
         $filePath = '';
 
         if (preg_match('#^assets/(.*)$#i', $uri, $matches)) {
-            $filePath = ROOTDIR.'assets'.DS.$matches[1];
+            $filePath = ROOTDIR .'assets' .DS .$matches[1];
         } else if (preg_match('#^(templates|modules)/(.+)/assets/(.*)$#i', $uri, $matches)) {
             // We need to classify the path name (the Module/Template path).
             $basePath = ucfirst($matches[1]) .DS .Inflector::classify($matches[2]);
 
-            $filePath = APPDIR.$basePath.DS.'Assets'.DS.$matches[3];
+            $filePath = APPDIR .$basePath .DS .'Assets' .DS .$matches[3];
         }
 
         if (! empty($filePath)) {

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -268,7 +268,7 @@ class Router
      * @param string $route URL pattern to match
      * @param callback $callback Callback object
      */
-    public static function register($method, $route, $callback = null)
+    protected static function register($method, $route, $callback = null)
     {
         // Get the Router instance.
         $router =& self::getInstance();

--- a/system/Core/Router.php
+++ b/system/Core/Router.php
@@ -100,9 +100,9 @@ class Router
         $method = strtoupper($method);
 
         if (($method != 'ANY') && ! in_array($method, static::$methods)) {
-            throw new \Exception('Invalid Route method');
+            throw new \Exception('Invalid method');
         } else if (empty($params)) {
-            throw new \Exception('Invalid Route parameters');
+            throw new \Exception('Invalid parameters');
         }
 
         // Get the Route.

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -10,7 +10,9 @@ namespace Core;
 
 use Core\BaseView;
 
-
+/**
+ * View class to load templates files.
+ */
 class Template extends BaseView
 {
     /**

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -8,10 +8,10 @@
 
 namespace Core;
 
-use Core\View;
+use Core\BaseView;
 
 
-class Template extends View
+class Template extends BaseView
 {
     /**
      * Constructor
@@ -20,7 +20,7 @@ class Template extends View
      *
      * @throws \UnexpectedValueException
      */
-    public function __construct($path, array $data = array())
+    protected function __construct($path, array $data = array())
     {
         parent::__construct($path, $data);
     }
@@ -39,16 +39,5 @@ class Template extends View
         $filePath = str_replace('/', DS, "Templates/$custom/$path.php");
 
         return new Template(APPDIR .$filePath, $data);
-    }
-
-    /**
-     * Magic Method for handling dynamic functions.
-     *
-     * This method handles calls to dynamic with helpers.
-     */
-    public static function __callStatic($method, $params)
-    {
-        // No Compatibility Layer there; nothing to do.
-        return null;
     }
 }

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -48,6 +48,7 @@ class Template extends View
      */
     public static function __callStatic($method, $params)
     {
-        // No Compatibility Layer exists there; nothing to do.
+        // No Compatibility Layer there; nothing to do.
+        return null;
     }
 }

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -50,18 +50,4 @@ class Template extends View
     {
         // No Compatibility Layer exists there; nothing to do.
     }
-
-    /**
-     * Compat Layer - Render a Module View file.
-     *
-     * @param  string  $path  path to file from Modules folder
-     * @param  array $data  array of data
-     * @param  array $error array of errors
-     *
-     * @throws \Exception
-     */
-    public static function renderModule($path, $data = false, $error = false)
-    {
-        throw new \Exception('renderModule is not available on ' .static::class);
-    }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -325,13 +325,13 @@ class View implements ArrayAccess
      */
     public static function __callStatic($method, $params)
     {
-        // Throw an \Exception when is requested the Compat Method View::renderModule()
-        if ($method == 'renderModule') {
-            throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');
-        }
-
-        // Process the compat Methods associated to Headers management.
+        // Throw an \Exception for the deprecated View::renderModule().
+        // Process the compat Methods associated to Headers management
         switch ($method) {
+            case 'renderModule':
+                throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');
+
+                break;
             case 'addHeader':
             case 'addHeaders':
             case 'sendHeaders':

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -356,7 +356,7 @@ class View implements ArrayAccess
         } else if ($method == 'renderTemplate') {
             $className = Template::class;
         } else {
-            // No valid Compat Method found.
+            // No valid Compat Method found; go out.
             return null;
         }
 

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -262,7 +262,7 @@ class View implements ArrayAccess
      */
     public function __get($key)
     {
-        return $this->data[$key];
+        return isset($this->data[$key]) ? $this->data[$key] : null;
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -238,7 +238,7 @@ class View implements ArrayAccess
      */
     public function offsetGet($offset)
     {
-        if (isset($this[$offset])) return $this->data[$offset];
+        return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -59,7 +59,7 @@ class View extends BaseView
     public static function __callStatic($method, $params)
     {
         // Throw an \Exception for the deprecated View::renderModule().
-        // Process the compat Methods associated to Headers management
+        // Process the compat Methods associated to Headers management.
         switch ($method) {
             case 'renderModule':
                 throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -325,6 +325,11 @@ class View implements ArrayAccess
      */
     public static function __callStatic($method, $params)
     {
+        // Throw an \Exception when is requested the Compat Method View::renderModule()
+        if ($method == 'renderModule') {
+            throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');
+        }
+
         // Process the compat Methods associated to Headers management.
         switch ($method) {
             case 'addHeader':
@@ -342,7 +347,7 @@ class View implements ArrayAccess
         // Flag for fetching the View rendering output.
         $shouldFetch = false;
 
-        // Flag for sending, or not, the HTTP Headers.
+        // Flag for sending, or not, the HTTP Headers before rendering.
         $withHeaders = true;
 
         // Prepare the required information.
@@ -375,17 +380,5 @@ class View implements ArrayAccess
 
         // Render the View object.
         return $object->render();
-    }
-
-    /**
-     * Compat Layer - Render a Module View file (now throwing an Exception instead).
-     *
-     * @param  string  $path  path to file from Modules folder
-     * @param  array $data  array of data
-     * @param  array $error array of errors
-     */
-    public static function renderModule($path, $data = false, $error = false)
-    {
-        throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');
     }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -366,11 +366,11 @@ class View implements ArrayAccess
         }
 
         // Create a View instance, using the current Class and the given parameters.
-        $object = call_user_func_array(array($className, 'make'), $params);
+        $view = call_user_func_array(array($className, 'make'), $params);
 
         if ($shouldFetch) {
             // Render the object and return the captured output.
-            return $object->fetch();
+            return $view->fetch();
         }
 
         if ($withHeaders) {
@@ -379,6 +379,6 @@ class View implements ArrayAccess
         }
 
         // Render the View object.
-        return $object->render();
+        return $view->render();
     }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -314,6 +314,8 @@ class View implements ArrayAccess
 
             return $this->with($name, array_shift($params));
         }
+
+        return null;
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -15,7 +15,7 @@ use Core\BaseView;
 
 
 /**
- * View class to load template and views files.
+ * View class to load views files.
  */
 class View extends BaseView
 {

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -368,7 +368,7 @@ class View implements ArrayAccess
     }
 
     /**
-     * Compat Layer - Render a Module View file.
+     * Compat Layer - Render a Module View file (now throw a Exception).
      *
      * @param  string  $path  path to file from Modules folder
      * @param  array $data  array of data
@@ -376,18 +376,6 @@ class View implements ArrayAccess
      */
     public static function renderModule($path, $data = false, $error = false)
     {
-        echo '<p>Please use <b>View::render()</b> instead of <b>View::renderModule()</b></p>';
-
-        if (($error !== false) && ! isset($data['error'])) {
-            // Adjust the $error parameter handling, injecting it into $data.
-            $data['error'] = $error;
-        }
-
-        if (preg_match('#^(.+)/Views/(.*)$#i', $path, $matches)) {
-            // Render the Module's View using the standard way.
-            $object = call_user_func(array(static::class, 'make'), $matches[2], $data, $matches[1]);
-
-            $object->display();
-        }
+        throw new \Exception('Please use "View::render()" instead of "View::renderModule()"');
     }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -9,33 +9,16 @@
 
 namespace Core;
 
-use Helpers\Inflector;
 use Helpers\Response;
 use Core\Template;
-
-use ArrayAccess;
+use Core\BaseView;
 
 
 /**
  * View class to load template and views files.
  */
-class View implements ArrayAccess
+class View extends BaseView
 {
-    /**
-     * @var array Array of shared data
-     */
-    protected static $shared = array();
-
-    /**
-     * @var string The path to the View file on disk.
-     */
-    protected $path = null;
-
-    /**
-     * @var array Array of local data.
-     */
-    protected $data = array();
-
     /**
      * Constructor
      * @param mixed $path
@@ -43,14 +26,9 @@ class View implements ArrayAccess
      *
      * @throws \UnexpectedValueException
      */
-    public function __construct($path, array $data = array())
+    protected function __construct($path, array $data = array())
     {
-        if (! is_readable($path)) {
-            throw new \UnexpectedValueException('File not found: ' .$path);
-        }
-
-        $this->path = $path;
-        $this->data = $data;
+        parent::__construct($path, $data);
     }
 
     /**
@@ -71,251 +49,6 @@ class View implements ArrayAccess
         }
 
         return new View(APPDIR .$filePath, $data);
-    }
-
-    /**
-     * Render the View and return the result.
-     *
-     * @return string
-     */
-    protected function fetch()
-    {
-        ob_start();
-
-        $this->render();
-
-        return ob_get_clean();
-    }
-
-    /**
-     * Render the View and output the result.
-     *
-     * @return void
-     */
-    protected function render()
-    {
-        // Get a local copy of the prepared data.
-        $data = $this->data();
-
-        // Extract the rendering variables from the local data copy.
-        foreach ($data as $variable => $value) {
-            ${$variable} = $value;
-        }
-
-        require $this->path;
-    }
-
-    /**
-     * Render the View and display the result.
-     *
-     * @return void
-     */
-    public function display()
-    {
-        Response::sendHeaders();
-
-        $this->render();
-    }
-
-    /**
-     * Return all variables stored on local and shared data.
-     *
-     * @return array
-     */
-    public function data()
-    {
-        $data =& $this->data;
-
-        // Make a local copy of the shared data.
-        $shared = static::$shared;
-
-        // All nested Views are evaluated before the main View.
-        foreach ($data as $key => $value) {
-            if ($value instanceof View) {
-                $data[$key] = $value->fetch();
-            }
-        }
-
-        // Merge the local and shared data using two steps.
-        foreach (array('afterBody', 'css', 'js') as $key) {
-            $value = isset($data[$key]) ? $data[$key] : '';
-
-            if (isset($shared[$key])) {
-                $value .= $shared[$key];
-            }
-
-            $data[$key] = $value;
-
-            // Remove that key from shared data.
-            unset($shared[$key]);
-        }
-
-        return array_merge($data, $shared);
-    }
-
-    /**
-     * Add a view instance to the view data.
-     *
-     * <code>
-     *     // Add a View instance to a View's data
-     *     $view = View::make('foo')->nest('footer', 'Partials/Footer');
-     *
-     *     // Equivalent functionality using the "with" method
-     *     $view = View::make('foo')->with('footer', View::make('Partials/Footer'));
-     * </code>
-     *
-     * @param  string  $key
-     * @param  string  $view
-     * @param  array   $data
-     * @param  string|null  $module
-     * @return View
-     */
-    public function nest($key, $view, array $data = array(), $module = null)
-    {
-        return $this->with($key, View::make($view, $data, $module));
-    }
-
-    /**
-     * Add a key / value pair to the view data.
-     *
-     * Bound data will be available to the view as variables.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return View
-     */
-    public function with($key, $value = null)
-    {
-        if (is_array($key)) {
-            $this->data = array_merge($this->data, $key);
-        } else {
-            $this->data[$key] = $value;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add a key / value pair to the shared view data.
-     *
-     * Shared view data is accessible to every view created by the application.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return View
-     */
-    public function shares($key, $value)
-    {
-        static::share($key, $value);
-
-        return $this;
-    }
-
-    /**
-     * Add a key / value pair to the shared View data.
-     *
-     * Shared View data is accessible to every View created by the application.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public static function share($key, $value)
-    {
-        static::$shared[$key] = $value;
-    }
-
-    /**
-     * Implementation of the ArrayAccess offsetExists method.
-     */
-    public function offsetExists($offset)
-    {
-        return array_key_exists($offset, $this->data);
-    }
-
-    /**
-     * Implementation of the ArrayAccess offsetGet method.
-     */
-    public function offsetGet($offset)
-    {
-        return isset($this->data[$offset]) ? $this->data[$offset] : null;
-    }
-
-    /**
-      * Implementation of the ArrayAccess offsetSet method.
-      */
-    public function offsetSet($offset, $value)
-    {
-        $this->data[$offset] = $value;
-    }
-
-    /**
-     * Implementation of the ArrayAccess offsetUnset method.
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->data[$offset]);
-    }
-
-    /**
-     * Magic Method for handling dynamic data access.
-     */
-    public function __get($key)
-    {
-        return isset($this->data[$key]) ? $this->data[$key] : null;
-    }
-
-    /**
-     * Magic Method for handling the dynamic setting of data.
-     */
-    public function __set($key, $value)
-    {
-        $this->data[$key] = $value;
-    }
-
-    /**
-     * Magic Method for checking dynamically-set data.
-     */
-    public function __isset($key)
-    {
-        return isset($this->data[$key]);
-    }
-
-    /**
-     * Get the evaluated string content of the View.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->fetch();
-    }
-
-     /**
-     * Magic Method for handling dynamic functions.
-     *
-     * This method handles calls to dynamic with helpers.
-     */
-    public function __call($method, $params)
-    {
-        // The 'fetch' and 'render' Methods are protected; expose them.
-        switch ($method) {
-            case 'fetch':
-            case 'render':
-                return call_user_func_array(array($this, $method), $params);
-
-            default:
-                break;
-        }
-
-        // Add the support for the dynamic with* Methods.
-        if (strpos($method, 'with') === 0) {
-            $name = lcfirst(substr($method, 4));
-
-            return $this->with($name, array_shift($params));
-        }
-
-        return null;
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -369,7 +369,7 @@ class View implements ArrayAccess
         }
 
         if ($withHeaders) {
-            // Send the Headers first.
+            // Send the HTTP Headers first.
             Response::sendHeaders();
         }
 

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -336,33 +336,41 @@ class View implements ArrayAccess
                 break;
         }
 
-        // Flag for sending, or not, the Headers, default being true.
+        // Flag for fetching the View rendering output.
+        $shouldFetch = false;
+
+        // Flag for sending, or not, the HTTP Headers.
         $withHeaders = true;
 
         // The called Class name for getting an instance.
         $className = static::class;
 
         // Prepare the required information.
-        if ($method == 'render') {
+        if ($method == 'fetch') {
+            $shouldFetch = true;
+        } else if ($method == 'render') {
             if (count($params) == 4) {
                 // There is a withHeaders parameter.
                 $withHeaders = array_pop($params);
             }
         } else if ($method == 'renderTemplate') {
             $className = Template::class;
-        } else if ($method != 'fetch') {
+        } else {
+            // No valid Compat Method found.
             return null;
         }
 
         // Create a View instance, using the given classMethod and parameters.
         $object = call_user_func_array(array($className, 'make'), $params);
 
-        if ($method == 'fetch') {
+        if ($shouldFetch) {
             // Render the object and return the captured output.
             return $object->fetch();
-        } else if ($withHeaders) {
-            // Render the object with sending the Headers first.
-            return $object->display();
+        }
+
+        if ($withHeaders) {
+            // Send the Headers first.
+            Response::sendHeaders();
         }
 
         // Render the View object.

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -370,7 +370,7 @@ class View implements ArrayAccess
     }
 
     /**
-     * Compat Layer - Render a Module View file (now throw a Exception).
+     * Compat Layer - Render a Module View file (now throwing an Exception instead).
      *
      * @param  string  $path  path to file from Modules folder
      * @param  array $data  array of data

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -336,14 +336,14 @@ class View implements ArrayAccess
                 break;
         }
 
+        // The called Class; for getting a View instance.
+        $className = static::class;
+
         // Flag for fetching the View rendering output.
         $shouldFetch = false;
 
         // Flag for sending, or not, the HTTP Headers.
         $withHeaders = true;
-
-        // The called Class name for getting an instance.
-        $className = static::class;
 
         // Prepare the required information.
         if ($method == 'fetch') {
@@ -360,7 +360,7 @@ class View implements ArrayAccess
             return null;
         }
 
-        // Create a View instance, using the given classMethod and parameters.
+        // Create a View instance, using the current Class and the given parameters.
         $object = call_user_func_array(array($className, 'make'), $params);
 
         if ($shouldFetch) {


### PR DESCRIPTION
This Pull Request introduce a new class, called **Core\BaseView**, which is the base for **Core\View** and **Core\Template**, and contains their common logic. This way, the code of Rendering is simplified.

To note that this Pull Request remove the Compat Layer for **View::renderModule()**, its functionality being supported completely by **View::render()**, as its third parameter being the optional **Module** name, and for now we throw a meaningful Exception for.

Also to note that removing the Compat Layer for **View::renderModule()** sensible simplify the **Core\View** and **Core\Template**. 

Finally, this Pull Request introduce improvements on Routing.