### PR TITLE
Reorder the new Language codes and adjust the Language changer; make the default Layout stand-alone

### DIFF
--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -29,7 +29,7 @@ class Welcome extends Controller
     }
 
     /**
-     * Define Index page title and load template files
+     * Define Index page title and load template files.
      */
     public function index()
     {
@@ -42,7 +42,7 @@ class Welcome extends Controller
     }
 
     /**
-     * Define Subpage page title and load template files
+     * The New Style Rendering - create and return a proper View instance.
      */
     public function subPage()
     {

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -23,6 +23,8 @@ class Welcome extends Controller
     public function __construct()
     {
         parent::__construct();
+
+        // Load the Language file.
         $this->language->load('Welcome');
     }
 

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -44,20 +44,8 @@ class Welcome extends Controller
      */
     public function subPage()
     {
-        // The Default Rendering Style.
-        /*
-        $data['title'] = $this->language->get('subpageText');
-        $data['welcomeMessage'] = $this->language->get('subpageMessage');
-
-
-        View::renderTemplate('header', $data);
-        View::render('Welcome/SubPage', $data);
-        View::renderTemplate('footer', $data);
-        */
-
-        // The New Rendering Style.
         return View::make('Welcome/SubPage')
-            ->shares('title', $this->trans('subpageText'))
+            ->withTitle($this->trans('subpageText'))
             ->withWelcomeMessage($this->trans('subpageMessage'));
     }
 }

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -13,7 +13,7 @@ echo $meta; //place to pass data / plugable hook zone
 
 Assets::css([
     'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css',
-    Url::templatePath() .'css/style.css',
+    template_url('css/style.css'),
 ]);
 
 echo $css; //place to pass data / plugable hook zone
@@ -24,21 +24,21 @@ echo $css; //place to pass data / plugable hook zone
 
 <div class="container">
     <p class="pull-right">
-        <a href='<?= DIR; ?>language/cs'>Czech</a> |
-        <a href='<?= DIR; ?>language/en'>English</a> |
-        <a href='<?= DIR; ?>language/de'>German</a> |
-        <a href='<?= DIR; ?>language/fr'>French</a> |
-        <a href='<?= DIR; ?>language/it'>Italian</a> |
-        <a href='<?= DIR; ?>language/nl'>Dutch</a> |
-        <a href='<?= DIR; ?>language/fa'>Persian</a> |
-        <a href='<?= DIR; ?>language/pl'>Polish</a> |
-        <a href='<?= DIR; ?>language/ro'>Romanian</a> |
-        <a href='<?= DIR; ?>language/ru'>Russian</a> |
-        <a href='<?= DIR; ?>language/es'>Spanish</a>
+        <a href='<?= site_url('language/cs'); ?>'>Czech</a> |
+        <a href='<?= site_url('language/en'); ?>'>English</a> |
+        <a href='<?= site_url('language/de'); ?>'>German</a> |
+        <a href='<?= site_url('language/fr'); ?>'>French</a> |
+        <a href='<?= site_url('language/it'); ?>'>Italian</a> |
+        <a href='<?= site_url('language/nl'); ?>'>Dutch</a> |
+        <a href='<?= site_url('language/fa'); ?>'>Persian</a> |
+        <a href='<?= site_url('language/pl'); ?>'>Polish</a> |
+        <a href='<?= site_url('language/ro'); ?>'>Romanian</a> |
+        <a href='<?= site_url('language/ru'); ?>'>Russian</a> |
+        <a href='<?= site_url('language/es'); ?>'>Spanish</a>
     </p>
     <div class="clearfix"></div>
     <p>
-        <img src='<?= Url::templatePath(); ?>images/nova.png' alt='<?= SITETITLE; ?>'>
+        <img src='<?= template_url('images/nova.png'); ?>' alt='<?= SITETITLE; ?>'>
     </p>
 
     <?= $content; ?>

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -1,10 +1,58 @@
 <?php
 /**
- * Default Composed Layout - make a layout from the classic Header and Footer files.
+ * Default Layout - a Layout similar with the classic Header and Footer files.
  */
+?>
+<!DOCTYPE html>
+<html lang="<?php echo LANGUAGE_CODE; ?>">
+<head>
+    <meta charset="utf-8">
+    <title><?= $title .' - ' .SITETITLE; ?></title>
+<?php
+echo $meta; //place to pass data / plugable hook zone
 
-require dirname(__FILE__) .'/header.php';
+Assets::css([
+    'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css',
+    Url::templatePath() .'css/style.css',
+]);
 
-echo $content;
+echo $css; //place to pass data / plugable hook zone
+?>
+</head>
+<body>
+<?= $afterBody; //place to pass data / plugable hook zone ?>
 
-require dirname(__FILE__) .'/footer.php';
+<div class="container">
+    <p class="pull-right">
+        <a href='<?=DIR;?>language/cs'>Czech</a> |
+        <a href='<?=DIR;?>language/en'>English</a> |
+        <a href='<?=DIR;?>language/de'>German</a> |
+        <a href='<?=DIR;?>language/fr'>French</a> |
+        <a href='<?=DIR;?>language/it'>Italian</a> |
+        <a href='<?=DIR;?>language/nl'>Dutch</a> |
+        <a href='<?=DIR;?>language/fa'>Persian</a> |
+        <a href='<?=DIR;?>language/pl'>Polish</a> |
+        <a href='<?=DIR;?>language/ro'>Romanian</a> |
+        <a href='<?=DIR;?>language/ru'>Russian</a> |
+        <a href='<?=DIR;?>language/es'>Spanish</a>
+    </p>
+    <div class="clearfix"></div>
+    <p>
+        <img src='<?= Url::templatePath(); ?>images/nova.png' alt='<?= SITETITLE; ?>'>
+    </p>
+
+    <?= $content; ?>
+</div>
+
+<?php
+Assets::js([
+    'https://code.jquery.com/jquery-1.12.1.min.js',
+    'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js',
+]);
+
+echo $js; //place to pass data / plugable hook zone
+echo $footer; //place to pass data / plugable hook zone
+?>
+
+</body>
+</html>

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -24,17 +24,17 @@ echo $css; //place to pass data / plugable hook zone
 
 <div class="container">
     <p class="pull-right">
-        <a href='<?=DIR;?>language/cs'>Czech</a> |
-        <a href='<?=DIR;?>language/en'>English</a> |
-        <a href='<?=DIR;?>language/de'>German</a> |
-        <a href='<?=DIR;?>language/fr'>French</a> |
-        <a href='<?=DIR;?>language/it'>Italian</a> |
-        <a href='<?=DIR;?>language/nl'>Dutch</a> |
-        <a href='<?=DIR;?>language/fa'>Persian</a> |
-        <a href='<?=DIR;?>language/pl'>Polish</a> |
-        <a href='<?=DIR;?>language/ro'>Romanian</a> |
-        <a href='<?=DIR;?>language/ru'>Russian</a> |
-        <a href='<?=DIR;?>language/es'>Spanish</a>
+        <a href='<?= DIR; ?>language/cs'>Czech</a> |
+        <a href='<?= DIR; ?>language/en'>English</a> |
+        <a href='<?= DIR; ?>language/de'>German</a> |
+        <a href='<?= DIR; ?>language/fr'>French</a> |
+        <a href='<?= DIR; ?>language/it'>Italian</a> |
+        <a href='<?= DIR; ?>language/nl'>Dutch</a> |
+        <a href='<?= DIR; ?>language/fa'>Persian</a> |
+        <a href='<?= DIR; ?>language/pl'>Polish</a> |
+        <a href='<?= DIR; ?>language/ro'>Romanian</a> |
+        <a href='<?= DIR; ?>language/ru'>Russian</a> |
+        <a href='<?= DIR; ?>language/es'>Spanish</a>
     </p>
     <div class="clearfix"></div>
     <p>

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -13,7 +13,7 @@ echo $meta; //place to pass data / plugable hook zone
 
 Assets::css([
     'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css',
-    template_url('css/style.css'),
+    template_url('css/style.css', 'Default'),
 ]);
 
 echo $css; //place to pass data / plugable hook zone
@@ -38,7 +38,7 @@ echo $css; //place to pass data / plugable hook zone
     </p>
     <div class="clearfix"></div>
     <p>
-        <img src='<?= template_url('images/nova.png'); ?>' alt='<?= SITETITLE; ?>'>
+        <img src='<?= template_url('images/nova.png', 'Default'); ?>' alt='<?= SITETITLE; ?>'>
     </p>
 
     <?= $content; ?>

--- a/app/Templates/Default/header.php
+++ b/app/Templates/Default/header.php
@@ -24,10 +24,11 @@
 <a href='<?=DIR;?>language/fr'>French</a> |
 <a href='<?=DIR;?>language/it'>Italian</a> |
 <a href='<?=DIR;?>language/nl'>Dutch</a> |
+<a href='<?=DIR;?>language/fa'>Persian</a> |
 <a href='<?=DIR;?>language/pl'>Polish</a> |
 <a href='<?=DIR;?>language/ro'>Romanian</a> |
 <a href='<?=DIR;?>language/ru'>Russian</a> |
-<a href='<?=DIR;?>language/fa'>Persian</a>
+<a href='<?=DIR;?>language/es'>Spanish</a>
 </p>
 <div class="clearfix"></div>
 

--- a/system/Core/Aliases.php
+++ b/system/Core/Aliases.php
@@ -28,6 +28,12 @@ class Aliases
                 $classAlias = '\\' .$classAlias;
             }
 
+            // Check if a class already exists
+            if (class_exists($classAlias)) {
+                // Bail out, a Class already exists with the same name.
+                throw new RuntimeException('Class already exists!');
+            }
+
             class_alias($className, $classAlias);
         }
     }

--- a/system/Core/Aliases.php
+++ b/system/Core/Aliases.php
@@ -10,7 +10,7 @@ namespace Core;
 use Core\Config;
 
 /**
- * Aliases - make alias for classes for views to use without declaring a use element.
+ * Aliases - make alias for classes for Views to use without declaring a use element.
  */
 class Aliases
 {
@@ -18,10 +18,17 @@ class Aliases
     {
         $classes = Config::get('class_aliases');
 
-        if(is_array($classes)) {
-            foreach ($classes as $classAlias => $className) {
-                class_alias($className, $classAlias);
+        if(! is_array($classes)) {
+            return;
+        }
+
+        foreach ($classes as $classAlias => $className) {
+            if (substr($classAlias, 0, 1) != '\\') {
+                // This ensures the alias is created in the global namespace.
+                $classAlias = '\\' .$classAlias;
             }
+
+            class_alias($className, $classAlias);
         }
     }
 }

--- a/system/Core/Aliases.php
+++ b/system/Core/Aliases.php
@@ -28,7 +28,7 @@ class Aliases
                 $classAlias = '\\' .$classAlias;
             }
 
-            // Check if a class already exists
+            // Check if the Class already exists
             if (class_exists($classAlias)) {
                 // Bail out, a Class already exists with the same name.
                 throw new RuntimeException('Class already exists!');

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -173,6 +173,11 @@ abstract class BaseView implements ArrayAccess
      */
     public function nest($key, $view, array $data = array(), $module = null)
     {
+        if(empty($data)) {
+            // The nested View instance inherit parent Data if none is given.
+            $data = $this->data;
+        }
+
         return $this->with($key, View::make($view, $data, $module));
     }
 

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -289,10 +289,14 @@ abstract class BaseView implements ArrayAccess
         }
 
         // Add the support for the dynamic with* Methods.
-        if (strpos($method, 'with') === 0) {
+        if ((strpos($method, 'with') === 0) && (strlen($method) > 4)) {
             $name = lcfirst(substr($method, 4));
 
             return $this->with($name, array_shift($params));
+        } else if ((strpos($method, 'share') === 0) && (strlen($method) > 5)) {
+            $name = lcfirst(substr($method, 5));
+
+            return $this->shares($name, array_shift($params));
         }
 
         return null;

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -288,12 +288,14 @@ abstract class BaseView implements ArrayAccess
                 break;
         }
 
-        // Add the support for the dynamic with* Methods.
+        // Add the support for the dynamic withX Methods.
         if ((strpos($method, 'with') === 0) && (strlen($method) > 5)) {
             $name = lcfirst(substr($method, 4));
 
             return $this->with($name, array_shift($params));
-        } else if ((strpos($method, 'share') === 0) && (strlen($method) > 6)) {
+        }
+        // Add the support for the dynamic shareX Methods.
+        else if ((strpos($method, 'share') === 0) && (strlen($method) > 6)) {
             $name = lcfirst(substr($method, 5));
 
             return $this->shares($name, array_shift($params));

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -294,7 +294,11 @@ abstract class BaseView implements ArrayAccess
      */
     public function __toString()
     {
-        return $this->fetch();
+        try {
+            return $this->fetch();
+        } catch (\Exception $e) {
+            return '';
+        }
     }
 
      /**

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -27,6 +27,11 @@ abstract class BaseView implements ArrayAccess
     protected static $shared = array();
 
     /**
+     * @var string The given View name.
+     */
+    protected $view = null;
+
+    /**
      * @var string The path to the View file on disk.
      */
     protected $path = null;
@@ -40,15 +45,10 @@ abstract class BaseView implements ArrayAccess
      * Constructor
      * @param mixed $path
      * @param array $data
-     *
-     * @throws \UnexpectedValueException
      */
-    protected function __construct($path, array $data = array())
+    protected function __construct($view, $path, array $data = array())
     {
-        if (! is_readable($path)) {
-            throw new \UnexpectedValueException('File not found: ' .$path);
-        }
-
+        $this->view = $view;
         $this->path = $path;
         $this->data = $data;
     }
@@ -71,9 +71,15 @@ abstract class BaseView implements ArrayAccess
      * Render the View and output the result.
      *
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     protected function render()
     {
+        if (! is_readable($this->path)) {
+            throw new \InvalidArgumentException("Unable to load the view '" .$this->view ."'. File '" .$this->path."' not found.", 1);
+        }
+
         // Get a local copy of the prepared data.
         $data = $this->data();
 
@@ -124,10 +130,10 @@ abstract class BaseView implements ArrayAccess
      */
     public function data()
     {
-        // A local array of Data, to simulate the old behavior.
+        // Get a local array of Data.
         $data =& $this->data;
 
-        // A local copy of the shared Data.
+        // Get a local copy of the shared Data.
         $shared = static::$shared;
 
         // All nested Views are evaluated before the main View.

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -289,7 +289,7 @@ abstract class BaseView implements ArrayAccess
         }
 
         // Add the support for the dynamic with* Methods.
-        if ((strpos($method, 'with') === 0) && (strlen($method) > 4)) {
+        if ((strpos($method, 'with') === 0) && (strlen($method) > 5)) {
             $name = lcfirst(substr($method, 4));
 
             return $this->with($name, array_shift($params));

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -98,15 +98,36 @@ abstract class BaseView implements ArrayAccess
     }
 
     /**
+     * Return all variables stored on local data.
+     *
+     * @return array
+     */
+    public function localData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Return all variables stored on shared data.
+     *
+     * @return array
+     */
+    public static function sharedData()
+    {
+        return static::$shared;
+    }
+
+    /**
      * Return all variables stored on local and shared data.
      *
      * @return array
      */
     public function data()
     {
-        $data =& $this->data;
+        // A local array of Data, to simulate the old behavior.
+        $data = $this->data;
 
-        // Make a local copy of the shared data.
+        // A local copy of the shared Data.
         $shared = static::$shared;
 
         // All nested Views are evaluated before the main View.
@@ -130,7 +151,7 @@ abstract class BaseView implements ArrayAccess
             unset($shared[$key]);
         }
 
-        return array_merge($data, $shared);
+        return empty($shared) ? $data : array_merge($data, $shared);
     }
 
     /**

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -125,7 +125,7 @@ abstract class BaseView implements ArrayAccess
     public function data()
     {
         // A local array of Data, to simulate the old behavior.
-        $data = $this->data;
+        $data =& $this->data;
 
         // A local copy of the shared Data.
         $shared = static::$shared;

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -293,7 +293,7 @@ abstract class BaseView implements ArrayAccess
             $name = lcfirst(substr($method, 4));
 
             return $this->with($name, array_shift($params));
-        } else if ((strpos($method, 'share') === 0) && (strlen($method) > 5)) {
+        } else if ((strpos($method, 'share') === 0) && (strlen($method) > 6)) {
             $name = lcfirst(substr($method, 5));
 
             return $this->shares($name, array_shift($params));

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -133,7 +133,7 @@ abstract class Controller
                 ->withContent($data)
                 ->display();
         } else {
-            // The given View instance is a Template, or no Layout is specified.
+            // The instance is a Template, or a View while no Layout is specified.
             $data->display();
         }
     }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -49,7 +49,9 @@ abstract class Controller
     public function __construct()
     {
         // Adjust to default Template if no one is defined.
-        $this->template = ($this->template !== null) ?: TEMPLATE;
+        if ($this->template === null) {
+            $this->template = TEMPLATE;
+        }
 
         /** Initialise the Language object */
         $this->language = new Language();

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -9,8 +9,9 @@
 namespace Core;
 
 use Core\Language;
-use Core\View;
+use Core\BaseView;
 use Core\Template;
+use Core\View;
 use Helpers\Hooks;
 
 /**

--- a/system/Core/Language.php
+++ b/system/Core/Language.php
@@ -21,7 +21,7 @@ class Language
      * list of language codes
      * @var array
      */
-    public static $codes = ['cs', 'de', 'en', 'fr', 'it', 'nl', 'pl', 'ro', 'ru', 'fa', 'es'];
+    public static $codes = ['cs', 'de', 'en', 'es', 'fa', 'fr', 'it', 'nl', 'pl', 'ro', 'ru'];
 
     /**
      * Variable holds array with language.

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -38,8 +38,8 @@ class Template extends BaseView
     public static function make($view, array $data = array(), $template = TEMPLATE)
     {
         // Prepare the file path.
-        $filePath = str_replace('/', DS, "Templates/$template/$view.php");
+        $path = str_replace('/', DS, APPDIR ."Templates/$template/$view.php");
 
-        return new Template($view, APPDIR .$filePath, $data);
+        return new Template($view, $path, $data);
     }
 }

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -22,9 +22,9 @@ class Template extends BaseView
      *
      * @throws \UnexpectedValueException
      */
-    protected function __construct($path, array $data = array())
+    protected function __construct($view, $path, array $data = array())
     {
-        parent::__construct($path, $data);
+        parent::__construct($view, $path, $data);
     }
 
     /**
@@ -40,6 +40,6 @@ class Template extends BaseView
         // Prepare the file path.
         $filePath = str_replace('/', DS, "Templates/$custom/$path.php");
 
-        return new Template(APPDIR .$filePath, $data);
+        return new Template($path, APPDIR .$filePath, $data);
     }
 }

--- a/system/Core/Template.php
+++ b/system/Core/Template.php
@@ -30,16 +30,16 @@ class Template extends BaseView
     /**
      * Create a Template instance
      *
-     * @param string $path
+     * @param string $view
      * @param array $data
      * @param string $custom
      * @return Template
      */
-    public static function make($path, array $data = array(), $custom = TEMPLATE)
+    public static function make($view, array $data = array(), $template = TEMPLATE)
     {
         // Prepare the file path.
-        $filePath = str_replace('/', DS, "Templates/$custom/$path.php");
+        $filePath = str_replace('/', DS, "Templates/$template/$view.php");
 
-        return new Template($path, APPDIR .$filePath, $data);
+        return new Template($view, APPDIR .$filePath, $data);
     }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -43,12 +43,12 @@ class View extends BaseView
     {
         // Prepare the (relative) file path according with Module parameter presence.
         if ($module !== null) {
-            $filePath = str_replace('/', DS, "Modules/$module/Views/$view.php");
+            $path = str_replace('/', DS, APPDIR ."Modules/$module/Views/$view.php");
         } else {
-            $filePath = str_replace('/', DS, "Views/$view.php");
+            $path = str_replace('/', DS, APPDIR ."Views/$view.php");
         }
 
-        return new View($view, APPDIR .$filePath, $data);
+        return new View($view, $path, $data);
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -39,16 +39,16 @@ class View extends BaseView
      * @param string|null $module
      * @return View
      */
-    public static function make($path, array $data = array(), $module = null)
+    public static function make($view, array $data = array(), $module = null)
     {
         // Prepare the (relative) file path according with Module parameter presence.
         if ($module !== null) {
-            $filePath = str_replace('/', DS, "Modules/$module/Views/$path.php");
+            $filePath = str_replace('/', DS, "Modules/$module/Views/$view.php");
         } else {
-            $filePath = str_replace('/', DS, "Views/$path.php");
+            $filePath = str_replace('/', DS, "Views/$view.php");
         }
 
-        return new View($path, APPDIR .$filePath, $data);
+        return new View($view, APPDIR .$filePath, $data);
     }
 
     /**

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -99,11 +99,11 @@ class View extends BaseView
         }
 
         // Create a View instance, using the current Class and the given parameters.
-        $view = call_user_func_array(array($className, 'make'), $params);
+        $instance = call_user_func_array(array($className, 'make'), $params);
 
         if ($shouldFetch) {
             // Render the object and return the captured output.
-            return $view->fetch();
+            return $instance->fetch();
         }
 
         if ($withHeaders) {
@@ -112,6 +112,6 @@ class View extends BaseView
         }
 
         // Render the View object.
-        return $view->render();
+        return $instance->render();
     }
 }

--- a/system/Core/View.php
+++ b/system/Core/View.php
@@ -26,9 +26,9 @@ class View extends BaseView
      *
      * @throws \UnexpectedValueException
      */
-    protected function __construct($path, array $data = array())
+    protected function __construct($view, $path, array $data = array())
     {
-        parent::__construct($path, $data);
+        parent::__construct($view, $path, $data);
     }
 
     /**
@@ -48,7 +48,7 @@ class View extends BaseView
             $filePath = str_replace('/', DS, "Views/$path.php");
         }
 
-        return new View(APPDIR .$filePath, $data);
+        return new View($path, APPDIR .$filePath, $data);
     }
 
     /**

--- a/system/Helpers/Response.php
+++ b/system/Helpers/Response.php
@@ -78,11 +78,13 @@ class Response
      */
     public static function addStatus($code)
     {
-        if (isset(self::$status[$code])) {
-            $httpProtocol = $_SERVER['SERVER_PROTOCOL'];
-
-            self::addHeader("$httpProtocol $code " . self::$status[$code]);
+        if (! isset(self::$status[$code])) {
+            return;
         }
+
+        $httpProtocol = $_SERVER['SERVER_PROTOCOL'];
+
+        self::addHeader("$httpProtocol $code " . self::$status[$code]);
     }
 
     /**
@@ -100,8 +102,12 @@ class Response
      *
      * @param array $headers
      */
-    public static function addHeaders(array $headers = array())
+    public static function addHeaders(array $headers)
     {
+        if(empty($headers)) {
+            return;
+        }
+
         self::$headers = array_merge(self::$headers, $headers);
     }
 
@@ -110,10 +116,12 @@ class Response
      */
     public static function sendHeaders()
     {
-        if (! headers_sent()) {
-            foreach (self::$headers as $header) {
-                header($header, true);
-            }
+        if (headers_sent()) {
+            return;
+        }
+
+        foreach (self::$headers as $header) {
+            header($header, true);
         }
     }
 

--- a/system/functions.php
+++ b/system/functions.php
@@ -7,14 +7,40 @@
  * @date April 12th, 2016
  */
 
+use Helpers\Url;
+
+
 /**
- * Site url helper
+ * Site URL helper
  * @param string $path
  * @return string
  */
 function site_url($path = '/')
 {
     return SITEURL .ltrim($path, '/');
+}
+
+/**
+ * Resource URL helper
+ * @param string $path
+ * @param string|null $module
+ * @return string
+ */
+function resource_url($path, $module = null)
+{
+    return Url::resourcePath($module) .ltrim($path, '/');
+}
+
+/**
+ * Template URL helper
+ * @param string $path
+ * @param string $template
+ * @param string $folder
+ * @return string
+ */
+function template_url($path, $template = TEMPLATE, $folder = '/assets/')
+{
+    return Url::templatePath($template, $folder) .ltrim($path, '/');
 }
 
 /** String helpers. */


### PR DESCRIPTION
Like the title say.

To note that this pull request introduce two new useful helper functions:

```php
resource_url($path, $module = null);

template_url($path, $template = TEMPLATE, $folder = '/assets/');
```

Finally, this pull-request introduce the ability to use dynamic methods **shareX** into **Core\View** and **Core\Template** classes. Usage:
```php
return View::make('Welcome/SubPage', $data, 'Home')->shareTitle($title);
```