### PR TITLE
Improve the Auth System

### DIFF
--- a/app/Controllers/Users.php
+++ b/app/Controllers/Users.php
@@ -95,14 +95,16 @@ class Users extends Controller
         $error = array();
 
         if(Request::isPost()) {
+            // Get the actual Password.
             $password = Request::post('password');
 
+            // The requested new Password information.
             $newPassword = Request::post('newPassword');
-            $verPassword = Request::post('verPassword');
+            $verifyPass  = Request::post('verifyPass');
 
             if (! Password::verify($password, $user->password)) {
-                $error[] = 'Wrong current Password inserted.';
-            } else if ($newPassword != $verPassword) {
+                $error[] = 'The current Password is invalid.';
+            } else if ($newPassword != $verifyPass) {
                 $error[] = 'The new Password and its verification are not equals.';
             } else if(! preg_match("/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/", $newPassword)) {
                 $error[] = 'The new Password is not strong enough.';

--- a/app/Views/Users/Profile.php
+++ b/app/Views/Users/Profile.php
@@ -22,7 +22,7 @@
                         <input type="password" class="input-medium input-block-level form-control" name="newPassword" placeholder="Insert the new Password" title="Insert the new Password">
                     </div>
                     <div class="form-control-container" style="margin-bottom: 10px;">
-                        <input type="password" class="input-medium input-block-level form-control" name="verPassword" placeholder="Verify the new Password" title="Verify the new Password">
+                        <input type="password" class="input-medium input-block-level form-control" name="verifyPass" placeholder="Verify the new Password" title="Verify the new Password">
                     </div>
                     <hr>
                     <div>


### PR DESCRIPTION
This pull request introduce improvement into **Auth System** and new methods into **Auth\Guard** API, exposed via **Auth\Auth** Facade. Notable, there is **Auth::id()** which returns the current authenticated User **ID**, or **null** for Guests. Usage is simple:
```php
$userId = Auth::id();

// Do something with userId.
```
Also, is introduced the ability to store and retrieve a boolean flag about login via Cookie, usable as:
```php
if(Auth::viaRemember()) {
    // User authenticated via Cookie; do something about...
}
```