### PR TITLE
Improved Auth\Auth; make configurable the Table columns used by Auth\Guard

### DIFF
--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -161,8 +161,8 @@ Config::set('authentication', array(
     //'model'      => 'Auth\Model',
     'model'      => 'App\Models\Users',
     // The used Table name and its primary key.
-    'table'         => 'users',
-    'primaryKey'    => 'id',
+    'table'      => 'users',
+    'primaryKey' => 'id',
     // The used Table columns.
     'columns' => array(
         'password'      => 'password',

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -157,7 +157,6 @@ Config::set('classAliases', array(
  * Setup the Auth configuration.
  */
 Config::set('authentication', array(
-    'guard'      => 'Auth\Guard',
     //'model'      => 'Auth\Model',
     'model'      => 'App\Models\Users',
     // The used Table name and its primary key.

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -160,7 +160,12 @@ Config::set('authentication', array(
     'guard'      => 'Auth\Guard',
     //'model'      => 'Auth\Model',
     'model'      => 'App\Models\Users',
-    // The User's Table information.
-    'table'      => 'users',
-    'primaryKey' => 'id'
+    // The used Table name and its primary key.
+    'table'         => 'users',
+    'primaryKey'    => 'id',
+    // The used Table columns.
+    'columns' => array(
+        'password'      => 'password',
+        'rememberToken' => 'remember_token'
+    ),
 ));

--- a/app/Controllers/Users.php
+++ b/app/Controllers/Users.php
@@ -95,21 +95,18 @@ class Users extends Controller
         $error = array();
 
         if(Request::isPost()) {
-            // Get the actual Password.
-            $password = Request::post('password');
-
             // The requested new Password information.
-            $newPassword = Request::post('newPassword');
-            $verifyPass  = Request::post('verifyPass');
+            $password = Request::post('newPassword');
+            $confirm  = Request::post('confirmPass');
 
-            if (! Password::verify($password, $user->password)) {
+            if (! Password::verify(Request::post('password'), $user->password)) {
                 $error[] = 'The current Password is invalid.';
-            } else if ($newPassword != $verifyPass) {
+            } else if ($password != $confirm) {
                 $error[] = 'The new Password and its verification are not equals.';
-            } else if(! preg_match("/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/", $newPassword)) {
+            } else if(! preg_match("/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/", $password)) {
                 $error[] = 'The new Password is not strong enough.';
             } else {
-                $this->model->updateUser($user, array('password' => Password::make($newPassword)));
+                $this->model->updateUser($user, array('password' => Password::make($password)));
 
                 // Use a Redirect to avoid the reposting the data.
                 return Redirect::to('profile')->with('message', 'You have successfully updated your Password.');

--- a/app/Views/Users/Profile.php
+++ b/app/Views/Users/Profile.php
@@ -22,7 +22,7 @@
                         <input type="password" class="input-medium input-block-level form-control" name="newPassword" placeholder="Insert the new Password" title="Insert the new Password">
                     </div>
                     <div class="form-control-container" style="margin-bottom: 10px;">
-                        <input type="password" class="input-medium input-block-level form-control" name="verifyPass" placeholder="Verify the new Password" title="Verify the new Password">
+                        <input type="password" class="input-medium input-block-level form-control" name="confirmPass" placeholder="Verify the new Password" title="Verify the new Password">
                     </div>
                     <hr>
                     <div>

--- a/system/Auth/Auth.php
+++ b/system/Auth/Auth.php
@@ -10,36 +10,89 @@ namespace Auth;
 
 use Core\Config;
 
+use \Closure;
+
 
 class Auth
 {
     /**
-     * The Authentication Guard instance.
+     * The currently active Authentication Guards.
      *
-     * @var \Auth\Guard
+     * @var array
      */
-    protected static $guard;
+     public static $guards = array();
 
     /**
-     * Get the Guard instance dynamically.
+     * The third-party Guard Registrar.
      *
-     * @return \Auth\Guard
+     * @var array
      */
-    protected static function getGuardInstance()
+    public static $registrar = array();
+
+    /**
+     * Get an Authentication Guard instance.
+     *
+     * @param  string  $driver
+     * @return Guard
+     */
+    public static function guard($guard = null)
     {
-        if (! isset(static::$guard)) {
-            $config = Config::get('authentication');
+        $guard = ($guard !== null) ? $guard : 'native';
 
-            $className = '\\' .ltrim($config['guard'], '\\');
-
-            static::$guard = new $className($config);
+        if ( ! isset(static::$guards[$guard])) {
+            static::$guards[$guard] = static::factory($guard);
         }
 
-        return static::$guard;
+        return static::$guards[$guard];
     }
 
     /**
-     * Call the Guard methods dynamically.
+     * Create a new Authentication Guard instance.
+     *
+     * @param  string  $driver
+     * @return Guard
+     */
+     protected static function factory($guard)
+     {
+         if (isset(static::$registrar[$guard])) {
+            $resolver = static::$registrar[$guard];
+
+            return call_user_func($resolver);
+         }
+
+         $config = Config::get('authentication');
+
+         switch ($guard) {
+            case 'native':
+                return new \Auth\Guard($config);
+
+            default:
+                throw new \Exception("Auth Guard {$guard} is not supported.");
+         }
+    }
+
+    /**
+     * Register a third-party Authentication Guard.
+     *
+     * @param  string   $guard
+     * @param  Closure  $resolver
+     * @return void
+     */
+    public static function extend($guard, Closure $resolver)
+    {
+        static::$registrar[$guard] = $resolver;
+    }
+
+    /**
+     * Magic Method for calling the methods on the default cache Guard.
+     *
+     * <code>
+     *      // Call the "user" method on the default Auth Guard
+     *      $user = Auth::user();
+     *
+     *      // Call the "check" method on the default Auth Guard
+     *      Auth::check();
+     * </code>
      *
      * @param  string $method
      * @param  array  $params
@@ -47,8 +100,6 @@ class Auth
      */
     public static function __callStatic($method, $params)
     {
-        $guard = static::getGuardInstance();
-
-        return call_user_func_array(array($guard, $method), $params);
+        return call_user_func_array(array(static::guard(), $method), $params);
     }
 }

--- a/system/Auth/Auth.php
+++ b/system/Auth/Auth.php
@@ -54,13 +54,13 @@ class Auth
      */
     protected static function factory($guard)
     {
+        $config = Config::get('authentication');
+
         if (isset(static::$registrar[$guard])) {
             $resolver = static::$registrar[$guard];
 
-            return call_user_func($resolver);
+            return call_user_func($resolver, $config);
         } else if($guard == 'default') {
-            $config = Config::get('authentication');
-
             return new \Auth\Guard($config);
         }
 

--- a/system/Auth/Auth.php
+++ b/system/Auth/Auth.php
@@ -37,7 +37,7 @@ class Auth
      */
     public static function guard($guard = null)
     {
-        $guard = ($guard !== null) ? $guard : 'native';
+        $guard = ($guard !== null) ? $guard : 'default';
 
         if ( ! isset(static::$guards[$guard])) {
             static::$guards[$guard] = static::factory($guard);
@@ -58,7 +58,7 @@ class Auth
             $resolver = static::$registrar[$guard];
 
             return call_user_func($resolver);
-        } else if($guard == 'native') {
+        } else if($guard == 'default') {
             $config = Config::get('authentication');
 
             return new \Auth\Guard($config);

--- a/system/Auth/Auth.php
+++ b/system/Auth/Auth.php
@@ -32,7 +32,7 @@ class Auth
     /**
      * Get an Authentication Guard instance.
      *
-     * @param  string  $driver
+     * @param  string  $guard
      * @return Guard
      */
     public static function guard($guard = null)
@@ -49,7 +49,7 @@ class Auth
     /**
      * Create a new Authentication Guard instance.
      *
-     * @param  string  $driver
+     * @param  string  $guard
      * @return Guard
      */
      protected static function factory($guard)

--- a/system/Auth/Auth.php
+++ b/system/Auth/Auth.php
@@ -52,23 +52,19 @@ class Auth
      * @param  string  $guard
      * @return Guard
      */
-     protected static function factory($guard)
-     {
-         if (isset(static::$registrar[$guard])) {
+    protected static function factory($guard)
+    {
+        if (isset(static::$registrar[$guard])) {
             $resolver = static::$registrar[$guard];
 
             return call_user_func($resolver);
-         }
+        } else if($guard == 'native') {
+            $config = Config::get('authentication');
 
-         $config = Config::get('authentication');
+            return new \Auth\Guard($config);
+        }
 
-         switch ($guard) {
-            case 'native':
-                return new \Auth\Guard($config);
-
-            default:
-                throw new \Exception("Auth Guard {$guard} is not supported.");
-         }
+        throw new \Exception("Auth Guard {$guard} is not supported.");
     }
 
     /**

--- a/system/Auth/Guard.php
+++ b/system/Auth/Guard.php
@@ -344,7 +344,7 @@ class Guard
 
             list($id, $remember_token) = explode('|', $recaller, 2);
 
-            // Prepare the User credentials.
+            // Prepare the requested User credentials.
             $keyName = $this->model->getKeyName();
 
             $credentials = array(

--- a/system/Auth/Guard.php
+++ b/system/Auth/Guard.php
@@ -55,15 +55,31 @@ class Guard
     protected $tokenRetrievalAttempted = false;
 
     /**
+     * @var string
+     */
+    protected $passwordField = 'password';
+
+    /**
+     * @var string
+     */
+    protected $rememberToken = 'remember_token';
+
+    /**
      * Create a new Authentication Guard instance.
      *
      * @return void
      */
     public function __construct(array $config)
     {
-        $className = '\\' .ltrim($config['model'], '\\');
+        // Get the used Table columns from configuration.
+        $fields = $config['columns'];
+
+        $this->passwordField = $fields['password'];
+        $this->rememberToken = $fields['rememberToken'];
 
         // Create the configuration specified Model instance.
+        $className = '\\' .ltrim($config['model'], '\\');
+
         $this->model = new $className($config);
     }
 
@@ -179,7 +195,7 @@ class Guard
         $this->updateSession($user);
 
         if ($remember) {
-            if (empty($user->remember_token)) {
+            if (empty($user->{$this->rememberToken})) {
                 $this->refreshRememberToken($user);
             }
 
@@ -220,7 +236,7 @@ class Guard
         $query = $this->model->newQuery();
 
         foreach ($credentials as $key => $value) {
-            if ($key !== 'password') {
+            if ($key !== $this->passwordField) {
                 $query->where($key, $value);
             }
         }
@@ -250,7 +266,7 @@ class Guard
      */
     protected function validateCredentials(stdClass $user, array $credentials)
     {
-        return Password::verify($credentials['password'], $user->password);
+        return Password::verify($credentials['password'], $user->{$this->passwordField});
     }
 
     /**
@@ -269,7 +285,8 @@ class Guard
         // Create a new Token and update it into Database.
         $user->remember_token = createKey(60);
 
-        $query->where($keyName, $user->{$keyName})->update(array('remember_token' => $user->remember_token));
+        $query->where($keyName, $user->{$keyName})
+            ->update(array($this->rememberToken => $user->remember_token));
     }
 
     /**
@@ -325,7 +342,15 @@ class Guard
 
             list($id, $remember_token) = explode('|', $recaller, 2);
 
-            $this->viaRemember = ! is_null($user = $this->retrieveUser(compact('id', 'remember_token')));
+            // Prepare the User credentials.
+            $keyName = $this->model->getKeyName();
+
+            $credentials = array(
+                $keyName => $id,
+                $this->rememberToken => $remember_token
+            );
+
+            $this->viaRemember = ! is_null($user = $this->retrieveUser($credentials));
 
             return $user;
         }

--- a/system/Auth/Guard.php
+++ b/system/Auth/Guard.php
@@ -151,13 +151,11 @@ class Guard
      */
     public function id()
     {
-        if ($this->loggedOut) {
-            return null;
+        if (! $this->loggedOut) {
+            $id = Session::get($this->getName());
+
+            return ! is_null($id) ? $id : $this->getRecallerId();
         }
-
-        $id = Session::get($this->getName());
-
-        return ! is_null($id) ? $id : $this->getRecallerId();
     }
 
     /**

--- a/system/Auth/Guard.php
+++ b/system/Auth/Guard.php
@@ -72,10 +72,12 @@ class Guard
     public function __construct(array $config)
     {
         // Get the used Table columns from configuration.
-        $fields = $config['columns'];
+        if(isset($config['columns']) && is_array($config['columns'])) {
+            $fields = $config['columns'];
 
-        $this->passwordField = $fields['password'];
-        $this->rememberToken = $fields['rememberToken'];
+            $this->passwordField = $fields['password'];
+            $this->rememberToken = $fields['rememberToken'];
+        }
 
         // Create the configuration specified Model instance.
         $className = '\\' .ltrim($config['model'], '\\');


### PR DESCRIPTION
This pull request introduce the ability to specify into configuration the Users Table columns used by **Auth\Guard**.

Also, there is introduced a improved **Auth\Auth** Facade, which is now extensible, permitting to register on it new third-party Authentication Guards.