### PR TITLE
Implementing a simple Cache Helper in top of phpFastCache

### DIFF
--- a/app/Cache/.gitignore
+++ b/app/Cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -123,7 +123,7 @@ Config::set('classAliases', array(
     'Date'          => '\Helpers\Date',
     'Document'      => '\Helpers\Document',
     'Encrypter'     => '\Helpers\Encrypter',
-    'Cache'         => '\Helpers\FastCache',
+    'FastCache'     => '\Helpers\FastCache',
     'Form'          => '\Helpers\Form',
     'Ftp'           => '\Helpers\Ftp',
     'GeoCode'       => '\Helpers\GeoCode',

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -179,7 +179,7 @@ Config::set('authentication', array(
 ));
 
 /**
- * FastCache configuration
+ * Setup the FastCache configuration.
  */
 Config::set('cache', array(
     'storage'       => 'files', // Blank for auto

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -93,33 +93,22 @@ define('SESSION_PREFIX', 'nova_');
 define('SITETITLE', 'Nova V3.0');
 
 /**
- * Define a 32 bit Encryption Key.
- */
-define('ENCRYPT_KEY', '');
-
-/**
  * OPTIONAL, set a site email address.
  */
 // define('SITEEMAIL', 'email@domain.com');
 
 /**
- * Setup the Database configuration.
+ * Define a 32 bit Encryption Key.
  */
-Config::set('database', array(
-    'default' => array(
-        'driver'    => DB_TYPE,
-        'hostname'  => DB_HOST,
-        'database'  => DB_NAME,
-        'username'  => DB_USER,
-        'password'  => DB_PASS,
-        'prefix'    => PREFIX,
-        'charset'   => 'utf8',
-        'collation' => 'utf8_general_ci',
-    ),
-));
+define('ENCRYPT_KEY', '');
 
 /**
- * Setup the (class) Aliases configuration.
+ * Set the Cache files Path.
+ */
+define('CACHEPATH', APPDIR .'Cache');
+
+/**
+ * Setup the Class Aliases configuration.
  */
 Config::set('classAliases', array(
     'Errors'        => '\Core\Error',
@@ -133,6 +122,8 @@ Config::set('classAliases', array(
     'Csrf'          => '\Helpers\Csrf',
     'Date'          => '\Helpers\Date',
     'Document'      => '\Helpers\Document',
+    'Encrypter'     => '\Helpers\Encrypter',
+    'Cache'         => '\Helpers\FastCache',
     'Form'          => '\Helpers\Form',
     'Ftp'           => '\Helpers\Ftp',
     'GeoCode'       => '\Helpers\GeoCode',
@@ -156,6 +147,22 @@ Config::set('classAliases', array(
 ));
 
 /**
+ * Setup the Database configuration.
+ */
+Config::set('database', array(
+    'default' => array(
+        'driver'    => DB_TYPE,
+        'hostname'  => DB_HOST,
+        'database'  => DB_NAME,
+        'username'  => DB_USER,
+        'password'  => DB_PASS,
+        'prefix'    => PREFIX,
+        'charset'   => 'utf8',
+        'collation' => 'utf8_general_ci',
+    ),
+));
+
+/**
  * Setup the Auth configuration.
  */
 Config::set('authentication', array(
@@ -170,3 +177,39 @@ Config::set('authentication', array(
         'rememberToken' => 'remember_token'
     ),
 ));
+
+/**
+ * FastCache configuration
+ */
+Config::set('cache', array(
+    'storage'       => 'files', // Blank for auto
+    'default_chmod' => 0777,    // 0777, 0666, 0644
+
+    /*
+     * Fall back when Driver is not supported.
+     */
+    'fallback'    => "files",
+
+    'securityKey' => 'auto',
+    'htaccess'    => true,
+    'path'        => CACHEPATH,
+
+    'memcache' => array(
+        array("127.0.0.1",11211,1),
+    ),
+    'redis' => array(
+        'host'     => '127.0.0.1',
+        'port'     => '',
+        'password' => '',
+        'database' => '',
+        'timeout'  => ''
+    ),
+    'ssdb' => array(
+        'host'     => '127.0.0.1',
+        'port'     => 8888,
+        'password' => '',
+        'timeout'  => ''
+    ),
+    'extensions' => array(),
+));
+

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=5.5.0",
         "symfony/console": "3.0.*",
         "doctrine/inflector": "1.0.*",
-        "phpmailer/phpmailer": "5.2.*"
+        "phpmailer/phpmailer": "5.2.*",
+        "phpfastcache/phpfastcache": "3.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -768,7 +768,7 @@ class Query
 
         $this->aggregate = null;
 
-        if (! empty($results)) {
+        if (count($results) > 0) {
             $result = (array) reset($results);
 
             return $result['aggregate'];

--- a/system/Helpers/FastCache.php
+++ b/system/Helpers/FastCache.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * FastCache - A simple Cache Management built on top of phpFastCache.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Helpers;
+
+use Core\Config;
+
+use \phpFastCache;
+
+
+/**
+ * FastCache
+ */
+class FastCache
+{
+    // The FastCache instances.
+    protected static $instances = array();
+
+    // The phpFastCahe instance.
+    protected $cache = null;
+
+
+    /**
+     * Constructor.
+     *
+     * @param string $storage The Storage type.
+     */
+    protected function __construct($storage)
+    {
+        $config = Config::get('cache');
+
+        $config['storage'] = $storage;
+
+        $storage = strtolower($storage);
+
+        if (empty($storage) || ($storage == 'auto')) {
+            $storage = phpFastCache::getAutoClass($config);
+        }
+
+        $this->cache = phpFastCache($storage, $config);
+    }
+
+    /**
+     * Get the FastCache instance of specified Storage type.
+     *
+     * @param string $storage
+     * @return mixed
+     */
+    public static function getInstance($storage = 'files')
+    {
+        if (! isset(self::$instances[$storage])) {
+            static::$instances[$storage] = new static($storage);
+        }
+
+        return static::$instances[$storage];
+    }
+
+    /**
+     * Provide transparent access to any of \phpFastCache Methods.
+     *
+     * @param $method
+     * @param $params
+     * @return mixed
+     */
+    public function __call($method, $params = null)
+    {
+        return call_user_func_array(array($this->cache, $method), $params);
+    }
+}


### PR DESCRIPTION
This pull request introduce a very simple **Cache** Helper, built in top of **phpFastCache**, and called **Helpers\FastCache**. Its usage is very simple:

```php
use Helpers\FastCache;

$cache = FastCache::getInstance();

// Use any phpFastCache methods on FastCache instance.
```

To note that the **Helpers\FastCache** practically acts like a **Decorator** for phpFastCache, then could be called any phpFastCache method, its API applying.

Also, note that this pull request introduce a new directory into App, called **Cache**, to store the Cache files.