### PR TITLE
 	Implementing a simple Events management

### DIFF
--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -142,6 +142,7 @@ Config::set('classAliases', array(
     'Url'           => '\Helpers\Url',
     'DB'            => '\Database\Facade',
     'Auth'          => '\Auth\Auth',
+    'Event'         => '\Events\Facade',
     // The Legacy Mailer
     'Helpers\PhpMailer\Mail' => '\Helpers\Mailer',
 ));

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -53,7 +53,7 @@ class Demo extends Controller
         //
         echo '<h3 style="margin-top: 50px;">Events dispatching</h3>';
 
-        // Prepare a message.
+        // Prepare the Event payload.
         $payload = array(
             'Hello, this is Event sent from ' .str_replace('::', '@', __METHOD__),
             $params

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -5,6 +5,8 @@ use Core\View;
 use Core\Controller;
 use Helpers\Url;
 
+use Event;
+
 /*
 *
 * Demo controller
@@ -17,6 +19,14 @@ class Demo extends Controller
     public function __construct()
     {
         parent::__construct();
+    }
+
+    protected function before()
+    {
+        // Add a Listener to the Event 'test'.
+        Event::listen('test', 'App\Events\Test@handle');
+
+        return parent::before();
     }
 
     /**
@@ -36,6 +46,20 @@ class Demo extends Controller
             'param4' => $param4
         );
 
+        echo '<h3 style="margin-top: 50px;">Action parameters</h3>';
+
         echo '<pre>' .var_export($params, true) .'</pre>';
+
+        //
+        echo '<h3 style="margin-top: 50px;">Events dispatching</h3>';
+
+        // Prepare a message.
+        $payload = array(
+            'Hello, this is Event sent from ' .str_replace('::', '@', __METHOD__),
+            $params
+        );
+
+        // Fire the Event 'test'.
+        Event::fire('test', $payload);
     }
 }

--- a/app/Events/Test.php
+++ b/app/Events/Test.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Events;
+
+
+class Test
+{
+    public static function handle($message, $params)
+    {
+        echo '<pre>' .var_export($message, true) .'</pre>';
+        echo '<pre>' .var_export($params, true) .'</pre>';
+    }
+}

--- a/system/Events/Dispatcher.php
+++ b/system/Events/Dispatcher.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Dispatcher - A simple Events Dispatcher.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Events;
+
+
+class Dispatcher
+{
+    /**
+     * The active Dispatcher instance.
+     *
+     * @var \Events\Dispatcher
+     */
+    private static $instance;
+
+    /**
+     * The registered Event listeners.
+     *
+     * @var array
+     */
+    protected $listeners = array();
+
+    /**
+     * The wildcard listeners.
+     *
+     * @var array
+     */
+    protected $wildcards = array();
+
+    /**
+     * The sorted Event listeners.
+     *
+     * @var array
+     */
+    protected $sorted = array();
+
+    /**
+     * Get the Dispatcher instance.
+     *
+     * @return \Events\Dispatcher
+     */
+    public static function getInstance()
+    {
+        if (! isset(self::$instance)) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Register an Event Listener with the Dispatcher.
+     *
+     * @param  string|array  $event
+     * @param  mixed   $listener
+     * @param  int     $priority
+     * @return void
+     */
+    public function listen($events, $listener, $priority = 0)
+    {
+        foreach ((array) $events as $event) {
+            if (str_contains($event, '*')) {
+                return $this->setupWildcardListen($event, $listener);
+            }
+
+            $this->listeners[$event][$priority][] = $this->makeListener($listener);
+
+            unset($this->sorted[$event]);
+        }
+    }
+
+    /**
+     * Setup a wildcard Listener callback.
+     *
+     * @param  string  $event
+     * @param  mixed   $listener
+     * @return void
+     */
+    protected function setupWildcardListen($event, $listener)
+    {
+        $this->wildcards[$event][] = $this->makeListener($listener);
+    }
+
+    /**
+     * Determine if a given Event has listeners.
+     *
+     * @param  string  $eventName
+     * @return bool
+     */
+    public function hasListeners($eventName)
+    {
+        return isset($this->listeners[$eventName]);
+    }
+
+    /**
+     * Fire an Event and call the listeners.
+     *
+     * @param  string  $event
+     * @param  mixed   $payload
+     * @return array|null
+     */
+    public function fire($event, $payload = array())
+    {
+        $responses = array();
+
+        if (! is_array($payload)) {
+            $payload = array($payload);
+        }
+
+        foreach ($this->getListeners($event) as $listener) {
+            $response = call_user_func_array($listener, $payload);
+
+            if (! is_null($response)) {
+                return $response;
+            } else if ($response === false) {
+                break;
+            }
+
+            $responses[] = $response;
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Get all of the listeners for a given Event name.
+     *
+     * @param  string  $eventName
+     * @return array
+     */
+    public function getListeners($eventName)
+    {
+        $wildcards = $this->getWildcardListeners($eventName);
+
+        if (! isset($this->sorted[$eventName])) {
+            $this->sortListeners($eventName);
+        }
+
+        return array_merge($this->sorted[$eventName], $wildcards);
+    }
+
+    /**
+     * Get the wildcard listeners for the Event.
+     *
+     * @param  string  $eventName
+     * @return array
+     */
+    protected function getWildcardListeners($eventName)
+    {
+        $wildcards = array();
+
+        foreach ($this->wildcards as $key => $listeners) {
+            if (str_is($key, $eventName)) {
+                $wildcards = array_merge($wildcards, $listeners);
+            }
+        }
+
+        return $wildcards;
+    }
+
+    /**
+     * Sort the listeners for a given Event by priority.
+     *
+     * @param  string  $eventName
+     * @return array
+     */
+    protected function sortListeners($eventName)
+    {
+        $this->sorted[$eventName] = array();
+
+        if (! isset($this->listeners[$eventName])) {
+            return;
+        }
+
+        krsort($this->listeners[$eventName]);
+
+        $this->sorted[$eventName] = call_user_func_array('array_merge', $this->listeners[$eventName]);
+    }
+
+    /**
+     * Register an Event listener with the dispatcher.
+     *
+     * @param  mixed  $listener
+     * @return mixed
+     */
+    public function makeListener($listener)
+    {
+        if (is_string($listener)) {
+            return $this->createClassListener($listener);
+        }
+
+        return $listener;
+    }
+
+    /**
+     * Create a Class based Listener.
+     *
+     * @param  string  $listener
+     * @return \Closure
+     */
+    public function createClassListener($listener)
+    {
+        return function() use ($listener) {
+            $data = func_get_args();
+
+            // Explode the Listener string.
+            $segments = explode('@', $listener);
+
+            $className = array_shift($segments);
+
+            $method = ! empty($segments) ? reset($segments) : 'handle';
+
+            return call_user_func_array(array($className, $method), $data);
+        };
+    }
+
+    /**
+     * Remove a set of listeners from the Dispatcher.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function forget($event)
+    {
+        unset($this->listeners[$event]);
+
+        unset($this->sorted[$event]);
+    }
+}

--- a/system/Events/Dispatcher.php
+++ b/system/Events/Dispatcher.php
@@ -102,9 +102,10 @@ class Dispatcher
      *
      * @param  string  $event
      * @param  mixed   $payload
+     * @param  bool    $halt
      * @return array|null
      */
-    public function fire($event, $payload = array())
+    public function fire($event, $payload = array(), $halt = false)
     {
         $responses = array();
 
@@ -115,16 +116,16 @@ class Dispatcher
         foreach ($this->getListeners($event) as $listener) {
             $response = call_user_func_array($listener, $payload);
 
-            if (! is_null($response)) {
+            if (! is_null($response) && $halt) {
                 return $response;
-            } else if ($response === false) {
-                break;
             }
+
+            if ($response === false) break;
 
             $responses[] = $response;
         }
 
-        return $responses;
+        return $halt ? null : $responses;
     }
 
     /**

--- a/system/Events/Facade.php
+++ b/system/Events/Facade.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Facade - A Facade to Events Dispatcher.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Events;
+
+use Events\Dispatcher;
+
+
+class Facade
+{
+    /**
+     * Magic Method for calling the methods on the default Dispatcher instance.
+     *
+     * @param $method
+     * @param $params
+     *
+     * @return mixed
+     */
+    public static function __callStatic($method, $params)
+    {
+        $instance = Dispatcher::getInstance();
+
+        // Call the non-static method from the Dispatcher instance.
+        return call_user_func_array(array($instance, $method), $params);
+    }
+}

--- a/system/functions.php
+++ b/system/functions.php
@@ -46,6 +46,42 @@ function template_url($path, $template = TEMPLATE, $folder = '/assets/')
 /** String helpers. */
 
 /**
+ * Determine if a given string matches a given pattern.
+ *
+ * @param  string  $pattern
+ * @param  string  $value
+ * @return bool
+ */
+function str_is($pattern, $value)
+{
+    if ($pattern != $value) {
+        $pattern = str_replace('\*', '.*', preg_quote($pattern, '#')) .'\z';
+
+        return (bool) preg_match('#^' .$pattern .'#', $value);
+    }
+
+    return true;
+}
+
+/**
+ * Determine if a given string contains a given substring.
+ *
+ * @param  string  $haystack
+ * @param  string|array  $needles
+ * @return bool
+ */
+function str_contains($haystack, $needles)
+{
+    foreach ((array) $needles as $needle) {
+        if (($needle != '') && (strpos($haystack, $needle) !== false)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Test for string starts with
  * @param $haystack
  * @param $needle


### PR DESCRIPTION
This pull request introduce a simple **Events\Dispatcher**, in a Laravel-esque style, and its associated **Facade**.

The idea behind the Events is the ability to send data, as parameters, to interested **Listeners** and call them, when a Event happen. The Listeners could be a Closure or **static** Class Method. 

To note that the  **Events\Dispatcher** do **not** instantiate a Listener's Class, then the called method is a must to be **static**.

Its usage is simple; first we have to register a **Listener**, adding:

```php
use Event;

// Add a Listener to the Event 'test'.
Event::listen('test', 'App\Events\Test@handle');
```

Where the class **App\Events\Test** is
```php
namespace App\Events;

class Test
{
    public static function handle($message)
    {
        echo $message;
    }
}
```

Then, when is need, we could fire the Event:

```php
// Prepare the Event payload.
$payload = array(
    'Hello, this is a Event!',
);

// Fire the Event 'test'.
Event::fire('test', $payload);
```
