### PR TITLE
Improve Events\Dispatcher

### DIFF
--- a/app/Events/Test.php
+++ b/app/Events/Test.php
@@ -5,7 +5,7 @@ namespace App\Events;
 
 class Test
 {
-    public static function handle($message, $params)
+    public static function handle($message, $params = array())
     {
         echo '<pre>' .var_export($message, true) .'</pre>';
         echo '<pre>' .var_export($params, true) .'</pre>';

--- a/system/Database/Model.php
+++ b/system/Database/Model.php
@@ -22,14 +22,14 @@ class Model
     protected $db;
 
     /**
-     * The table associated with the model.
+     * The table associated with the Model.
      *
      * @var string
      */
     protected $table = null;
 
     /**
-     * The primary key for the model.
+     * The primary key for the Model.
      *
      * @var string
      */
@@ -44,7 +44,7 @@ class Model
     public function __construct()
     {
         if(is_null($this->table)) {
-            // If there is not a table name specified, try to auto-calculate it.
+            // If there is not a Table name specified, try to auto-calculate it.
             $className = get_class($this);
 
             if($className != 'Database\Model') {

--- a/system/Events/Dispatcher.php
+++ b/system/Events/Dispatcher.php
@@ -98,6 +98,18 @@ class Dispatcher
     }
 
     /**
+     * Fire an Event until the first non-null response is returned.
+     *
+     * @param  string  $event
+     * @param  array   $payload
+     * @return mixed
+     */
+    public function until($event, $payload = array())
+    {
+        return $this->fire($event, $payload, true);
+    }
+
+    /**
      * Fire an Event and call the listeners.
      *
      * @param  string  $event

--- a/system/Events/Dispatcher.php
+++ b/system/Events/Dispatcher.php
@@ -114,6 +114,17 @@ class Dispatcher
     }
 
     /**
+     * Flush a set of Queued Events.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function flush($event)
+    {
+        $this->fire($event .'_queue');
+    }
+
+    /**
      * Fire an Event until the first non-null response is returned.
      *
      * @param  string  $event
@@ -123,17 +134,6 @@ class Dispatcher
     public function until($event, $payload = array())
     {
         return $this->fire($event, $payload, true);
-    }
-
-    /**
-     * Flush a set of Queued Events.
-     *
-     * @param  string  $event
-     * @return void
-     */
-    public function flush($event)
-    {
-        $this->fire($event .'_queue');
     }
 
     /**


### PR DESCRIPTION
This pull-request introduce improvements into **Events\Dispatcher** as in support for Queued Events and a new method **Events\Dispatcher@until**.

The **Queued Events** is a method to add a number of **Events** to a **Queue**, then firing them together, flushing the Queue. E.g
```php
// Queue the Events
Event::queue('test', array('This is the First Event'));
Event::queue('test', array('This is the Second Event'));
Event::queue('test', array('This is the Third Event'));

// Flush the Queue, firing all defined Events
Event::flush('test'); 
```

The new method **Events\Dispatcher@until** is about firing a Event **until** first **Listener** returns a valid and non-null response, which will be returned. Its usage is simple:
```php
$response = Event::until('testing', $payload);

if($response !== null) {
    // Do something with $response
}
```
