### PR TITLE
Improve the Modules Configuration management

### DIFF
--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -108,6 +108,13 @@ define('ENCRYPT_KEY', '');
 define('CACHEPATH', APPDIR .'Cache');
 
 /**
+ * Setup the Active Modules
+ */
+Config::set('modules', array(
+    //'Users',
+));
+
+/**
  * Setup the Class Aliases configuration.
  */
 Config::set('classAliases', array(

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -14,7 +14,7 @@ use Core\Config;
 class Modules
 {
     /**
-     * There we load the Modules configuration.
+     * The loaded Modules configuration.
      *
      * @var array
      */

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Modules Manager - class responsible to Modules management.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Core;
+
+use Core\Config;
+
+
+class Modules
+{
+    /**
+     * There we load the Modules configuration.
+     *
+     * @var array
+     */
+    static $modules = array();
+
+    /**
+     * Load the Configuration and the Route Filters from the active Modules.
+     */
+    public static function init()
+    {
+        if(empty(static::$modules)) {
+            static::$modules = Config::get('modules');
+        }
+
+        foreach (static::$modules as $module) {
+            // Load the Configuration.
+            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Config.php');
+
+            if (is_readable($filePath)) {
+                require $filePath;
+            }
+
+            // Load the Route Filters.
+            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Filters.php');
+
+            if (is_readable($filePath)) {
+                require $filePath;
+            }
+        }
+    }
+
+    /**
+     * Load the Routes from the active Modules.
+     */
+    public static function loadRoutes()
+    {
+        if(empty(static::$modules)) {
+            static::$modules = Config::get('modules');
+        }
+
+        foreach (static::$modules as $module) {
+            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Routes.php');
+
+            if (is_readable($filePath)) {
+                require $filePath;
+            }
+        }
+    }
+}

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -28,7 +28,7 @@ class Modules
         // Load the the Modules configuration.
         static::$modules = Config::get('modules');
 
-        // Load the Config(uration) and Routes Filters for every specified Module.
+        // Load the Config(uration) and Routes Filters from every specified Module.
         foreach (static::$modules as $module) {
             foreach (array('Config', 'Filters') as $file) {
                 $filePath = APPDIR .'Modules' .DS .$module .DS .$file .'.php';
@@ -45,6 +45,7 @@ class Modules
      */
     public static function loadRoutes()
     {
+        // Load the Routes from every specified Module.
         foreach (static::$modules as $module) {
             $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Routes.php');
 

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -33,9 +33,11 @@ class Modules
             foreach (array('Config', 'Filters') as $file) {
                 $filePath = APPDIR .'Modules' .DS .$module .DS .$file .'.php';
 
-                if (is_readable($filePath)) {
-                    require $filePath;
+                if (! is_readable($filePath)) {
+                    continue;
                 }
+
+                require $filePath;
             }
         }
     }
@@ -49,9 +51,11 @@ class Modules
         foreach (static::$modules as $module) {
             $filePath = APPDIR .'Modules' .DS .$module .DS .'Routes.php';
 
-            if (is_readable($filePath)) {
-                require $filePath;
+            if (! is_readable($filePath)) {
+                continue;
             }
+
+            require $filePath;
         }
     }
 }

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -47,7 +47,7 @@ class Modules
     {
         // Load the Routes from every specified Module.
         foreach (static::$modules as $module) {
-            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Routes.php');
+            $filePath = str_replace('/', DS, APPDIR .'Modules/' .$module .'/Routes.php');
 
             if (is_readable($filePath)) {
                 require $filePath;

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -28,6 +28,7 @@ class Modules
         // Load the the Modules configuration.
         static::$modules = Config::get('modules');
 
+        // Load the Config(uration) and Routes Filters for every specified Module.
         foreach (static::$modules as $module) {
             foreach (array('Config', 'Filters') as $file) {
                 $filePath = APPDIR .'Modules' .DS .$module .DS .$file .'.php';

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -29,18 +29,12 @@ class Modules
         static::$modules = Config::get('modules');
 
         foreach (static::$modules as $module) {
-            // Load the Configuration.
-            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Config.php');
+            foreach (array('Config', 'Filters') as $file) {
+                $filePath = APPDIR .'Modules' .DS .$module .DS .$file .'.php';
 
-            if (is_readable($filePath)) {
-                require $filePath;
-            }
-
-            // Load the Route Filters.
-            $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Filters.php');
-
-            if (is_readable($filePath)) {
-                require $filePath;
+                if (is_readable($filePath)) {
+                    require $filePath;
+                }
             }
         }
     }

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -51,10 +51,6 @@ class Modules
      */
     public static function loadRoutes()
     {
-        if(empty(static::$modules)) {
-            static::$modules = Config::get('modules');
-        }
-
         foreach (static::$modules as $module) {
             $filePath = str_replace('/', DS, APPDIR.'Modules/'.$module.'/Routes.php');
 

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Modules - A Class responsible to Modules management.
+ * Modules - A Class responsible for the Modules initialization.
  *
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Modules Manager - class responsible to Modules management.
+ * Modules - A Class responsible to Modules management.
  *
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -47,7 +47,7 @@ class Modules
     {
         // Load the Routes from every specified Module.
         foreach (static::$modules as $module) {
-            $filePath = str_replace('/', DS, APPDIR .'Modules/' .$module .'/Routes.php');
+            $filePath = APPDIR .'Modules' .DS .$module .DS .'Routes.php';
 
             if (is_readable($filePath)) {
                 require $filePath;

--- a/system/Core/Modules.php
+++ b/system/Core/Modules.php
@@ -25,9 +25,8 @@ class Modules
      */
     public static function init()
     {
-        if(empty(static::$modules)) {
-            static::$modules = Config::get('modules');
-        }
+        // Load the the Modules configuration.
+        static::$modules = Config::get('modules');
 
         foreach (static::$modules as $module) {
             // Load the Configuration.

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -9,6 +9,7 @@
 
 use Core\Aliases;
 use Core\Language;
+use Core\Modules;
 use Core\Router;
 use Helpers\Session;
 
@@ -41,11 +42,17 @@ Session::init();
 /** Initialize the Language. */
 Language::init();
 
+/** Initialize the active Modules */
+Modules::init();
+
 /** Get the Router instance. */
 $router = Router::getInstance();
 
 /** Load the Routes */
 require APPDIR .'Routes.php';
+
+/** Load the Routes from the active Modules */
+Modules::loadRoutes();
 
 /** Execute matched Routes. */
 $router->dispatch();


### PR DESCRIPTION
This pull-request introduce a simple but enhanced Modules configuration, using  a new Class called **Core\Modules**. Basically, now every Module can be considered a **min-App**, sporting its own **Config.php**, **Filters.php** and **Routes.php**, with functionality similar with the main ones.

To properly work, a App Configuration entry was added, and there should be specified the **active** Modules, the **Core\Modules** looking only for those specified by name there. E.g.

```php
Config::set('modules', array(
    'Users',
    'Blog',
    'Articles',
));
```
