### PR TITLE
Implementation of a Laravel-esque Request, Input (and Response) support

### DIFF
--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -166,7 +166,7 @@ Config::set('classAliases', array(
     'TableBuilder'  => '\Helpers\TableBuilder',
     'Tags'          => '\Helpers\Tags',
     'Url'           => '\Helpers\Url',
-    // The Facades
+    // The Support Facades
     'Auth'          => '\Auth\Auth',
     'DB'            => '\Support\Facades\Database',
     'Event'         => '\Support\Facades\Event',

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -171,7 +171,9 @@ Config::set('classAliases', array(
     'Auth'          => '\Auth\Auth',
     'DB'            => '\Support\Facades\Database',
     'Event'         => '\Support\Facades\Event',
+    'Input'         => '\Support\Facades\Input',
     'Language'      => '\Support\Facades\Language',
+    'Request'       => '\Support\Facades\Request',
     'Validator'     => '\Support\Facades\Validator',
     // The Legacy Mailer
     'Helpers\PhpMailer\Mail' => '\Helpers\Mailer',

--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -140,7 +140,6 @@ Config::set('modules', array(
 Config::set('classAliases', array(
     'Config'        => '\Core\Config',
     'Errors'        => '\Core\Error',
-    'Request'       => '\Core\Request',
     'Response'      => '\Core\Response',
     'Redirect'      => '\Core\Redirect',
     'Mail'          => '\Helpers\Mailer',

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -69,6 +69,9 @@ class Demo extends Controller
 
         echo '<pre>' .var_export(Request::segment(1), true).'</pre>';
 
+        echo '<pre>' .var_export(Request::isGet(), true).'</pre>';
+        echo '<pre>' .var_export(Request::isPost(), true).'</pre>';
+
         echo '<pre>' .var_export(Input::all(), true).'</pre>';
     }
 

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -57,7 +57,7 @@ class Demo extends Controller
 
     public function request($param1 = '', $param2 = '', $param3 = '', $param4 = '')
     {
-        echo '<h3>Request</h3>';
+        echo '<h3>HTTP Request</h3>';
 
         echo '<pre>' .var_export(Request::root(), true).'</pre>';
 
@@ -70,9 +70,12 @@ class Demo extends Controller
         echo '<pre>' .var_export(Request::segment(1), true).'</pre>';
 
         echo '<pre>' .var_export(Request::isGet(), true).'</pre>';
+
         echo '<pre>' .var_export(Request::isPost(), true).'</pre>';
 
         echo '<pre>' .var_export(Input::all(), true).'</pre>';
+
+        echo '<pre>' .var_export(Request::createFromGlobals(), true).'</pre>';
     }
 
     public function events()

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -8,8 +8,11 @@ use Helpers\Url;
 
 use Event;
 use Validator;
+use Input;
+use Request;
 
 use App\Models\ORM\User;
+
 
 /*
 *
@@ -50,6 +53,23 @@ class Demo extends Controller
         echo '<h3>Action parameters</h3>';
 
         echo '<pre>' .var_export($params, true) .'</pre>';
+    }
+
+    public function request($param1 = '', $param2 = '', $param3 = '', $param4 = '')
+    {
+        echo '<h3>Request</h3>';
+
+        echo '<pre>' .var_export(Request::root(), true).'</pre>';
+
+        echo '<pre>' .var_export(Request::url(), true).'</pre>';
+
+        echo '<pre>' .var_export(Request::path(), true).'</pre>';
+
+        echo '<pre>' .var_export(Request::segments(), true).'</pre>';
+
+        echo '<pre>' .var_export(Request::segment(1), true).'</pre>';
+
+        echo '<pre>' .var_export(Input::all(), true).'</pre>';
     }
 
     public function events()

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -22,6 +22,8 @@ Router::any('demo/database',        'App\Controllers\Demo@database');
 Router::any('demo/events',          'App\Controllers\Demo@events');
 Router::any('demo/validate',        'App\Controllers\Demo@validate');
 
+Router::any('demo/request(/(:any)(/(:any)(/(:all))))', 'App\Controllers\Demo@request');
+
 Router::any('admin/(:any)(/(:any)(/(:any)(/(:all))))', array(
     'filters' => 'test',
     'uses'    => 'App\Controllers\Demo@test'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "doctrine/inflector": "1.0.*",
         "phpmailer/phpmailer": "5.2.*",
         "phpfastcache/phpfastcache": "3.0.*",
-        "symfony/http-foundation": "^3.0"
+        "symfony/http-foundation": "^3.0",
+        "patchwork/utf8": "~1.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/console": "3.0.*",
         "doctrine/inflector": "1.0.*",
         "phpmailer/phpmailer": "5.2.*",
-        "phpfastcache/phpfastcache": "3.0.*"
+        "phpfastcache/phpfastcache": "3.0.*",
+        "symfony/http-foundation": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/system/Cookie/CookieJar.php
+++ b/system/Cookie/CookieJar.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Cookie;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+
+class CookieJar
+{
+    /**
+     * The default path (if specified).
+     *
+     * @var string
+     */
+    protected $path = '/';
+
+    /**
+     * The default domain (if specified).
+     *
+     * @var string
+     */
+    protected $domain = null;
+
+    /**
+     * All of the cookies queued for sending.
+     *
+     * @var array
+     */
+    protected $queued = array();
+
+    /**
+     * Create a new Cookie instance.
+     *
+     * @param  string  $name
+     * @param  string  $value
+     * @param  int     $minutes
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool    $secure
+     * @param  bool    $httpOnly
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    {
+        list($path, $domain) = $this->getPathAndDomain($path, $domain);
+
+        $time = ($minutes == 0) ? 0 : time() + ($minutes * 60);
+
+        return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
+    }
+
+    /**
+     * Create a cookie that lasts "forever" (five years).
+     *
+     * @param  string  $name
+     * @param  string  $value
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool    $secure
+     * @param  bool    $httpOnly
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    {
+        return $this->make($name, $value, 2628000, $path, $domain, $secure, $httpOnly);
+    }
+
+    /**
+     * Expire the given Cookie.
+     *
+     * @param  string  $name
+     * @param  string  $path
+     * @param  string  $domain
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function forget($name, $path = null, $domain = null)
+    {
+        return $this->make($name, null, -2628000, $path, $domain);
+    }
+
+    /**
+     * Determine if a Cookie has been queued.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasQueued($key)
+    {
+        return ! is_null($this->queued($key));
+    }
+
+    /**
+     * Get a queued Cookie instance.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function queued($key, $default = null)
+    {
+        return array_get($this->queued, $key, $default);
+    }
+
+    /**
+     * Queue a Cookie to send with the next response.
+     *
+     * @param  dynamic
+     * @return void
+     */
+    public function queue()
+    {
+        if (head(func_get_args()) instanceof Cookie) {
+            $cookie = head(func_get_args());
+        } else {
+            $cookie = call_user_func_array(array($this, 'make'), func_get_args());
+        }
+
+        $this->queued[$cookie->getName()] = $cookie;
+    }
+
+    /**
+     * Remove a cookie from the queue.
+     *
+     * @param $cookieName
+     */
+    public function unqueue($name)
+    {
+        unset($this->queued[$name]);
+    }
+
+    /**
+     * Get the path and domain, or the default values.
+     *
+     * @param  string  $path
+     * @param  string  $domain
+     * @return array
+     */
+    protected function getPathAndDomain($path, $domain)
+    {
+        return array($path ?: $this->path, $domain ?: $this->domain);
+    }
+
+    /**
+     * Set the default path and domain for the jar.
+     *
+     * @param  string  $path
+     * @param  string  $domain
+     * @return self
+     */
+    public function setDefaultPathAndDomain($path, $domain)
+    {
+        list($this->path, $this->domain) = array($path, $domain);
+
+        return $this;
+    }
+
+    /**
+     * Get the cookies which have been queued for the next request
+     *
+     * @return array
+     */
+    public function getQueuedCookies()
+    {
+        return $this->queued;
+    }
+
+}

--- a/system/Core/Base/View.php
+++ b/system/Core/Base/View.php
@@ -13,15 +13,13 @@ use Core\Response;
 use Core\View as CoreView;
 use Helpers\Inflector;
 
-use Support\Contracts\RenderableInterface;
-
 use ArrayAccess;
 
 
 /**
  * View class to load template and views files.
  */
-abstract class View implements RenderableInterface, ArrayAccess
+abstract class View implements ArrayAccess
 {
     /**
      * @var array Array of shared data

--- a/system/Core/Base/View.php
+++ b/system/Core/Base/View.php
@@ -13,13 +13,15 @@ use Core\Response;
 use Core\View as CoreView;
 use Helpers\Inflector;
 
+use Support\Contracts\RenderableInterface;
+
 use ArrayAccess;
 
 
 /**
  * View class to load template and views files.
  */
-abstract class View implements ArrayAccess
+abstract class View implements RenderableInterface, ArrayAccess
 {
     /**
      * @var array Array of shared data

--- a/system/Database/ORM/Model.php
+++ b/system/Database/ORM/Model.php
@@ -13,10 +13,14 @@ use Database\Connection;
 use Database\Query\Builder as QueryBuilder;
 use Database\ORM\Builder;
 
+use Support\Contracts\ArrayableInterface;
+use Support\Contracts\JsonableInterface;
+
 use \PDO;
+use ArrayAccess;
 
 
-class Model implements \ArrayAccess
+class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
 {
     /**
      * The Database Connection name.

--- a/system/Http/JsonResponse.php
+++ b/system/Http/JsonResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Http;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Support\Contracts\JsonableInterface;
+
+class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
+
+    /**
+     * The json encoding options.
+     *
+     * @var int
+     */
+    protected $jsonOptions;
+
+    /**
+     * Constructor.
+     *
+     * @param  mixed  $data
+     * @param  int    $status
+     * @param  array  $headers
+     * @param  int    $options
+    */
+    public function __construct($data = null, $status = 200, $headers = array(), $options = 0)
+    {
+        $this->jsonOptions = $options;
+
+        parent::__construct($data, $status, $headers);
+    }
+
+    /**
+     * Get the json_decoded data from the response
+     *
+     * @param  bool $assoc
+     * @param  int  $depth
+     * @return mixed
+     */
+    public function getData($assoc = false, $depth = 512)
+    {
+        return json_decode($this->data, $assoc, $depth);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData($data = array())
+    {
+        $this->data = ($data instanceof JsonableInterface)
+                                   ? $data->toJson($this->jsonOptions)
+                                   : json_encode($data, $this->jsonOptions);
+
+        return $this->update();
+    }
+
+    /**
+     * Set a header on the Response.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  bool    $replace
+     * @return \Http\Response
+     */
+    public function header($key, $value, $replace = true)
+    {
+        $this->headers->set($key, $value, $replace);
+
+        return $this;
+    }
+
+    /**
+     * Add a cookie to the response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
+     * @return \Http\Response
+     */
+    public function withCookie(Cookie $cookie)
+    {
+        $this->headers->setCookie($cookie);
+
+        return $this;
+    }
+
+}

--- a/system/Http/RedirectResponse.php
+++ b/system/Http/RedirectResponse.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Http;
+
+use Support\MessageBag;
+use Symfony\Component\HttpFoundation\Cookie;
+use Session\Store as SessionStore;
+use Support\Contracts\MessageProviderInterface;
+
+class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectResponse
+{
+    /**
+     * The request instance.
+     *
+     * @var \Http\Request
+     */
+    protected $request;
+
+    /**
+     * The session store implementation.
+     *
+     * @var \Session\Store
+     */
+    protected $session;
+
+    /**
+     * Set a header on the Response.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  bool  $replace
+     * @return \Http\RedirectResponse
+     */
+    public function header($key, $value, $replace = true)
+    {
+        $this->headers->set($key, $value, $replace);
+
+        return $this;
+    }
+
+    /**
+     * Flash a piece of data to the session.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return \Http\RedirectResponse
+     */
+    public function with($key, $value = null)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k => $v) $this->with($k, $v);
+        } else {
+            $this->session->flash($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a cookie to the response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
+     * @return \Http\RedirectResponse
+     */
+    public function withCookie(Cookie $cookie)
+    {
+        $this->headers->setCookie($cookie);
+
+        return $this;
+    }
+
+    /**
+     * Flash an array of input to the session.
+     *
+     * @param  array  $input
+     * @return \Http\RedirectResponse
+     */
+    public function withInput(array $input = null)
+    {
+        $input = $input ?: $this->request->input();
+
+        $this->session->flashInput($input);
+
+        return $this;
+    }
+
+    /**
+     * Flash an array of input to the session.
+     *
+     * @param  dynamic  string
+     * @return \Http\RedirectResponse
+     */
+    public function onlyInput()
+    {
+        return $this->withInput($this->request->only(func_get_args()));
+    }
+
+    /**
+     * Flash an array of input to the session.
+     *
+     * @param  dynamic  string
+     * @return \Http\RedirectResponse
+     */
+    public function exceptInput()
+    {
+        return $this->withInput($this->request->except(func_get_args()));
+    }
+
+    /**
+     * Flash a container of errors to the session.
+     *
+     * @param  \Support\Contracts\MessageProviderInterface|array  $provider
+     * @return \Http\RedirectResponse
+     */
+    public function withErrors($provider)
+    {
+        if ($provider instanceof MessageProviderInterface) {
+            $this->with('errors', $provider->getMessageBag());
+        } else {
+            $this->with('errors', new MessageBag((array) $provider));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the Request instance.
+     *
+     * @return  \Http\Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Set the Request instance.
+     *
+     * @param  \Http\Request  $request
+     * @return void
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Get the Session Store implementation.
+     *
+     * @return \Session\Store
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+
+    /**
+     * Set the Session Store implementation.
+     *
+     * @param \Session\Store  $store
+     * @return void
+     */
+    public function setSession(SessionStore $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Dynamically bind flash data in the Session.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (starts_with($method, 'with')) {
+            return $this->with(lcfirst(substr($method, 4)), $parameters[0]);
+        }
+
+        throw new \BadMethodCallException("Method [$method] does not exist on Redirect.");
+    }
+}

--- a/system/Http/Request.php
+++ b/system/Http/Request.php
@@ -1,0 +1,551 @@
+<?php
+
+namespace Http;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+
+class Request extends SymfonyRequest
+{
+    /**
+     * The decoded JSON content for the request.
+     *
+     * @var string
+     */
+    protected $json;
+
+    /**
+     * The Nova Session Store implementation.
+     *
+     * @var \Session\Store
+     */
+    protected $sessionStore;
+
+    /**
+     * Return the Request instance.
+     *
+     * @return \Http\Request
+     */
+    public function instance()
+    {
+        return $this;
+    }
+
+    /**
+     * Get the request method.
+     *
+     * @return string
+     */
+    public function method()
+    {
+        return $this->getMethod();
+    }
+
+    /**
+     * Get the root URL for the application.
+     *
+     * @return string
+     */
+    public function root()
+    {
+        return rtrim($this->getSchemeAndHttpHost() .$this->getBaseUrl(), '/');
+    }
+
+    /**
+     * Get the URL (no query string) for the request.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return rtrim(preg_replace('/\?.*/', '', $this->getUri()), '/');
+    }
+
+    /**
+     * Get the full URL for the request.
+     *
+     * @return string
+     */
+    public function fullUrl()
+    {
+        $query = $this->getQueryString();
+
+        return $query ? $this->url() .'?' .$query : $this->url();
+    }
+
+    /**
+     * Get the current path info for the request.
+     *
+     * @return string
+     */
+    public function path()
+    {
+        $pattern = trim($this->getPathInfo(), '/');
+
+        return ($pattern == '') ? '/' : $pattern;
+    }
+
+    /**
+     * Get the current encoded path info for the request.
+     *
+     * @return string
+     */
+    public function decodedPath()
+    {
+        return rawurldecode($this->path());
+    }
+
+    /**
+     * Get a segment from the URI (1 based index).
+     *
+     * @param  string  $index
+     * @param  mixed   $default
+     * @return string
+     */
+    public function segment($index, $default = null)
+    {
+        return array_get($this->segments(), $index - 1, $default);
+    }
+
+    /**
+     * Get all of the segments for the request path.
+     *
+     * @return array
+     */
+    public function segments()
+    {
+        $segments = explode('/', $this->path());
+
+        return array_values(array_filter($segments, function($v) { return $v != ''; }));
+    }
+
+    /**
+     * Determine if the current request URI matches a pattern.
+     *
+     * @param  dynamic  string
+     * @return bool
+     */
+    public function is()
+    {
+        foreach (func_get_args() as $pattern)
+        {
+            if (str_is($pattern, urldecode($this->path()))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the request is the result of an AJAX call.
+     *
+     * @return bool
+     */
+    public function ajax()
+    {
+        return $this->isXmlHttpRequest();
+    }
+
+    /**
+     * Determine if the request is over HTTPS.
+     *
+     * @return bool
+     */
+    public function secure()
+    {
+        return $this->isSecure();
+    }
+
+    /**
+     * Determine if the request contains a given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function exists($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        $input = $this->all();
+
+        foreach ($keys as $value) {
+            if ( ! array_key_exists($value, $input)) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the request contains a non-emtpy value for an input item.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->isEmptyString($value)) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the given input key is an empty string for "has".
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEmptyString($key)
+    {
+        $boolOrArray = is_bool($this->input($key)) || is_array($this->input($key));
+
+        return ! $boolOrArray && (trim((string) $this->input($key)) === '');
+    }
+
+    /**
+     * Get all of the input and files for the request.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return array_merge_recursive($this->input(), $this->files->all());
+    }
+
+    /**
+     * Retrieve an input item from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public function input($key = null, $default = null)
+    {
+        $input = $this->getInputSource()->all() + $this->query->all();
+
+        return array_get($input, $key, $default);
+    }
+
+    /**
+     * Get a subset of the items from the input data.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function only($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return array_only($this->input(), $keys) + array_fill_keys($keys, null);
+    }
+
+    /**
+     * Get all of the input except for a specified array of items.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function except($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = $this->input();
+
+        foreach ($keys as $key) array_forget($results, $key);
+
+        return $results;
+    }
+
+    /**
+     * Retrieve a query string item from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public function query($key = null, $default = null)
+    {
+        return $this->retrieveItem('query', $key, $default);
+    }
+
+    /**
+     * Determine if a cookie is set on the request.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasCookie($key)
+    {
+        return ! is_null($this->cookie($key));
+    }
+
+    /**
+     * Retrieve a cookie from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public function cookie($key = null, $default = null)
+    {
+        return $this->retrieveItem('cookies', $key, $default);
+    }
+
+    /**
+     * Retrieve a file from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return \Symfony\Component\HttpFoundation\File\UploadedFile|array
+     */
+    public function file($key = null, $default = null)
+    {
+        return array_get($this->files->all(), $key, $default);
+    }
+
+    /**
+     * Determine if the uploaded data contains a file.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasFile($key)
+    {
+        if (is_array($file = $this->file($key))) $file = head($file);
+
+        return (($file instanceof \SplFileInfo) && ($file->getPath() != ''));
+    }
+
+    /**
+     * Retrieve a header from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public function header($key = null, $default = null)
+    {
+        return $this->retrieveItem('headers', $key, $default);
+    }
+
+    /**
+     * Retrieve a server variable from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public function server($key = null, $default = null)
+    {
+        return $this->retrieveItem('server', $key, $default);
+    }
+
+    /**
+     * Retrieve an old input item.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public function old($key = null, $default = null)
+    {
+        return $this->session()->getOldInput($key, $default);
+    }
+
+    /**
+     * Flash the input for the current request to the session.
+     *
+     * @param  string $filter
+     * @param  array  $keys
+     * @return void
+     */
+    public function flash($filter = null, $keys = array())
+    {
+        $flash = ( ! is_null($filter)) ? $this->$filter($keys) : $this->input();
+
+        $this->session()->flashInput($flash);
+    }
+
+    /**
+     * Flash only some of the input to the session.
+     *
+     * @param  dynamic  string
+     * @return void
+     */
+    public function flashOnly($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return $this->flash('only', $keys);
+    }
+
+    /**
+     * Flash only some of the input to the session.
+     *
+     * @param  dynamic  string
+     * @return void
+     */
+    public function flashExcept($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return $this->flash('except', $keys);
+    }
+
+    /**
+     * Flush all of the old input from the session.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->session()->flashInput(array());
+    }
+
+    /**
+     * Retrieve a parameter item from a given source.
+     *
+     * @param  string  $source
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    protected function retrieveItem($source, $key, $default)
+    {
+        if (is_null($key)) {
+            return $this->$source->all();
+        } else {
+            return $this->$source->get($key, $default, true);
+        }
+    }
+
+    /**
+     * Merge new input into the current request's input array.
+     *
+     * @param  array  $input
+     * @return void
+     */
+    public function merge(array $input)
+    {
+        $this->getInputSource()->add($input);
+    }
+
+    /**
+     * Replace the input for the current request.
+     *
+     * @param  array  $input
+     * @return void
+     */
+    public function replace(array $input)
+    {
+        $this->getInputSource()->replace($input);
+    }
+
+    /**
+     * Get the JSON payload for the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public function json($key = null, $default = null)
+    {
+        if ( ! isset($this->json)) {
+            $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+        }
+
+        if (is_null($key)) return $this->json;
+
+        return array_get($this->json->all(), $key, $default);
+    }
+
+    /**
+     * Get the input source for the request.
+     *
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     */
+    protected function getInputSource()
+    {
+        if ($this->isJson()) return $this->json();
+
+        return ($this->getMethod() == 'GET') ? $this->query : $this->request;
+    }
+
+    /**
+     * Determine if the request is sending JSON.
+     *
+     * @return bool
+     */
+    public function isJson()
+    {
+        return str_contains($this->header('CONTENT_TYPE'), '/json');
+    }
+
+    /**
+     * Determine if the current request is asking for JSON in return.
+     *
+     * @return bool
+     */
+    public function wantsJson()
+    {
+        $acceptable = $this->getAcceptableContentTypes();
+
+        return (isset($acceptable[0]) && ($acceptable[0] == 'application/json'));
+    }
+
+    /**
+     * Get the data format expected in the response.
+     *
+     * @return string
+     */
+    public function format($default = 'html')
+    {
+        foreach ($this->getAcceptableContentTypes() as $type) {
+            if ($format = $this->getFormat($type)) return $format;
+        }
+
+        return $default;
+    }
+
+    /**
+     * Create an Nova request from a Symfony instance.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @return \Http\Request
+     */
+    public static function createFromBase(SymfonyRequest $request)
+    {
+        if ($request instanceof static) return $request;
+
+        return with(new static())->duplicate(
+            $request->query->all(),
+            $request->request->all(),
+            $request->attributes->all(),
+            $request->cookies->all(),
+            $request->files->all(),
+            $request->server->all()
+        );
+    }
+
+    /**
+     * Get the session associated with the request.
+     *
+     * @return \Session\Store
+     *
+     * @throws \RuntimeException
+     */
+    public function session()
+    {
+        if ( ! $this->hasSession()) {
+            throw new \RuntimeException("Session store not set on request.");
+        }
+
+        return $this->getSession();
+    }
+
+}

--- a/system/Http/Response.php
+++ b/system/Http/Response.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Http;
+
+use ArrayObject;
+use Symfony\Component\HttpFoundation\Cookie;
+
+use Support\Contracts\JsonableInterface;
+use Support\Contracts\RenderableInterface;
+
+class Response extends \Symfony\Component\HttpFoundation\Response
+{
+    /**
+     * The original content of the response.
+     *
+     * @var mixed
+     */
+    public $original;
+
+    /**
+     * Set a header on the Response.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  bool    $replace
+     * @return \Http\Response
+     */
+    public function header($key, $value, $replace = true)
+    {
+        $this->headers->set($key, $value, $replace);
+
+        return $this;
+    }
+
+    /**
+     * Add a cookie to the response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
+     * @return \Http\Response
+     */
+    public function withCookie(Cookie $cookie)
+    {
+        $this->headers->setCookie($cookie);
+
+        return $this;
+    }
+
+    /**
+     * Set the content on the response.
+     *
+     * @param  mixed  $content
+     * @return void
+     */
+    public function setContent($content)
+    {
+        $this->original = $content;
+
+        if ($this->shouldBeJson($content)) {
+            $this->headers->set('Content-Type', 'application/json');
+
+            $content = $this->morphToJson($content);
+        } else if ($content instanceof RenderableInterface) {
+            $content = $content->render();
+        }
+
+        return parent::setContent($content);
+    }
+
+    /**
+     * Morph the given content into JSON.
+     *
+     * @param  mixed   $content
+     * @return string
+     */
+    protected function morphToJson($content)
+    {
+        if ($content instanceof JsonableInterface) return $content->toJson();
+
+        return json_encode($content);
+    }
+
+    /**
+     * Determine if the given content should be turned into JSON.
+     *
+     * @param  mixed  $content
+     * @return bool
+     */
+    protected function shouldBeJson($content)
+    {
+        return ($content instanceof JsonableInterface) ||
+               ($content instanceof ArrayObject) ||
+               is_array($content);
+    }
+
+    /**
+     * Get the original response content.
+     *
+     * @return mixed
+     */
+    public function getOriginalContent()
+    {
+        return $this->original;
+    }
+
+}

--- a/system/Http/Response.php
+++ b/system/Http/Response.php
@@ -12,12 +12,13 @@ use Support\Contracts\RenderableInterface;
 class Response extends \Symfony\Component\HttpFoundation\Response
 {
     /**
-     * The original content of the response.
+     * The original content of the Response.
      *
      * @var mixed
      */
     public $original;
 
+    
     /**
      * Set a header on the Response.
      *

--- a/system/Http/Response.php
+++ b/system/Http/Response.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Support\Contracts\JsonableInterface;
 use Support\Contracts\RenderableInterface;
 
+
 class Response extends \Symfony\Component\HttpFoundation\Response
 {
     /**

--- a/system/Http/Response.php
+++ b/system/Http/Response.php
@@ -5,6 +5,7 @@ namespace Http;
 use ArrayObject;
 use Symfony\Component\HttpFoundation\Cookie;
 
+use Core\Bse\View;
 use Support\Contracts\JsonableInterface;
 use Support\Contracts\RenderableInterface;
 
@@ -18,7 +19,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response
      */
     public $original;
 
-    
+
     /**
      * Set a header on the Response.
      *
@@ -61,7 +62,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response
             $this->headers->set('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
-        } else if ($content instanceof RenderableInterface) {
+        } else if (($content instanceof RenderableInterface) || ($content instanceof View)) {
             $content = $content->render();
         }
 
@@ -76,7 +77,9 @@ class Response extends \Symfony\Component\HttpFoundation\Response
      */
     protected function morphToJson($content)
     {
-        if ($content instanceof JsonableInterface) return $content->toJson();
+        if ($content instanceof JsonableInterface) {
+            return $content->toJson();
+        }
 
         return json_encode($content);
     }
@@ -89,9 +92,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response
      */
     protected function shouldBeJson($content)
     {
-        return ($content instanceof JsonableInterface) ||
-               ($content instanceof ArrayObject) ||
-               is_array($content);
+        return (($content instanceof JsonableInterface) || ($content instanceof ArrayObject) || is_array($content));
     }
 
     /**

--- a/system/Session/Store.php
+++ b/system/Session/Store.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Store - A Class which implements a Session Store.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Session;
+
+use Helpers\Encrypter;
+
+
+class Store implements \ArrayAccess
+{
+    /**
+     * Create a new Session Store instance.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function __construct($name)
+    {
+        $this->setName($name);
+    }
+
+    /**
+     * Start the Session.
+     *
+     * @return \Session\Store
+     */
+    public function start()
+    {
+        if (!$this->getId()) {
+            session_start();
+        }
+
+        if (!$this->has('_token')) {
+            $this->regenerateToken();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the current Session id.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return session_id();
+    }
+
+    /**
+     * Set the current Session id.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    public function setId($id)
+    {
+        return session_id($id);
+    }
+
+    /**
+     * Get the current Session name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return session_name();
+    }
+
+    /**
+     * Set the current Session name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function setName($name)
+    {
+        return session_name($name);
+    }
+
+    /**
+     * Set a key / value pair or array of key / value pairs in the Session.
+     *
+     * @param  string|array  $key
+     * @param  mixed|null       $value
+     * @return void
+     */
+    public function set($key, $value = null)
+    {
+        if (! is_array($key)) {
+            $key = array($key => $value);
+        }
+
+        foreach ($key as $arrayKey => $arrayValue) {
+            array_set($_SESSION, $arrayKey, $arrayValue);
+        }
+    }
+
+    /**
+     * Push a value onto an array Session value.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return void
+     */
+    public function push($key, $value)
+    {
+        $array = $this->get($key, array());
+
+        $array[] = $value;
+
+        $this->set($key, $array);
+    }
+
+    /**
+     * Flash a key / value pair to the Session.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function flash($key, $value)
+    {
+        $this->set($key, $value);
+
+        $this->push('flash', $key);
+    }
+
+
+    /**
+     * Delete all the flashed data.
+     *
+     * @return void
+     */
+    public function deleteFlash()
+    {
+        foreach ($this->get('flash', array()) as $key) {
+            $this->delete($key);
+        }
+
+        $this->set('flash', array());
+    }
+
+    /**
+     * Retrieve an item from the Session.
+     *
+     * @param  string  $name
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public function get($name, $default = null)
+    {
+        return array_get($_SESSION, $name, $default);
+    }
+
+    /**
+     * Retrieve all items from the Session.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $_SESSION;
+    }
+
+    /**
+     * Determine if an item exists in the Session.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function has($name)
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Remove an item from the Session.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function delete($key)
+    {
+        array_forget($_SESSION, $key);
+    }
+
+    /**
+     * Destroy all data registered to a Session.
+     *
+     * @return bool
+     */
+    public function destroy()
+    {
+        if ($this->getId()) {
+            return session_destroy();
+        }
+    }
+
+    /**
+     * Remove all items from the Session.
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        return session_unset();
+    }
+
+    /**
+     * Get CSRF token value.
+     *
+     * @return void
+     */
+    public function token()
+    {
+        return $this->get('csrfToken');
+    }
+
+    /**
+     * Regenerate the CSRF token value.
+     *
+     * @return void
+     */
+    public function regenerateToken()
+    {
+        $this->set('csrfToken', hash('sha512', Encrypter::randomBytes()));
+    }
+
+    /**
+     * Determine if the given configuration option exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return $this->has($key);
+    }
+
+    /**
+     * Get a configuration option.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
+     * Set a configuration option.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    /**
+     * Unset a configuration option.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        $this->delete($key);
+    }
+}

--- a/system/Session/Store.php
+++ b/system/Session/Store.php
@@ -31,11 +31,11 @@ class Store implements \ArrayAccess
      */
     public function start()
     {
-        if (!$this->getId()) {
+        if (! $this->getId()) {
             session_start();
         }
 
-        if (!$this->has('_token')) {
+        if (! $this->has('csrfToken')) {
             $this->regenerateToken();
         }
 
@@ -53,7 +53,7 @@ class Store implements \ArrayAccess
     }
 
     /**
-     * Set the current Session id.
+     * Set the current Session ID.
      *
      * @param  string  $id
      * @return void
@@ -88,7 +88,7 @@ class Store implements \ArrayAccess
      * Set a key / value pair or array of key / value pairs in the Session.
      *
      * @param  string|array  $key
-     * @param  mixed|null       $value
+     * @param  mixed|null    $value
      * @return void
      */
     public function set($key, $value = null)

--- a/system/Support/Contracts/ArrayableInterface.php
+++ b/system/Support/Contracts/ArrayableInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Support\Contracts;
+
+
+interface ArrayableInterface
+{
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/system/Support/Contracts/JsonableInterface.php
+++ b/system/Support/Contracts/JsonableInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Support\Contracts;
+
+
+interface JsonableInterface
+{
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0);
+}

--- a/system/Support/Contracts/MessageProviderInterface.php
+++ b/system/Support/Contracts/MessageProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Support\Contracts;
+
+
+interface MessageProviderInterface
+{
+    /**
+     * Get the messages for the instance.
+     *
+     * @return \Support\MessageBag
+     */
+    public function getMessageBag();
+}

--- a/system/Support/Contracts/RenderableInterface.php
+++ b/system/Support/Contracts/RenderableInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Support\Contracts;
+
+
+interface RenderableInterface
+{
+    /**
+     * Get the evaluated contents of the object.
+     *
+     * @return string
+     */
+    public function render();
+}

--- a/system/Support/Contracts/ResponsePreparerInterface.php
+++ b/system/Support/Contracts/ResponsePreparerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Support\Contracts;
+
+
+interface ResponsePreparerInterface
+{
+    /**
+     * Prepare the given value as a Response object.
+     *
+     * @param  mixed  $value
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function prepareResponse($value);
+
+    /**
+     * Determine if provider is ready to return responses.
+     *
+     * @return bool
+     */
+    public function readyForResponses();
+}

--- a/system/Support/Facades/Cookie.php
+++ b/system/Support/Facades/Cookie.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Cookie - A Facade to \Cookie\CookieJar.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Support\Facades;
+
+use Cookie\CookieJar;
+use Support\Facades\Request;
+
+/**
+ * @see \Cookie\CookieJar
+ */
+class Cookie
+{
+    /**
+     * The \Cookie\CookieJar instance being handled.
+     *
+     * @var \Cookie\CookieJar|null
+     */
+    protected static $cookieJar;
+
+    /**
+     * Return a \Http\Request instance
+     *
+     * @return \Http\Request
+     */
+    protected static function getCookieJar()
+    {
+        if (isset(static::$cookieJar)) {
+            return static::$cookieJar;
+        }
+
+        return static::$cookieJar = new CookieJar();
+    }
+
+    /**
+     * Determine if a cookie exists on the request.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public static function has($key)
+    {
+        return ! is_null(Request::instance()->cookie($key, null));
+    }
+
+    /**
+     * Retrieve a cookie from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return string
+     */
+    public static function get($key = null, $default = null)
+    {
+        return Request::instance()->cookie($key, $default);
+    }
+
+    /**
+     * Magic Method for calling the methods on the default CookieJar instance.
+     *
+     * @param $method
+     * @param $params
+     *
+     * @return mixed
+     */
+    public static function __callStatic($method, $params)
+    {
+        // Get a \Http\Request instance.
+        $instance = static::getCookieJar();
+
+        // Call the non-static method from the Request instance.
+        return call_user_func_array(array($instance, $method), $params);
+    }
+}

--- a/system/Support/Facades/Input.php
+++ b/system/Support/Facades/Input.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Input - A Facade to the \Http\Request.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Support\Facades;
+
+use Support\Facades\Request;
+
+
+class Input extends Request
+{
+    /**
+     * Get an item from the input data.
+     *
+     * This method is used for all request verbs (GET, POST, PUT, and DELETE)
+     *
+     * @param  string $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function get($key = null, $default = null)
+    {
+        return static::instance()->input($key, $default);
+    }
+}

--- a/system/Support/Facades/Language.php
+++ b/system/Support/Facades/Language.php
@@ -10,6 +10,9 @@ namespace Support\Facades;
 
 use Core\Language as CoreLanguage;
 
+use ReflectionMethod;
+use ReflectionException;
+
 
 class Language
 {
@@ -24,13 +27,15 @@ class Language
     public static function __callStatic($method, $params)
     {
         // First handle the static Methods from Core\Language.
-        switch ($method) {
-            case 'init':
-            case 'getInstance':
-                return call_user_func_array(array(CoreLanguage::class, $method), $params);
+        try {
+            $reflection = new ReflectionMethod(CoreLanguage::class, $method);
 
-            default:
-                break;
+            if ($reflection->isStatic()) {
+                // Method is static.
+                return call_user_func_array(array(CoreLanguage::class, $method), $params);
+            }
+        } catch ( ReflectionException $e ) {
+            // Nothing to do.
         }
 
         // Get a Core\Language instance.

--- a/system/Support/Facades/Redirect.php
+++ b/system/Support/Facades/Redirect.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Language - A Facade to the Language.
+ * Request - A Facade to the \Http\Request.
  *
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0
@@ -8,16 +8,16 @@
 
 namespace Support\Facades;
 
-use Core\Language as CoreLanguage;
+use Http\RedirectResponse;
 
 use ReflectionMethod;
 use ReflectionException;
 
 
-class Language
+class Redirect
 {
     /**
-     * Magic Method for calling the methods on the default Language instance.
+     * Magic Method for calling the methods on a RedirectResponse instance.
      *
      * @param $method
      * @param $params
@@ -26,22 +26,22 @@ class Language
      */
     public static function __callStatic($method, $params)
     {
-        // First handle the static Methods from Core\Language.
+        // First handle the static Methods from Http\Request.
         try {
-            $reflection = new ReflectionMethod(CoreLanguage::class, $method);
+            $reflection = new ReflectionMethod(RedirectResponse::class, $method);
 
             if ($reflection->isStatic()) {
                 // The Method is static.
-                return call_user_func_array(array(CoreLanguage::class, $method), $params);
+                return call_user_func_array(array(RedirectResponse::class, $method), $params);
             }
         } catch ( ReflectionException $e ) {
             // Nothing to do.
         }
 
-        // Get a Core\Language instance.
-        $instance = CoreLanguage::getInstance();
+        // Get a RedirectResponse instance.
+        $instance = new RedirectResponse();
 
-        // Call the non-static method from the Language instance.
+        // Call the non-static method from the Request instance.
         return call_user_func_array(array($instance, $method), $params);
     }
 }

--- a/system/Support/Facades/Request.php
+++ b/system/Support/Facades/Request.php
@@ -67,6 +67,11 @@ class Request
         // Get a \Http\Request instance.
         $instance = static::getRequest();
 
+        // Support for checking the HTTP Method via isX.
+        if (str_starts_with($method, 'is') && (strlen($method) > 4)) {
+            return ($instance->method() == strtoupper(substr($method, 2)));
+        }
+
         // Call the non-static method from the Request instance.
         return call_user_func_array(array($instance, $method), $params);
     }

--- a/system/Support/Facades/Request.php
+++ b/system/Support/Facades/Request.php
@@ -47,19 +47,19 @@ class Request
      */
     public static function __callStatic($method, $params)
     {
-        // First handle the static Methods from Http\Request.
+        // First handle the static Methods from HttpRequest.
         try {
             $reflection = new ReflectionMethod(HttpRequest::class, $method);
 
             if ($reflection->isStatic()) {
-                // Method is static.
+                // The Method is static.
                 return call_user_func_array(array(HttpRequest::class, $method), $params);
             }
         } catch ( ReflectionException $e ) {
             // Nothing to do.
         }
 
-        // Get a \Http\Request instance.
+        // Get a HttpRequest instance.
         $instance = static::getRequest();
 
         // Support for checking the HTTP Method via isX.

--- a/system/Support/Facades/Request.php
+++ b/system/Support/Facades/Request.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Request - A Facade to the \Http\Request.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Support\Facades;
+
+use Http\Request as HttpRequest;
+
+
+class Request
+{
+    /**
+     * The \Http\Request instance being handled.
+     *
+     * @var \Validation\Factory|null
+     */
+    protected static $request;
+
+    /**
+     * Return a \Http\Request instance
+     *
+     * @return \Http\Request
+     */
+    protected static function getRequest()
+    {
+        if (isset(static::$request)) {
+            return static::$request;
+        }
+
+        return static::$request = HttpRequest::createFromGlobals();
+    }
+
+    /**
+     * Magic Method for calling the methods on the default Request instance.
+     *
+     * @param $method
+     * @param $params
+     *
+     * @return mixed
+     */
+    public static function __callStatic($method, $params)
+    {
+        // First handle the static Methods from Http\Request.
+        switch ($method) {
+            case 'createFromGlobals':
+            case 'create':
+            case 'setFactory':
+            case 'setTrustedProxies':
+            case 'getTrustedProxies' :
+            case 'setTrustedHosts':
+            case 'getTrustedHosts':
+            case 'setTrustedHeaderName':
+            case 'getTrustedHeaderName':
+            case 'normalizeQueryString':
+            case 'enableHttpMethodParameterOverride':
+            case 'getHttpMethodParameterOverride':
+                return call_user_func_array(array(HttpRequest::class, $method), $params);
+
+            default:
+                break;
+        }
+
+        // Get a \Http\Request instance.
+        $instance = static::getRequest();
+
+        // Call the non-static method from the Request instance.
+        return call_user_func_array(array($instance, $method), $params);
+    }
+}

--- a/system/Support/Facades/Request.php
+++ b/system/Support/Facades/Request.php
@@ -10,6 +10,9 @@ namespace Support\Facades;
 
 use Http\Request as HttpRequest;
 
+use ReflectionMethod;
+use ReflectionException;
+
 
 class Request
 {
@@ -45,23 +48,15 @@ class Request
     public static function __callStatic($method, $params)
     {
         // First handle the static Methods from Http\Request.
-        switch ($method) {
-            case 'createFromGlobals':
-            case 'create':
-            case 'setFactory':
-            case 'setTrustedProxies':
-            case 'getTrustedProxies' :
-            case 'setTrustedHosts':
-            case 'getTrustedHosts':
-            case 'setTrustedHeaderName':
-            case 'getTrustedHeaderName':
-            case 'normalizeQueryString':
-            case 'enableHttpMethodParameterOverride':
-            case 'getHttpMethodParameterOverride':
-                return call_user_func_array(array(HttpRequest::class, $method), $params);
+        try {
+            $reflection = new ReflectionMethod(HttpRequest::class, $method);
 
-            default:
-                break;
+            if ($reflection->isStatic()) {
+                // Method is static.
+                return call_user_func_array(array(HttpRequest::class, $method), $params);
+            }
+        } catch ( ReflectionException $e ) {
+            // Nothing to do.
         }
 
         // Get a \Http\Request instance.

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -1,0 +1,132 @@
+<?php namespace Illuminate\Support\Facades;
+
+use Illuminate\Support\Str;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Support\Contracts\ArrayableInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class Response {
+
+	/**
+	 * An array of registered Response macros.
+	 *
+	 * @var array
+	 */
+	protected static $macros = array();
+
+	/**
+	 * Return a new response from the application.
+	 *
+	 * @param  string  $content
+	 * @param  int     $status
+	 * @param  array   $headers
+	 * @return \Illuminate\Http\Response
+	 */
+	public static function make($content = '', $status = 200, array $headers = array())
+	{
+		return new IlluminateResponse($content, $status, $headers);
+	}
+
+	/**
+	 * Return a new view response from the application.
+	 *
+	 * @param  string  $view
+	 * @param  array   $data
+	 * @param  int     $status
+	 * @param  array   $headers
+	 * @return \Illuminate\Http\Response
+	 */
+	public static function view($view, $data = array(), $status = 200, array $headers = array())
+	{
+		$app = Facade::getFacadeApplication();
+
+		return static::make($app['view']->make($view, $data), $status, $headers);
+	}
+
+	/**
+	 * Return a new JSON response from the application.
+	 *
+	 * @param  string|array  $data
+	 * @param  int    $status
+	 * @param  array  $headers
+	 * @param  int    $options
+	 * @return \Illuminate\Http\JsonResponse
+	 */
+	public static function json($data = array(), $status = 200, array $headers = array(), $options = 0)
+	{
+		if ($data instanceof ArrayableInterface)
+		{
+			$data = $data->toArray();
+		}
+
+		return new JsonResponse($data, $status, $headers, $options);
+	}
+
+	/**
+	 * Return a new streamed response from the application.
+	 *
+	 * @param  \Closure  $callback
+	 * @param  int      $status
+	 * @param  array    $headers
+	 * @return \Symfony\Component\HttpFoundation\StreamedResponse
+	 */
+	public static function stream($callback, $status = 200, array $headers = array())
+	{
+		return new StreamedResponse($callback, $status, $headers);
+	}
+
+	/**
+	 * Create a new file download response.
+	 *
+	 * @param  \SplFileInfo|string  $file
+	 * @param  string  $name
+	 * @param  array   $headers
+	 * @param  null|string  $disposition
+	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+	 */
+	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
+	{
+		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+
+		if ( ! is_null($name))
+		{
+			return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Register a macro with the Response class.
+	 *
+	 * @param  string  $name
+	 * @param  callable  $callback
+	 * @return void
+	 */
+	public static function macro($name, $callback)
+	{
+		static::$macros[$name] = $callback;
+	}
+
+	/**
+	 * Handle dynamic calls into Response macros.
+	 *
+	 * @param  string  $method
+	 * @param  array  $parameters
+	 * @return mixed
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public static function __callStatic($method, $parameters)
+	{
+		if (isset(static::$macros[$method]))
+		{
+			return call_user_func_array(static::$macros[$method], $parameters);
+		}
+
+		throw new \BadMethodCallException("Call to undefined method $method");
+	}
+
+}

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -11,7 +11,7 @@ use Support\Contracts\ArrayableInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
-use Patchwork\Utf8;
+use Patchwork\Utf8 as Patchwork;
 
 
 class Response
@@ -82,7 +82,7 @@ class Response
     }
 
     /**
-     * Create a new File Download response.
+     * Create a new file Download Response.
      *
      * @param  \SplFileInfo|string  $file
      * @param  string  $name
@@ -95,7 +95,7 @@ class Response
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
         if ( ! is_null($name)) {
-            return $response->setContentDisposition($disposition, $name, Utf8::toAscii($name));
+            return $response->setContentDisposition($disposition, $name, Patchwork::toAscii($name));
         }
 
         return $response;

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -4,7 +4,7 @@ namespace Support\Facades;
 
 use Core\View;
 use Http\JsonResponse;
-use Http\Response as IlluminateResponse;
+use Http\Response as HttpResponse;
 use Support\Contracts\ArrayableInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -22,7 +22,7 @@ class Response
     protected static $macros = array();
 
     /**
-     * Return a new response from the application.
+     * Return a new Response from the application.
      *
      * @param  string  $content
      * @param  int     $status
@@ -31,11 +31,11 @@ class Response
      */
     public static function make($content = '', $status = 200, array $headers = array())
     {
-        return new IlluminateResponse($content, $status, $headers);
+        return new HttpResponse($content, $status, $headers);
     }
 
     /**
-     * Return a new View response from the application.
+     * Return a new View Response from the application.
      *
      * @param  string  $view
      * @param  array   $data
@@ -49,7 +49,7 @@ class Response
     }
 
     /**
-     * Return a new JSON response from the application.
+     * Return a new JSON Response from the application.
      *
      * @param  string|array  $data
      * @param  int    $status
@@ -67,7 +67,7 @@ class Response
     }
 
     /**
-     * Return a new streamed response from the application.
+     * Return a new Streamed Response from the application.
      *
      * @param  \Closure  $callback
      * @param  int      $status
@@ -80,7 +80,7 @@ class Response
     }
 
     /**
-     * Create a new file download response.
+     * Create a new File Download response.
      *
      * @param  \SplFileInfo|string  $file
      * @param  string  $name

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -9,8 +9,11 @@ use Support\Contracts\ArrayableInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
-class Response {
+use Patchwork\Utf8;
 
+
+class Response
+{
     /**
      * An array of registered Response macros.
      *
@@ -90,7 +93,7 @@ class Response {
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
         if ( ! is_null($name)) {
-            return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+            return $response->setContentDisposition($disposition, $name, Utf8::toAscii($name));
         }
 
         return $response;
@@ -119,8 +122,7 @@ class Response {
      */
     public static function __callStatic($method, $parameters)
     {
-        if (isset(static::$macros[$method]))
-        {
+        if (isset(static::$macros[$method])) {
             return call_user_func_array(static::$macros[$method], $parameters);
         }
 

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -1,132 +1,130 @@
-<?php namespace Illuminate\Support\Facades;
+<?php
 
-use Illuminate\Support\Str;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response as IlluminateResponse;
-use Illuminate\Support\Contracts\ArrayableInterface;
+namespace Support\Facades;
+
+use Core\View;
+use Http\JsonResponse;
+use Http\Response as IlluminateResponse;
+use Support\Contracts\ArrayableInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class Response {
 
-	/**
-	 * An array of registered Response macros.
-	 *
-	 * @var array
-	 */
-	protected static $macros = array();
+    /**
+     * An array of registered Response macros.
+     *
+     * @var array
+     */
+    protected static $macros = array();
 
-	/**
-	 * Return a new response from the application.
-	 *
-	 * @param  string  $content
-	 * @param  int     $status
-	 * @param  array   $headers
-	 * @return \Illuminate\Http\Response
-	 */
-	public static function make($content = '', $status = 200, array $headers = array())
-	{
-		return new IlluminateResponse($content, $status, $headers);
-	}
+    /**
+     * Return a new response from the application.
+     *
+     * @param  string  $content
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Http\Response
+     */
+    public static function make($content = '', $status = 200, array $headers = array())
+    {
+        return new IlluminateResponse($content, $status, $headers);
+    }
 
-	/**
-	 * Return a new view response from the application.
-	 *
-	 * @param  string  $view
-	 * @param  array   $data
-	 * @param  int     $status
-	 * @param  array   $headers
-	 * @return \Illuminate\Http\Response
-	 */
-	public static function view($view, $data = array(), $status = 200, array $headers = array())
-	{
-		$app = Facade::getFacadeApplication();
+    /**
+     * Return a new View response from the application.
+     *
+     * @param  string  $view
+     * @param  array   $data
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Http\Response
+     */
+    public static function view($view, $data = array(), $status = 200, array $headers = array())
+    {
+        return static::make(View::make($view, $data), $status, $headers);
+    }
 
-		return static::make($app['view']->make($view, $data), $status, $headers);
-	}
+    /**
+     * Return a new JSON response from the application.
+     *
+     * @param  string|array  $data
+     * @param  int    $status
+     * @param  array  $headers
+     * @param  int    $options
+     * @return \Http\JsonResponse
+     */
+    public static function json($data = array(), $status = 200, array $headers = array(), $options = 0)
+    {
+        if ($data instanceof ArrayableInterface) {
+            $data = $data->toArray();
+        }
 
-	/**
-	 * Return a new JSON response from the application.
-	 *
-	 * @param  string|array  $data
-	 * @param  int    $status
-	 * @param  array  $headers
-	 * @param  int    $options
-	 * @return \Illuminate\Http\JsonResponse
-	 */
-	public static function json($data = array(), $status = 200, array $headers = array(), $options = 0)
-	{
-		if ($data instanceof ArrayableInterface)
-		{
-			$data = $data->toArray();
-		}
+        return new JsonResponse($data, $status, $headers, $options);
+    }
 
-		return new JsonResponse($data, $status, $headers, $options);
-	}
+    /**
+     * Return a new streamed response from the application.
+     *
+     * @param  \Closure  $callback
+     * @param  int      $status
+     * @param  array    $headers
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public static function stream($callback, $status = 200, array $headers = array())
+    {
+        return new StreamedResponse($callback, $status, $headers);
+    }
 
-	/**
-	 * Return a new streamed response from the application.
-	 *
-	 * @param  \Closure  $callback
-	 * @param  int      $status
-	 * @param  array    $headers
-	 * @return \Symfony\Component\HttpFoundation\StreamedResponse
-	 */
-	public static function stream($callback, $status = 200, array $headers = array())
-	{
-		return new StreamedResponse($callback, $status, $headers);
-	}
+    /**
+     * Create a new file download response.
+     *
+     * @param  \SplFileInfo|string  $file
+     * @param  string  $name
+     * @param  array   $headers
+     * @param  null|string  $disposition
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
+    {
+        $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
-	/**
-	 * Create a new file download response.
-	 *
-	 * @param  \SplFileInfo|string  $file
-	 * @param  string  $name
-	 * @param  array   $headers
-	 * @param  null|string  $disposition
-	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
-	 */
-	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
-	{
-		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+        if ( ! is_null($name)) {
+            return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+        }
 
-		if ( ! is_null($name))
-		{
-			return $response->setContentDisposition($disposition, $name, Str::ascii($name));
-		}
+        return $response;
+    }
 
-		return $response;
-	}
+    /**
+     * Register a macro with the Response class.
+     *
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function macro($name, $callback)
+    {
+        static::$macros[$name] = $callback;
+    }
 
-	/**
-	 * Register a macro with the Response class.
-	 *
-	 * @param  string  $name
-	 * @param  callable  $callback
-	 * @return void
-	 */
-	public static function macro($name, $callback)
-	{
-		static::$macros[$name] = $callback;
-	}
+    /**
+     * Handle dynamic calls into Response macros.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if (isset(static::$macros[$method]))
+        {
+            return call_user_func_array(static::$macros[$method], $parameters);
+        }
 
-	/**
-	 * Handle dynamic calls into Response macros.
-	 *
-	 * @param  string  $method
-	 * @param  array  $parameters
-	 * @return mixed
-	 *
-	 * @throws \BadMethodCallException
-	 */
-	public static function __callStatic($method, $parameters)
-	{
-		if (isset(static::$macros[$method]))
-		{
-			return call_user_func_array(static::$macros[$method], $parameters);
-		}
-
-		throw new \BadMethodCallException("Call to undefined method $method");
-	}
+        throw new \BadMethodCallException("Call to undefined method $method");
+    }
 
 }

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -2,6 +2,7 @@
 
 namespace Support\Facades;
 
+use Core\Template;
 use Core\View;
 use Http\JsonResponse;
 use Http\Response as HttpResponse;
@@ -99,6 +100,34 @@ class Response
         }
 
         return $response;
+    }
+
+    /**
+     * Create a new Error Response instance.
+     *
+     * The Response Status code will be set using the specified code.
+     *
+     * The specified error should match a View in your Views/Error directory.
+     *
+     * <code>
+     *      // Create a 404 response.
+     *      return Response::error('404');
+     *
+     *      // Create a 404 response with data.
+     *      return Response::error('404', array('message' => 'Not Found'));
+     * </code>
+     *
+     * @param  int       $code
+     * @param  array     $data
+     * @return Response
+     */
+    public static function error($status, array $data = array(), $headers = array())
+    {
+        $view = Template::make('default')
+            ->shares('title', 'Error ' .$code)
+            ->nest('content', 'Error/' .$code, $data);
+
+        return static::make($view, $status, $headers);
     }
 
     /**

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -5,7 +5,9 @@ namespace Support\Facades;
 use Core\View;
 use Http\JsonResponse;
 use Http\Response as HttpResponse;
+
 use Support\Contracts\ArrayableInterface;
+
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 

--- a/system/Support/Facades/Validator.php
+++ b/system/Support/Facades/Validator.php
@@ -79,9 +79,9 @@ class Validator
      */
     public static function __callStatic($method, $params)
     {
-        $factory = static::getFactory();
+        $instance = static::getFactory();
 
         // Call the non-static method from the Dispatcher instance.
-        return call_user_func_array(array($factory, $method), $params);
+        return call_user_func_array(array($instance, $method), $params);
     }
 }

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -12,6 +12,7 @@ use Core\Language;
 use Core\Modules;
 use Core\Router;
 use Helpers\Session;
+use Patchwork\Utf8\Bootup as PatchworkBootup;
 
 
 /** Turn on the custom error handling. */
@@ -44,6 +45,9 @@ Session::init();
 
 /** Initialize the Language. */
 Language::init();
+
+/** Initialize the Patchwork Utf8. */
+PatchworkBootup::initAll();
 
 /** Initialize the active Modules */
 Modules::init();

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -12,7 +12,7 @@ use Core\Language;
 use Core\Modules;
 use Core\Router;
 use Helpers\Session;
-use Patchwork\Utf8\Bootup as PatchworkBootup;
+use Patchwork\Utf8\Bootup as Patchwork;
 
 
 /** Turn on the custom error handling. */
@@ -47,7 +47,7 @@ Session::init();
 Language::init();
 
 /** Initialize the Patchwork Utf8. */
-PatchworkBootup::initAll();
+Patchwork::initAll();
 
 /** Initialize the active Modules */
 Modules::init();


### PR DESCRIPTION
This pull request introduce a implementation of a simple but very powerful **Request API**, built in top of **Symfony HTTP Foundation**, and being similar with its counterpart **Laravel 4.x**, of what documentation apply, excluding the **Session** part, which is not (yet) completed / integrated with the Framework.

The objective is to create a fully functional support for HTTP Requests, even for complicated RESTful APIs, in the same time to simplify the input data handling on a daily base.

The usage could be very simple, as in following example, together with the **Validator**:

```php
use Validator;
use Input;

$rules = array(
    'username' => 'required|min:3|max:50|alpha_dash|unique:users',
    'password' => 'required|between:4,30',
    'email'    => 'required|email|max:100|unique:users',
);

// Collect all input data - i.e. $_POST and $_FILES, for a POST Request
$data = Input::all();

$validator = Validator::make($data, $rules);

if ($validator->passes()) {
    // Do something shiny, the input data is perfect.
} else {
    $errors = $validator->errors()->all();

    // Do something nasty, because the data is wrong.
}
```
A more simple example is:
```php
if (Input::has('username')) {
    $username = Input::get('username');

    // Do something shiny with this variable
}
```

But this new Request API is not only about that, for example, you can simply detect a AJAX Request, just like in the actual API:

```php
if(Request::ajax()) {
    // You are set, this is a AJAX Request
}
```
OR see if you have a POST Request:
```php
if(Request::method() == 'POST') {
    // You are set, this is a POST Request
}
```

Finally, there apply almost the entire Illuminate\Request v.4.x API, for example, you can do:
```
if (Request::isJson()) {
    // Get the variable 'result' from the JSON encoded Content
    $result = Request::json('$result');
}
```
OR
```php
// Get the current path info for the request.
$path = Request::path();
```

To note that, while present, it is not possible yet to use the **Session (and Flash)** methods from **Http\Request**, because the **Session\Store** is not full integrated on Nova.

Also, it is not possible yet to use the **Response API**, which while completed, is not yet intergrated full, then it is safely to ignore it for moment.
