### PR TITLE
Introduce the (uploaded) Files validation on Validation\Validator, on top of the new Request API

### DIFF
--- a/system/Validation/Validator.php
+++ b/system/Validation/Validator.php
@@ -327,7 +327,7 @@ class Validator
     protected function passesOptionalCheck($attribute)
     {
         if ($this->hasRule($attribute, array('Sometimes'))) {
-            return (array_key_exists($attribute, $this->data) ||  || array_key_exists($attribute, $this->files));
+            return (array_key_exists($attribute, $this->data) || array_key_exists($attribute, $this->files));
         } else {
             return true;
         }
@@ -776,7 +776,7 @@ class Validator
             return count($value);
         } else if ($value instanceof File) {
             return $value->getSize() / 1024;
-        }  else {
+        } else {
             return $this->getStringSize($value);
         }
     }

--- a/system/Validation/Validator.php
+++ b/system/Validation/Validator.php
@@ -775,7 +775,7 @@ class Validator
         } else if (is_array($value)) {
             return count($value);
         } else if ($value instanceof File) {
-            return $value->getSize() / 1024;
+            return ($value->getSize() / 1024);
         } else {
             return $this->getStringSize($value);
         }


### PR DESCRIPTION
No API changes there, just completing the (uploaded) files associated validation rules as presented into Illuminate\Validation 4.x

Example usage of the new supported Validation Rules:
```php
$rules = array(
  'file'=>'image|max:2048000',
);
```
To note that Files validation works only when is used the new **Request API**, then you could have:

```php
use Input;
use Validator;

$rules = array(
  'file'=>'image|max:2048000',
);

$data = Input::all();

$validator = Validator::make($data, $rules);

if($validator->passes()) {
    // Do some shiny things there; the uploaded file is valid.
} else {
    $errors = $validator->errors()->all();

    // Do nasty things there; the User uploaded a strange file...
}

```