### PR TITLE
Implementation of a Pagination Support on New Style APIs

### DIFF
--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -22,4 +22,7 @@ Config::set('session', array(
     'path'     => '/',
     'domain'   => null,
     'secure'   => false,
+
+    // Wheter or not will be used the Cookies encryption.
+    'encrypt'  => true
 ));

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -18,7 +18,7 @@ Config::set('session', array(
     'lottery'  => array(2, 100), // Option used by the Garbage Collector, to remove the stalled Session files.
 
     // Cookie configuration.
-    'name'     => PREFIX .'session',
+    'cookie'   => PREFIX .'session',
     'path'     => '/',
     'domain'   => null,
     'secure'   => false,

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -163,7 +163,7 @@ class Demo extends Controller
 
         $content = $paginator ->links();
 
-        foreach ($paginator->results() as $post) {
+        foreach ($paginator->getItems() as $post) {
             $content .= '<h3>' .$post->title .'</h3>';
 
             $content .= $post->content;

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -5,6 +5,7 @@ use Core\View;
 use Core\Controller;
 use Helpers\Password;
 use Helpers\Url;
+use Pagination\Paginator;
 
 use Event;
 use Validator;
@@ -14,6 +15,7 @@ use Session;
 
 use App\Models\ORM\User;
 
+use DB;
 
 /*
 *
@@ -148,5 +150,24 @@ class Demo extends Controller
 
             echo '<pre>' .var_export($errors, true) .'</pre>';
         }
+    }
+
+    public function paginate()
+    {
+        $paginator = DB::table('posts')->paginate(3);
+
+        $content = $paginator ->links();
+
+        foreach ($paginator->results() as $post) {
+            $content .= '<h3>' .$post->title .'</h3>';
+
+            $content .= $post->content;
+
+            $content .= '<br><br>';
+        }
+
+        return View::make('Default')
+            ->shares('title', __('Pagination Test'))
+            ->with('content', $content);
     }
 }

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -154,16 +154,16 @@ class Demo extends Controller
 
     public function paginate()
     {
-        $paginator = DB::table('posts')->paginate(3);
+        $paginate = DB::table('posts')->paginate(3);
 
-        $paginator->appends(array(
+        $paginate->appends(array(
             'testing'  => 1,
             'validate' => 7,
         ));
 
-        $content = $paginator ->links();
+        $content = $paginate->links();
 
-        foreach ($paginator->getItems() as $post) {
+        foreach ($paginate as $post) {
             $content .= '<h3>' .$post->title .'</h3>';
 
             $content .= $post->content;
@@ -172,7 +172,7 @@ class Demo extends Controller
         }
 
         return View::make('Default')
-            ->shares('title', __('Pagination Test'))
+            ->shares('title', __('Pagination'))
             ->with('content', $content);
     }
 }

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -156,6 +156,11 @@ class Demo extends Controller
     {
         $paginator = DB::table('posts')->paginate(3);
 
+        $paginator->appends(array(
+            'testing'  => 1,
+            'validate' => 7,
+        ));
+
         $content = $paginator ->links();
 
         foreach ($paginator->results() as $post) {

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -5,7 +5,6 @@ use Core\View;
 use Core\Controller;
 use Helpers\Password;
 use Helpers\Url;
-use Pagination\Paginator;
 
 use Event;
 use Validator;
@@ -154,7 +153,7 @@ class Demo extends Controller
 
     public function paginate()
     {
-        $paginate = DB::table('posts')->paginate(3);
+        $paginate = DB::table('posts')->paginate(2);
 
         $paginate->appends(array(
             'testing'  => 1,

--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -158,7 +158,7 @@ class Demo extends Controller
 
         $paginate->appends(array(
             'testing'  => 1,
-            'validate' => 7,
+            'example' => 'the_example_string',
         ));
 
         $content = $paginate->links();

--- a/app/Language/Cz/messages.php
+++ b/app/Language/Cz/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Da/Welcome.php
+++ b/app/Language/Da/Welcome.php
@@ -16,7 +16,7 @@ return [
         Indeholdet kan ændres i <code>/app/Views/Welcome/SubPage.php</code>
     ',
     // Buttons
-    'openSubPage' => 'Åben undersiden ',
+    'openSubPage' => 'Åben undersiden',
     'backHome' => 'Hjem',
 ];
 

--- a/app/Language/Da/messages.php
+++ b/app/Language/Da/messages.php
@@ -1,5 +1,5 @@
 <?php
 
 return array (
-  'Pagination' => '',
+  'Pagination' => 'Sideinddeling',
 );

--- a/app/Language/Da/messages.php
+++ b/app/Language/Da/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/De/messages.php
+++ b/app/Language/De/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/En/messages.php
+++ b/app/Language/En/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Es/messages.php
+++ b/app/Language/Es/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Fa/messages.php
+++ b/app/Language/Fa/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Fr/messages.php
+++ b/app/Language/Fr/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/It/messages.php
+++ b/app/Language/It/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Ja/messages.php
+++ b/app/Language/Ja/messages.php
@@ -1,5 +1,5 @@
 <?php
 
 return array (
-  'Pagination' => '',
+  'Pagination' => 'ページネーション',
 );

--- a/app/Language/Ja/messages.php
+++ b/app/Language/Ja/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Nl/messages.php
+++ b/app/Language/Nl/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Pl/messages.php
+++ b/app/Language/Pl/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Ro/messages.php
+++ b/app/Language/Ro/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Language/Ru/messages.php
+++ b/app/Language/Ru/messages.php
@@ -1,4 +1,5 @@
 <?php
 
 return array (
+  'Pagination' => '',
 );

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -22,6 +22,7 @@ Router::any('demo/database',        'App\Controllers\Demo@database');
 Router::any('demo/events',          'App\Controllers\Demo@events');
 Router::any('demo/session',         'App\Controllers\Demo@session');
 Router::any('demo/validate',        'App\Controllers\Demo@validate');
+Router::any('demo/paginate',        'App\Controllers\Demo@paginate');
 
 Router::any('demo/request(/(:any)(/(:any)(/(:all))))', 'App\Controllers\Demo@request');
 

--- a/app/Views/Default.php
+++ b/app/Views/Default.php
@@ -1,0 +1,5 @@
+<div class="page-header">
+    <h1><?= $title; ?></h1>
+</div>
+
+<?= $content; ?>

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1109,14 +1109,14 @@ class Builder
      * @param  array  $columns
      * @return \Pagination\Paginator
      */
-    public function paginate($perPage = 15, $columns = array('*'), $pageName = 'offset')
+    public function paginate($perPage = 15, $columns = array('*'))
     {
         // Ensure that the columns are properly specified.
         if (! is_array($columns)) $columns = array($columns);
 
         if (isset($this->groups)) {
             // A query which contains a GROUP BY; use the alternative paginate.
-            return $this->groupedPaginate($perPage, $columns, $pageName);
+            return $this->groupedPaginate($perPage, $columns);
         }
 
         // Move the orders, limit and offset properties to local variables.
@@ -1129,7 +1129,7 @@ class Builder
         $total = $this->count(reset($columns));
 
         // Get the current Page from Paginator.
-        $page = Paginator::page($total, $perPage, $pageName);
+        $page = Paginator::page($total, $perPage);
 
         // Restore the orders, limit and offset properties.
         list($this->orders, $this->limit, $this->offset) = array($orders, $limit, $offset);
@@ -1137,7 +1137,7 @@ class Builder
         // Retrieve the results for the current page.
         $results = $this->forPage($page, $perPage)->get($columns);
 
-        return Paginator::make($results, $total, $perPage, $pageName);
+        return Paginator::make($results, $total, $perPage);
     }
 
     /**
@@ -1147,7 +1147,7 @@ class Builder
      * @param  array  $columns
      * @return \Pagination\Paginator
      */
-    protected function groupedPaginate($perPage, $columns, $pageName)
+    protected function groupedPaginate($perPage, $columns)
     {
         // Retrieve all results.
         $results = $this->get($columns);
@@ -1155,12 +1155,12 @@ class Builder
         $total = count($results);
 
         // Get the current Page from Paginator.
-        $page = Paginator::page($total, $perPage, $pageName);
+        $page = Paginator::page($total, $perPage);
 
         // Slice the results for the current Page.
         $sliced = array_slice($results, ($page - 1) * $perPage, $perPage);
 
-        return Paginator::make($sliced, $total, $perPage, $pageName);
+        return Paginator::make($sliced, $total, $perPage);
     }
 
     /**

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1111,6 +1111,9 @@ class Builder
      */
     public function paginate($perPage = 15, $columns = array('*'), $pageName = 'offset')
     {
+        // Ensure that the columns are properly specified.
+        if (! is_array($columns)) $columns = array($columns);
+
         if (isset($this->groups)) {
             // A query which contains a GROUP BY; use the alternative paginate.
             return $this->groupedPaginate($perPage, $columns, $pageName);

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1109,7 +1109,7 @@ class Builder
      * @param  array  $columns
      * @return \Pagination\Paginator
      */
-    public function paginate($perPage = 15, $columns = array('*'))
+    public function paginate($perPage = 15, $columns = array('*'), $pageName = 'offset')
     {
         if (isset($this->groups)) {
             // A query which contains a GROUP BY; use the alternative paginate.
@@ -1126,7 +1126,7 @@ class Builder
         $total = $this->count(reset($columns));
 
         // Get the current Page from Paginator.
-        $page = Paginator::page($total, $perPage);
+        $page = Paginator::page($total, $perPage, $pageName);
 
         // Restore the orders, limit and offset properties.
         list($this->orders, $this->limit, $this->offset) = array($orders, $limit, $offset);
@@ -1134,7 +1134,7 @@ class Builder
         // Retrieve the results for the current page.
         $results = $this->forPage($page, $perPage)->get($columns);
 
-        return Paginator::make($results, $total, $perPage);
+        return Paginator::make($results, $total, $perPage, $pageName);
     }
 
     /**
@@ -1144,7 +1144,7 @@ class Builder
      * @param  array  $columns
      * @return \Pagination\Paginator
      */
-    protected function groupedPaginate($perPage, $columns)
+    protected function groupedPaginate($perPage, $columns, $pageName)
     {
         // Retrieve all results.
         $results = $this->get($columns);
@@ -1152,12 +1152,12 @@ class Builder
         $total = count($results);
 
         // Get the current Page from Paginator.
-        $page = Paginator::page($total, $perPage);
+        $page = Paginator::page($total, $perPage, $pageName);
 
         // Slice the results for the current Page.
         $sliced = array_slice($results, ($page - 1) * $perPage, $perPage);
 
-        return Paginator::make($sliced, $total, $perPage);
+        return Paginator::make($sliced, $total, $perPage, $pageName);
     }
 
     /**

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1113,7 +1113,7 @@ class Builder
     {
         if (isset($this->groups)) {
             // A query which contains a GROUP BY; use the alternative paginate.
-            return $this->groupedPaginate($perPage, $columns);
+            return $this->groupedPaginate($perPage, $columns, $pageName);
         }
 
         // Move the orders, limit and offset properties to local variables.

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1171,11 +1171,9 @@ class Builder
     {
         $total = $this->getPaginationCount();
 
-        // Once we have the total number of records to be paginated, we can grab the
-        // current page and the result array. Then we are ready to create a brand
-        // new Paginator instances for the results which will create the links.
         $page = Paginator::page($total, $perPage);
 
+        //
         $results = $this->forPage($page, $perPage)->get($columns);
 
         return Paginator::make($results, $total, $perPage);

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1136,18 +1136,6 @@ class Builder
     {
         $results = $this->get($columns);
 
-        return $this->buildRawPaginator($results, $perPage);
-    }
-
-    /**
-     * Build a paginator instance from a raw result array.
-     *
-     * @param  array  $results
-     * @param  int    $perPage
-     * @return \Illuminate\Pagination\Paginator
-     */
-    public function buildRawPaginator($results, $perPage)
-    {
         $total = count($results);
 
         // For queries which have a GROUP BY, we will actually retrieve the entire set

--- a/system/Helpers/Cookie.php
+++ b/system/Helpers/Cookie.php
@@ -8,6 +8,7 @@
 
 namespace Helpers;
 
+use Core\Config;
 use Encryption\DecryptException;
 use Support\Facades\Crypt;
 
@@ -42,9 +43,12 @@ class Cookie
      */
     public static function set($key, $value, $expiry = self::FOURYEARS, $path = '/', $domain = false)
     {
+        // Retrieve the Session configuration.
+        $config = Config::get('session');
+
         // Encrypt the value
-        if ($key != 'PHPSESSID') {
-            // Just to be safe; when the end-user wants to manipulate the PHPSESSID.
+        if (($key != 'PHPSESSID') && ($config['encrypt'] == true)) {
+            // // No PHPSESSID and end-user want the Cookie encryption.
             $value = Crypt::encrypt($value);
         }
 
@@ -77,8 +81,11 @@ class Cookie
 
         $cookie = $_COOKIE[$key];
 
-        if ($key == 'PHPSESSID') {
-            // Just to be safe; when the end-user wants to retrieve the PHPSESSID.
+        // Retrieve the Session configuration.
+        $config = Config::get('session');
+
+        if (($key == 'PHPSESSID') || ($config['encrypt'] == false)) {
+            // A PHPSESSID or when end-user want not Cookie encryption.
             return $cookie;
         }
 

--- a/system/Helpers/Url.php
+++ b/system/Helpers/Url.php
@@ -12,7 +12,7 @@ use Helpers\Session;
 use Helpers\Inflector;
 
 use Support\Facades\Redirect;
-use Support\Facades\Session as SessionManager;
+use Support\Facades\Session as SessionStore;
 
 
 /**
@@ -23,21 +23,20 @@ class Url
     /**
      * Redirect to a chosen url.
      *
-     * @param string $url      the url to redirect to
-     * @param bool   $fullPath if true use only url in redirect instead of using DIR
-     * @param int $code the server status code for the redirection
+     * @param string $url      the URL to redirect to
+     * @param bool   $fullPath if true use only url in redirect instead of preparing a local URL
+     * @param int $code the Server Status code for the redirection
      */
-    public static function redirect($url = null, $fullPath = false, $code = 200)
+    public static function redirect($url = null, $fullPath = false, $code = 302)
     {
-        // Create a Response instance.
-        if ($fullPath === false) {
-            $response = Redirect::to(SITEURL .$url, $code);
-        } else {
-            $response = Redirect::away($url, $code);
-        }
+        // Process the URL according with fullPath.
+        $url = ($fullPath === false) ? $url : site_url($url);
 
-        // Finish the Session and send the Response.
-        SessionManager::finish($response);
+        // Create a Response instance.
+        $response = Redirect::to($url, $code);
+
+        // Finish the Session (and send the Response).
+        SessionStore::finish($response);
 
         // Quit the Nova.
         exit();

--- a/system/Http/JsonResponse.php
+++ b/system/Http/JsonResponse.php
@@ -46,9 +46,11 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
      */
     public function setData($data = array())
     {
-        $this->data = ($data instanceof JsonableInterface)
-                                   ? $data->toJson($this->jsonOptions)
-                                   : json_encode($data, $this->jsonOptions);
+        if ($data instanceof JsonableInterface) {
+            $this->data = $data->toJson($this->jsonOptions)
+        } else {
+            $this->data = json_encode($data, $this->jsonOptions);
+        }
 
         return $this->update();
     }

--- a/system/Pagination/Factory.php
+++ b/system/Pagination/Factory.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Factory - Implements the Pagination Factory.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
 
 namespace Pagination;
 

--- a/system/Pagination/Factory.php
+++ b/system/Pagination/Factory.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Pagination;
+
+use Http\Request;
+use Pagination\Paginator;
+
+
+class Factory
+{
+    /**
+     * The Request instance.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
+
+    /**
+     * The number of the current page.
+     *
+     * @var int
+     */
+    protected $currentPage;
+
+    /**
+     * The base URL in use by the paginator.
+     *
+     * @var string
+     */
+    protected $baseUrl;
+
+    /**
+     * The input parameter used for the current page.
+     *
+     * @var string
+     */
+    protected $pageName;
+
+    /**
+     * Create a new pagination factory.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  string  $pageName
+     * @return void
+     */
+    public function __construct(Request $request, $pageName = 'offset')
+    {
+        $this->request  = $request;
+        $this->pageName = $pageName;
+    }
+
+    /**
+     * Get a new Paginator instance.
+     *
+     * @param  array  $items
+     * @param  int    $total
+     * @param  int|null  $perPage
+     * @return \Pagination\Paginator
+     */
+    public function make(array $items, $total, $perPage = null)
+    {
+        $paginator = new Paginator($this, $items, $total, $perPage);
+
+        return $paginator->setupPaginationContext();
+    }
+
+    /**
+     * Get the number of the current page.
+     *
+     * @return int
+     */
+    public function getCurrentPage()
+    {
+        $page = (int) $this->currentPage ?: $this->request->input($this->pageName, 1);
+
+        if (($page < 1) || (filter_var($page, FILTER_VALIDATE_INT) === false)) {
+            return 1;
+        }
+
+        return $page;
+    }
+
+    /**
+     * Set the number of the current page.
+     *
+     * @param  int  $number
+     * @return void
+     */
+    public function setCurrentPage($number)
+    {
+        $this->currentPage = $number;
+    }
+
+    /**
+     * Get the root URL for the request.
+     *
+     * @return string
+     */
+    public function getCurrentUrl()
+    {
+        return $this->baseUrl ?: $this->request->url();
+    }
+
+    /**
+     * Set the base URL in use by the paginator.
+     *
+     * @param  string  $baseUrl
+     * @return void
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * Set the input page parameter name used by the paginator.
+     *
+     * @param  string  $pageName
+     * @return void
+     */
+    public function setPageName($pageName)
+    {
+        $this->pageName = $pageName;
+    }
+
+    /**
+     * Get the input page parameter name used by the paginator.
+     *
+     * @return string
+     */
+    public function getPageName()
+    {
+        return $this->pageName;
+    }
+
+    /**
+     * Get the active request instance.
+     *
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Set the active request instance.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @return void
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+    }
+
+}

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -163,11 +163,11 @@ class Paginator
      * explore some of the other public methods available on the instance.
      *
      * <code>
-     *        // Render the pagination links
-     *        echo $paginator->links();
+     *      // Render the Pagination links
+     *      echo $paginator->links();
      *
-     *        // Render the pagination links using a given window size
-     *        echo $paginator->links(5);
+     *      // Render the Pagination links using a given window size
+     *      echo $paginator->links(5);
      * </code>
      *
      * @param  int     $adjacent
@@ -177,13 +177,6 @@ class Paginator
     {
         if ($this->lastPage <= 1) return '';
 
-        // The hard-coded seven is to account for all of the constant elements in a
-        // sliding range, such as the current page, the two ellipses, and the two
-        // beginning and ending pages.
-        //
-        // If there are not enough pages to make the creation of a slider possible
-        // based on the adjacent pages, we will simply display all of the pages.
-        // Otherwise, we will create a "truncating" sliding window.
         if (($this->lastPage < 7) + ($adjacent * 2)) {
             $links = $this->range(1, $this->lastPage);
         } else {
@@ -202,11 +195,11 @@ class Paginator
      * render the "first" and "last" pagination links, but only the pages.
      *
      * <code>
-     *        // Render the pagination slider
-     *        echo $paginator->slider();
+     *      // Render the pagination slider
+     *      echo $paginator->slider();
      *
-     *        // Render the pagination slider using a given window size
-     *        echo $paginator->slider(5);
+     *      // Render the pagination slider using a given window size
+     *      echo $paginator->slider(5);
      * </code>
      *
      * @param  int     $adjacent
@@ -216,14 +209,6 @@ class Paginator
     {
         $window = $adjacent * 2;
 
-        // If the current page is so close to the beginning that we do not have
-        // room to create a full sliding window, we will only show the first
-        // several pages, followed by the ending of the slider.
-        //
-        // Likewise, if the page is very close to the end, we will create the
-        // beginning of the slider, but just show the last several pages at
-        // the end of the slider. Otherwise, we'll build the range.
-        //
         // Example: 1 [2] 3 4 5 6 ... 23 24
         if ($this->currentPage <= $window) {
             return $this->range(1, $window + 2).' '.$this->ending();
@@ -335,11 +320,11 @@ class Paginator
      * Generate the "previous" HTML link.
      *
      * <code>
-     *        // Create the "previous" pagination element
-     *        echo $paginator->previous();
+     *      // Create the "previous" pagination element
+     *      echo $paginator->previous();
      *
-     *        // Create the "previous" pagination element with custom text
-     *        echo $paginator->previous('Go Back');
+     *      // Create the "previous" pagination element with custom text
+     *      echo $paginator->previous('Go Back');
      * </code>
      *
      * @param  string  $text
@@ -364,11 +349,11 @@ class Paginator
      * Generate the "next" HTML link.
      *
      * <code>
-     *        // Create the "next" pagination element
-     *        echo $paginator->next();
+     *      // Create the "next" pagination element
+     *      echo $paginator->next();
      *
-     *        // Create the "next" pagination element with custom text
-     *        echo $paginator->next('Skip Forwards');
+     *      // Create the "next" pagination element with custom text
+     *      echo $paginator->next('Skip Forwards');
      * </code>
      *
      * @param  string  $text

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -1,0 +1,515 @@
+<?php
+
+namespace Pagination;
+
+use Input;
+use Request;
+
+
+class Paginator
+{
+    /**
+     * The results for the current page.
+     *
+     * @var array
+     */
+    protected $results;
+
+    /**
+     * The current page.
+     *
+     * @var int
+     */
+    protected $currentPage;
+
+    /**
+     * The last page available for the result set.
+     *
+     * @var int
+     */
+    protected $lastPage;
+
+    /**
+     * The total number of results.
+     *
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * The number of items per page.
+     *
+     * @var int
+     */
+    protected $perPage;
+
+    /**
+     * The base URL in use by the paginator.
+     *
+     * @var string
+     */
+    protected $baseUrl;
+
+    /**
+     * The input parameter used for the current page.
+     *
+     * @var string
+     */
+    protected $pageName;
+
+    /**
+     * The values that should be appended to the end of the link query strings.
+     *
+     * @var array
+     */
+    protected $appends;
+
+    /**
+     * The compiled appendage that will be appended to the links.
+     *
+     * This consists of a sprintf format with a page place-holder and query string.
+     *
+     * @var string
+     */
+    protected $appendage;
+
+    /**
+     * The "dots" element used in the pagination slider.
+     *
+     * @var string
+     */
+    protected $dots = '<li class="dots disabled"><a href="#">...</a></li>';
+
+    /**
+     * Create a new Paginator instance.
+     *
+     * @param  array  $results
+     * @param  int    $page
+     * @param  int    $total
+     * @param  int    $perPage
+     * @param  int    $last
+     * @return void
+     */
+    protected function __construct($results, $page, $total, $perPage, $lastPage, $pageName)
+    {
+        $this->currentPage = $page;
+        $this->lastPage    = $lastPage;
+        $this->total       = $total;
+        $this->results     = $results;
+        $this->perPage     = $perPage;
+        $this->pageName    = $pageName;
+    }
+
+    /**
+     * Create a new Paginator instance.
+     *
+     * @param  array      $results
+     * @param  int        $total
+     * @param  int        $perPage
+     * @return Paginator
+     */
+    public static function make($results, $total, $perPage, $pageName = 'page')
+    {
+        $page = static::page($total, $perPage, $pageName);
+
+        $lastPage = ceil($total / $perPage);
+
+        return new static($results, $page, $total, $perPage, $lastPage, $pageName);
+    }
+
+    /**
+     * Get the current page from the request query string.
+     *
+     * @param  int  $total
+     * @param  int  $perPage
+     * @return int
+     */
+    public static function page($total, $perPage, $pageName = 'page')
+    {
+        $page = Input::get($pageName, 1);
+
+        // Validate and adjust page if it is less than one or greater than the last page.
+        if (is_numeric($page) && ($page > ($last = ceil($total / $perPage)))) {
+            return ($last > 0) ? $last : 1;
+        }
+
+        return static::isValidPageNumber($page) ? $page : 1;
+    }
+
+    /**
+     * Determine if a given page number is a valid page.
+     *
+     * A valid page must be greater than or equal to one and a valid integer.
+     *
+     * @param  int   $page
+     * @return bool
+     */
+    protected static function isValidPageNumber($page)
+    {
+        return (($page >= 1) && (filter_var($page, FILTER_VALIDATE_INT) !== false);
+    }
+
+    /**
+     * Create the HTML pagination links.
+     *
+     * Typically, an intelligent, "sliding" window of links will be rendered based
+     * on the total number of pages, the current page, and the number of adjacent
+     * pages that should rendered. This creates a beautiful paginator similar to
+     * that of Google's.
+     *
+     * Example: 1 2 ... 23 24 25 [26] 27 28 29 ... 51 52
+     *
+     * If you wish to render only certain elements of the pagination control,
+     * explore some of the other public methods available on the instance.
+     *
+     * <code>
+     *        // Render the pagination links
+     *        echo $paginator->links();
+     *
+     *        // Render the pagination links using a given window size
+     *        echo $paginator->links(5);
+     * </code>
+     *
+     * @param  int     $adjacent
+     * @return string
+     */
+    public function links($adjacent = 3)
+    {
+        if ($this->lastPage <= 1) return '';
+
+        // The hard-coded seven is to account for all of the constant elements in a
+        // sliding range, such as the current page, the two ellipses, and the two
+        // beginning and ending pages.
+        //
+        // If there are not enough pages to make the creation of a slider possible
+        // based on the adjacent pages, we will simply display all of the pages.
+        // Otherwise, we will create a "truncating" sliding window.
+        if (($this->lastPage < 7) + ($adjacent * 2)) {
+            $links = $this->range(1, $this->lastPage);
+        } else {
+            $links = $this->slider($adjacent);
+        }
+
+        $content = '<ul>' .$this->previous() . $links .$this->next() .'</ul>';
+
+        return '<div class="pagination">' .$content .'</div>';
+    }
+
+    /**
+     * Build sliding list of HTML numeric page links.
+     *
+     * This method is very similar to the "links" method, only it does not
+     * render the "first" and "last" pagination links, but only the pages.
+     *
+     * <code>
+     *        // Render the pagination slider
+     *        echo $paginator->slider();
+     *
+     *        // Render the pagination slider using a given window size
+     *        echo $paginator->slider(5);
+     * </code>
+     *
+     * @param  int     $adjacent
+     * @return string
+     */
+    public function slider($adjacent = 3)
+    {
+        $window = $adjacent * 2;
+
+        // If the current page is so close to the beginning that we do not have
+        // room to create a full sliding window, we will only show the first
+        // several pages, followed by the ending of the slider.
+        //
+        // Likewise, if the page is very close to the end, we will create the
+        // beginning of the slider, but just show the last several pages at
+        // the end of the slider. Otherwise, we'll build the range.
+        //
+        // Example: 1 [2] 3 4 5 6 ... 23 24
+        if ($this->currentPage <= $window) {
+            return $this->range(1, $window + 2).' '.$this->ending();
+        }
+        // Example: 1 2 ... 32 33 34 35 [36] 37
+        else if ($this->currentPage >= $this->lastPage - $window) {
+            return $this->beginning() .' ' .$this->range($this->lastPage - $window - 2, $this->lastPage);
+        }
+
+        // Example: 1 2 ... 23 24 25 [26] 27 28 29 ... 51 52
+        $content = $this->range($this->currentPage - $adjacent, $this->currentPage + $adjacent);
+
+        return $this->beginning() .' ' .$content .' ' .$this->ending();
+    }
+
+    /**
+     * Get the Items being paginated.
+     *
+     * @return array
+     */
+    public function results()
+    {
+        return $this->results;
+    }
+
+    /**
+     * Get the number of the current page.
+     *
+     * @return int
+     */
+    public function getCurrentPage()
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * Get the last page that should be available.
+     *
+     * @return int
+     */
+    public function getLastPage()
+    {
+        return $this->lastPage;
+    }
+
+    /**
+     * Get the total number of Items in the collection.
+     *
+     * @return int
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * Get the number of Items to be displayed per page.
+     *
+     * @return int
+     */
+    public function getPerPage()
+    {
+        return $this->perPage;
+    }
+
+    /**
+     * Get the root URL for the request.
+     *
+     * @return string
+     */
+    public function getCurrentUrl()
+    {
+        return $this->baseUrl ?: Request::url();
+    }
+
+    /**
+     * Set the base URL in use by the paginator.
+     *
+     * @param  string  $baseUrl
+     * @return void
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * Set the input page parameter name used by the paginator.
+     *
+     * @param  string  $pageName
+     * @return void
+     */
+    public function setPageName($pageName)
+    {
+        $this->pageName = $pageName;
+    }
+
+    /**
+     * Get the input page parameter name used by the paginator.
+     *
+     * @return string
+     */
+    public function getPageName()
+    {
+        return $this->pageName;
+    }
+
+    /**
+     * Generate the "previous" HTML link.
+     *
+     * <code>
+     *        // Create the "previous" pagination element
+     *        echo $paginator->previous();
+     *
+     *        // Create the "previous" pagination element with custom text
+     *        echo $paginator->previous('Go Back');
+     * </code>
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function previous($text = null)
+    {
+        $text = $text ?: '&laquo;';
+
+        $callback = function($page, $lastPage) { return ($page <= 1); };
+
+        return $this->element(
+            __FUNCTION__,
+            $this->currentPage - 1,
+            __d('system', 'Previous page'),
+            $text,
+            $callback
+        );
+    }
+
+    /**
+     * Generate the "next" HTML link.
+     *
+     * <code>
+     *        // Create the "next" pagination element
+     *        echo $paginator->next();
+     *
+     *        // Create the "next" pagination element with custom text
+     *        echo $paginator->next('Skip Forwards');
+     * </code>
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function next($text = null)
+    {
+        $text = $text ?: '&raquo;';
+
+        $callback = function($page, $lastPage) { return ($page >= $lastPage); };
+
+        return $this->element(
+            __FUNCTION__,
+            $this->currentPage + 1,
+            __d('system', 'Next page'),
+            $text,
+            $callback
+        );
+    }
+
+    /**
+     * Create a chronological pagination element, such as a "previous" or "next" link.
+     *
+     * @param  string   $element
+     * @param  int      $page
+     * @param  string   $text
+     * @param  Closure  $callback
+     * @return string
+     */
+    protected function element($element, $page, $title, $text, $callback)
+    {
+        $class = "{$element}_page";
+
+        // Each consumer of this method provides a "disabled" Closure which can
+        // be used to determine if the element should be a span element or an
+        // actual link. For example, if the current page is the first page,
+        // the "first" element should be a span instead of a link.
+        if (call_user_func($callback, $this->currentPage, $this->lastPage)) {
+            return '<li class="' .$class .' disabled" title="' .$title .'"><a href="#">' .$text.'</a></li>';
+        } else {
+            return $this->link($page, $title, $text, $class);
+        }
+    }
+
+    /**
+     * Build the first two page links for a sliding page range.
+     *
+     * @return string
+     */
+    protected function beginning()
+    {
+        return $this->range(1, 2) .' ' .$this->dots;
+    }
+
+    /**
+     * Build the last two page links for a sliding page range.
+     *
+     * @return string
+     */
+    protected function ending()
+    {
+        return $this->dots .' ' .$this->range($this->lastPage - 1, $this->lastPage);
+    }
+
+    /**
+     * Build a range of numeric pagination links.
+     *
+     * For the current page, an HTML span element will be generated instead of a link.
+     *
+     * @param  int     $start
+     * @param  int     $end
+     * @return string
+     */
+    protected function range($start, $end)
+    {
+        $pages = array();
+
+        // To generate the range of page links, we will iterate through each page
+        // and, if the current page matches the page, we will generate a span,
+        // otherwise we will generate a link for the page. The span elements
+        // will be assigned the "current" CSS class for convenient styling.
+        for ($page = $start; $page <= $end; $page++) {
+            if ($this->currentPage == $page) {
+                $pages[] = '<li class="active" title="' .__d('system', 'Current page') .'"><a href="#">' .$page .'</a></li>';
+            } else {
+                $pages[] = $this->link($page, null, $page, null);
+            }
+        }
+
+        return implode(' ', $pages);
+    }
+
+    /**
+     * Create a HTML page link.
+     *
+     * @param  int     $page
+     * @param  string  $text
+     * @param  string  $class
+     * @return string
+     */
+    protected function link($page, $title, $text, $class)
+    {
+        $query = '?page='.$page .$this->appendage($this->appends);
+
+        $class = $class ? 'class="' .$class .'"' ? '';
+        $title = $title ? 'title="' .$title .'"' : '';
+
+        return '<li ' .$class .'><a href="' .Request::url() .$query .'" ' .$title .'>' .$text .'</a></li>';
+    }
+
+    /**
+     * Create the "appendage" to be attached to every pagination link.
+     *
+     * @param  array   $appends
+     * @return string
+     */
+    protected function appendage($appends)
+    {
+         // The developer may assign an array of values that will be converted to a
+         // query string and attached to every pagination link. This allows simple
+         // implementation of sorting or other things the developer may need.
+        if ( ! is_null($this->appendage)) return $this->appendage;
+
+        if (count($appends) <= 0) {
+            return $this->appendage = '';
+        }
+
+        return $this->appendage = '&' .http_build_query($appends);
+    }
+
+    /**
+     * Set the items that should be appended to the link query strings.
+     *
+     * @param  array      $values
+     * @return Paginator
+     */
+    public function appends($values)
+    {
+        $this->appends = $values;
+
+        return $this;
+    }
+
+}

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -197,7 +197,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     {
         $presenter = $this->getPresenter();
 
-        return $presenter->links($adjacent);
+        return $presenter->render();
     }
 
     /**

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -190,10 +190,9 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     /**
      * Create the HTML pagination links.
      *
-     * @param  int  $adjacent
      * @return string
      */
-    public function links($adjacent = 3)
+    public function links()
     {
         $presenter = $this->getPresenter();
 

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -31,6 +31,21 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
      */
     protected $items;
 
+
+    /**
+     * The total number of results.
+     *
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * The number of items per page.
+     *
+     * @var int
+     */
+    protected $perPage;
+
     /**
      * Get the current page for the request.
      *
@@ -46,18 +61,18 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     protected $lastPage;
 
     /**
-     * The total number of results.
+     * The number of the first item in this range.
      *
      * @var int
      */
-    protected $total;
+    protected $from;
 
     /**
-     * The number of items per page.
+     * The number of the last item in this range.
      *
      * @var int
      */
-    protected $perPage;
+    protected $to;
 
     /**
      * The base URL in use by the paginator.
@@ -100,12 +115,15 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
      */
     protected function __construct($items, $page, $total, $perPage, $lastPage, $pageName)
     {
-        $this->currentPage = $page;
-        $this->lastPage    = $lastPage;
-        $this->total       = $total;
         $this->items       = $items;
+        $this->currentPage = $page;
+        $this->total       = $total;
         $this->perPage     = $perPage;
+        $this->lastPage    = $lastPage;
         $this->pageName    = $pageName;
+
+        // Calculate the Item ranges.
+        $this->calculateItemRanges();
     }
 
     /**
@@ -155,6 +173,18 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     protected static function isValidPageNumber($page)
     {
         return (($page >= 1) && (filter_var($page, FILTER_VALIDATE_INT) !== false));
+    }
+
+    /**
+     * Calculate the first and last item number for this instance.
+     *
+     * @return void
+     */
+    protected function calculateItemRanges()
+    {
+        $this->from = $this->total ? ($this->currentPage - 1) * $this->perPage + 1 : 0;
+
+        $this->to = min($this->total, $this->currentPage * $this->perPage);
     }
 
     /**
@@ -294,6 +324,26 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     public function getLastPage()
     {
         return $this->lastPage;
+    }
+
+    /**
+     * Get the number of the first item on the paginator.
+     *
+     * @return int
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * Get the number of the last item on the paginator.
+     *
+     * @return int
+     */
+    public function getTo()
+    {
+        return $this->to;
     }
 
     /**
@@ -457,11 +507,13 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     public function toArray()
     {
         return array(
-            'total' => $this->total,
-            'per_page' => $this->perPage,
+            'total'        => $this->total,
+            'per_page'     => $this->perPage,
             'current_page' => $this->currentPage,
-            'last_page' => $this->lastPage,
-            'data' => $this->getCollection()->toArray(),
+            'last_page'    => $this->lastPage,
+            'from'         => $this->from,
+            'to'           => $this->to,
+            'data'         => $this->getCollection()->toArray(),
         );
     }
 

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -253,6 +253,17 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     }
 
     /**
+     * Set the base URL in use by the paginator.
+     *
+     * @param  string  $baseUrl
+     * @return void
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+    
+    /**
      * Get the root URL for the request.
      *
      * @return string
@@ -352,17 +363,6 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     public function getTotal()
     {
         return $this->total;
-    }
-
-    /**
-     * Set the base URL in use by the paginator.
-     *
-     * @param  string  $baseUrl
-     * @return void
-     */
-    public function setBaseUrl($baseUrl)
-    {
-        $this->baseUrl = $baseUrl;
     }
 
     /**

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -108,7 +108,7 @@ class Paginator
      * @param  int        $perPage
      * @return Paginator
      */
-    public static function make($results, $total, $perPage, $pageName = 'page')
+    public static function make($results, $total, $perPage, $pageName = 'offset')
     {
         $page = static::page($total, $perPage, $pageName);
 
@@ -124,7 +124,7 @@ class Paginator
      * @param  int  $perPage
      * @return int
      */
-    public static function page($total, $perPage, $pageName = 'page')
+    public static function page($total, $perPage, $pageName = 'offset')
     {
         $page = Input::get($pageName, 1);
 
@@ -146,7 +146,7 @@ class Paginator
      */
     protected static function isValidPageNumber($page)
     {
-        return (($page >= 1) && (filter_var($page, FILTER_VALIDATE_INT) !== false);
+        return (($page >= 1) && (filter_var($page, FILTER_VALIDATE_INT) !== false));
     }
 
     /**
@@ -190,9 +190,9 @@ class Paginator
             $links = $this->slider($adjacent);
         }
 
-        $content = '<ul>' .$this->previous() . $links .$this->next() .'</ul>';
+        $content = '<ul class="pagination">' .$this->previous() . $links .$this->next() .'</ul>';
 
-        return '<div class="pagination">' .$content .'</div>';
+        return '<nav>' .$content .'</nav>';
     }
 
     /**
@@ -471,12 +471,14 @@ class Paginator
      */
     protected function link($page, $title, $text, $class)
     {
-        $query = '?page='.$page .$this->appendage($this->appends);
+        $baseUrl = $this->baseUrl ?: $this->getCurrentUrl();
 
-        $class = $class ? 'class="' .$class .'"' ? '';
+        $query = '?' .$this->pageName .'=' .$page .$this->appendage($this->appends);
+
+        $class = $class ? 'class="' .$class .'"' : '';
         $title = $title ? 'title="' .$title .'"' : '';
 
-        return '<li ' .$class .'><a href="' .Request::url() .$query .'" ' .$title .'>' .$text .'</a></li>';
+        return '<li ' .$class .'><a href="' .$baseUrl .$query .'" ' .$title .'>' .$text .'</a></li>';
     }
 
     /**

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -262,7 +262,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     {
         $this->baseUrl = $baseUrl;
     }
-    
+
     /**
      * Get the root URL for the request.
      *
@@ -327,7 +327,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     /**
      * Get a collection instance containing the items.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function getCollection()
     {

--- a/system/Pagination/Paginator.php
+++ b/system/Pagination/Paginator.php
@@ -160,25 +160,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
     /**
      * Create the HTML pagination links.
      *
-     * Typically, an intelligent, "sliding" window of links will be rendered based
-     * on the total number of pages, the current page, and the number of adjacent
-     * pages that should rendered. This creates a beautiful paginator similar to
-     * that of Google's.
-     *
-     * Example: 1 2 ... 23 24 25 [26] 27 28 29 ... 51 52
-     *
-     * If you wish to render only certain elements of the pagination control,
-     * explore some of the other public methods available on the instance.
-     *
-     * <code>
-     *      // Render the Pagination links
-     *      echo $paginator->links();
-     *
-     *      // Render the Pagination links using a given window size
-     *      echo $paginator->links(5);
-     * </code>
-     *
-     * @param  int     $adjacent
+     * @param  int  $adjacent
      * @return string
      */
     public function links($adjacent = 3)

--- a/system/Pagination/Presenter.php
+++ b/system/Pagination/Presenter.php
@@ -41,7 +41,7 @@ class Presenter
      */
     protected $dots = '<li class="dots disabled"><a href="#">...</a></li>';
 
-    
+
     /**
      * Create a new Presenter instance.
      *
@@ -97,7 +97,7 @@ class Presenter
     /**
      * Get HTML wrapper for the entire paginator.
      *
-     * @param  string  $items
+     * @param  string  $content
      * @return string
      */
     public function getPaginationWrapper($content)

--- a/system/Pagination/Presenter.php
+++ b/system/Pagination/Presenter.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Presenter - Implements a Pagination Presenter using Bootstrap 3.x.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Pagination;
+
+use Pagination\Paginator;
+
+
+class Presenter
+{
+    /**
+     * The Paginator instance.
+     *
+     * @var \Pagination\Paginator
+     */
+    protected $paginator;
+
+    /**
+     * Get the current page for the request.
+     *
+     * @var int
+     */
+    protected $currentPage;
+
+    /**
+     * Get the last available page number.
+     *
+     * @return int
+     */
+    protected $lastPage;
+
+    /**
+     * The "dots" element used in the pagination slider.
+     *
+     * @var string
+     */
+    protected $dots = '<li class="dots disabled"><a href="#">...</a></li>';
+
+    
+    /**
+     * Create a new Presenter instance.
+     *
+     * @param  \Pagination\Paginator  $paginator
+     * @return void
+     */
+    public function __construct(Paginator $paginator)
+    {
+        $this->paginator = $paginator;
+
+        $this->currentPage = $paginator->getCurrentPage();
+
+        $this->lastPage = $paginator->getLastPage();
+    }
+
+    /**
+     * Get HTML wrapper for a page link.
+     *
+     * @param  string  $url
+     * @param  int  $page
+     * @param  string  $rel
+     * @return string
+     */
+    public function getPageLinkWrapper($url, $page, $rel = null)
+    {
+        $rel = is_null($rel) ? '' : ' class="'.$rel.'"';
+
+        return '<li><a href="'.$url.'"'.$rel.'>'.$page.'</a></li>';
+    }
+
+    /**
+     * Get HTML wrapper for disabled text.
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function getDisabledTextWrapper($text)
+    {
+        return '<li class="disabled"><span>'.$text.'</span></li>';
+    }
+
+    /**
+     * Get HTML wrapper for active text.
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function getActivePageWrapper($text)
+    {
+        return '<li class="active"><span>'.$text.'</span></li>';
+    }
+
+    /**
+     * Get HTML wrapper for the entire paginator.
+     *
+     * @param  string  $items
+     * @return string
+     */
+    public function getPaginationWrapper($content)
+    {
+        return '<nav><ul class="pagination">' .$content .'</ul></nav>';
+    }
+
+    /**
+     * Create the HTML pagination links.
+     *
+     * Typically, an intelligent, "sliding" window of links will be rendered based
+     * on the total number of pages, the current page, and the number of adjacent
+     * pages that should rendered. This creates a beautiful paginator similar to
+     * that of Google's.
+     *
+     * Example: 1 2 ... 23 24 25 [26] 27 28 29 ... 51 52
+     *
+     * If you wish to render only certain elements of the pagination control,
+     * explore some of the other public methods available on the instance.
+     *
+     * <code>
+     *      // Render the Pagination links
+     *      echo $paginator->links();
+     *
+     *      // Render the Pagination links using a given window size
+     *      echo $paginator->links(5);
+     * </code>
+     *
+     * @param  int     $adjacent
+     * @return string
+     */
+    public function links($adjacent = 3)
+    {
+        if ($this->lastPage <= 1) return '';
+
+        if (($this->lastPage < 7) + ($adjacent * 2)) {
+            $links = $this->range(1, $this->lastPage);
+        } else {
+            $links = $this->slider($adjacent);
+        }
+
+        $content = $this->previous() . $links .$this->next();
+
+        return $this->getPaginationWrapper($content);
+    }
+
+    /**
+     * Build sliding list of HTML numeric page links.
+     *
+     * This method is very similar to the "links" method, only it does not
+     * render the "first" and "last" pagination links, but only the pages.
+     *
+     * <code>
+     *      // Render the pagination slider
+     *      echo $paginator->slider();
+     *
+     *      // Render the pagination slider using a given window size
+     *      echo $paginator->slider(5);
+     * </code>
+     *
+     * @param  int     $adjacent
+     * @return string
+     */
+    public function slider($adjacent = 3)
+    {
+        $window = $adjacent * 2;
+
+        // Example: 1 [2] 3 4 5 6 ... 23 24
+        if ($this->currentPage <= $window) {
+            return $this->range(1, $window + 2).' '.$this->ending();
+        }
+        // Example: 1 2 ... 32 33 34 35 [36] 37
+        else if ($this->currentPage >= $this->lastPage - $window) {
+            return $this->beginning() .' ' .$this->range($this->lastPage - $window - 2, $this->lastPage);
+        }
+
+        // Example: 1 2 ... 23 24 25 [26] 27 28 29 ... 51 52
+        $content = $this->range($this->currentPage - $adjacent, $this->currentPage + $adjacent);
+
+        return $this->beginning() .' ' .$content .' ' .$this->ending();
+    }
+
+    /**
+     * Generate the "previous" HTML link.
+     *
+     * <code>
+     *      // Create the "previous" pagination element
+     *      echo $paginator->previous();
+     *
+     *      // Create the "previous" pagination element with custom text
+     *      echo $paginator->previous('Go Back');
+     * </code>
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function previous($text = null)
+    {
+        $text = $text ?: '&laquo;';
+
+        $callback = function($page, $lastPage) { return ($page <= 1); };
+
+        return $this->element(
+            __FUNCTION__,
+            $this->currentPage - 1,
+            $text,
+            $callback
+        );
+    }
+
+    /**
+     * Generate the "next" HTML link.
+     *
+     * <code>
+     *      // Create the "next" pagination element
+     *      echo $paginator->next();
+     *
+     *      // Create the "next" pagination element with custom text
+     *      echo $paginator->next('Skip Forwards');
+     * </code>
+     *
+     * @param  string  $text
+     * @return string
+     */
+    public function next($text = null)
+    {
+        $text = $text ?: '&raquo;';
+
+        $callback = function($page, $lastPage) { return ($page >= $lastPage); };
+
+        return $this->element(
+            __FUNCTION__,
+            $this->currentPage + 1,
+            $text,
+            $callback
+        );
+    }
+
+    /**
+     * Create a chronological pagination element, such as a "previous" or "next" link.
+     *
+     * @param  string   $element
+     * @param  int      $page
+     * @param  string   $text
+     * @param  Closure  $callback
+     * @return string
+     */
+    protected function element($element, $page, $text, $disabled)
+    {
+        if (call_user_func($disabled, $this->currentPage, $this->lastPage)) {
+            return $this->getDisabledTextWrapper($text);
+        }
+
+        $rel = "{$element}_page";
+
+        return $this->link($page, $text, $rel);
+    }
+
+    /**
+     * Build the first two page links for a sliding page range.
+     *
+     * @return string
+     */
+    protected function beginning()
+    {
+        return $this->range(1, 2) .' ' .$this->dots;
+    }
+
+    /**
+     * Build the last two page links for a sliding page range.
+     *
+     * @return string
+     */
+    protected function ending()
+    {
+        return $this->dots .' ' .$this->range($this->lastPage - 1, $this->lastPage);
+    }
+
+    /**
+     * Build a range of numeric pagination links.
+     *
+     * For the current page, an HTML span element will be generated instead of a link.
+     *
+     * @param  int     $start
+     * @param  int     $end
+     * @return string
+     */
+    protected function range($start, $end)
+    {
+        $pages = array();
+
+        // To generate the range of page links, we will iterate through each page
+        // and, if the current page matches the page, we will generate a span,
+        // otherwise we will generate a link for the page. The span elements
+        // will be assigned the "current" CSS class for convenient styling.
+        for ($page = $start; $page <= $end; $page++) {
+            if ($this->currentPage == $page) {
+                $pages[] = $this->getActivePageWrapper($page);
+            } else {
+                $pages[] = $this->link($page, $page, null);
+            }
+        }
+
+        return implode(' ', $pages);
+    }
+
+    /**
+     * Create a HTML page link.
+     *
+     * @param  int     $page
+     * @param  string  $text
+     * @param  string  $class
+     * @return string
+     */
+    protected function link($page, $text, $rel)
+    {
+        $url = $this->paginator->getUrl($page);
+
+        return $this->getPageLinkWrapper($url, $text, $rel);
+    }
+}

--- a/system/Pagination/Presenter.php
+++ b/system/Pagination/Presenter.php
@@ -52,9 +52,9 @@ class Presenter
     {
         $this->paginator = $paginator;
 
-        $this->currentPage = $paginator->getCurrentPage();
+        $this->currentPage = $presenter->getCurrentPage();
 
-        $this->lastPage = $paginator->getLastPage();
+        $this->lastPage = $presenter->getLastPage();
     }
 
     /**
@@ -120,10 +120,10 @@ class Presenter
      *
      * <code>
      *      // Render the Pagination links
-     *      echo $paginator->links();
+     *      echo $presenter->links();
      *
      *      // Render the Pagination links using a given window size
-     *      echo $paginator->links(5);
+     *      echo $presenter->links(5);
      * </code>
      *
      * @param  int     $adjacent
@@ -152,10 +152,10 @@ class Presenter
      *
      * <code>
      *      // Render the pagination slider
-     *      echo $paginator->slider();
+     *      echo $presenter->slider();
      *
      *      // Render the pagination slider using a given window size
-     *      echo $paginator->slider(5);
+     *      echo $presenter->slider(5);
      * </code>
      *
      * @param  int     $adjacent
@@ -185,10 +185,10 @@ class Presenter
      *
      * <code>
      *      // Create the "previous" pagination element
-     *      echo $paginator->previous();
+     *      echo $presenter->previous();
      *
      *      // Create the "previous" pagination element with custom text
-     *      echo $paginator->previous('Go Back');
+     *      echo $presenter->previous('Go Back');
      * </code>
      *
      * @param  string  $text
@@ -213,10 +213,10 @@ class Presenter
      *
      * <code>
      *      // Create the "next" pagination element
-     *      echo $paginator->next();
+     *      echo $presenter->next();
      *
      *      // Create the "next" pagination element with custom text
-     *      echo $paginator->next('Skip Forwards');
+     *      echo $presenter->next('Skip Forwards');
      * </code>
      *
      * @param  string  $text

--- a/system/Routing/BaseRouter.php
+++ b/system/Routing/BaseRouter.php
@@ -306,15 +306,12 @@ abstract class BaseRouter
         switch ($fileExt = pathinfo($filePath, PATHINFO_EXTENSION)) {
             case 'css':
                 $contentType = 'text/css';
-
                 break;
             case 'js':
                 $contentType = 'application/javascript';
-
                 break;
             default:
                 $contentType = $guesser->guess($filePath);
-
                 break;
         }
 

--- a/system/Routing/BaseRouter.php
+++ b/system/Routing/BaseRouter.php
@@ -14,6 +14,7 @@ use Helpers\Inflector;
 use Routing\Route;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
 use Response;
 use Session;
@@ -297,25 +298,23 @@ abstract class BaseRouter
         }
 
         // Collect the current file information.
+        $guesser = MimeTypeGuesser::getInstance();
 
-        $finfo = \finfo_open(FILEINFO_MIME_TYPE); // Return mime type a la mimetype extension
-
-        $contentType = \finfo_file($finfo, $filePath);
-
-        \finfo_close($finfo);
-
-        // There is a bug with finfo_file();
-        // https://bugs.php.net/bug.php?id=53035
+        // Even the Symfony's HTTP Foundation have troubles with the CSS and JS files?
         //
         // Hard coding the correct mime types for presently needed file extensions.
         switch ($fileExt = pathinfo($filePath, PATHINFO_EXTENSION)) {
             case 'css':
                 $contentType = 'text/css';
+
                 break;
             case 'js':
                 $contentType = 'application/javascript';
+
                 break;
             default:
+                $contentType = $guesser->guess($filePath);
+
                 break;
         }
 

--- a/system/Support/Arr.php
+++ b/system/Support/Arr.php
@@ -1,77 +1,230 @@
 <?php
-/**
- * Array Helper Class.
- *
- * @author Benjamin von Minden | http://pandory.de
- * @version 3.0
- */
 
 namespace Support;
 
-/**
- * Collection of array methods.
- */
+use Support\Traits\MacroableTrait;
+
+use Closure;
+
+
 class Arr
 {
+    use MacroableTrait;
+
     /**
-     * Sets an array value.
+     * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param array  $array
-     * @param string $path
-     * @param mixed  $value
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return array
+     */
+    public static function add($array, $key, $value)
+    {
+        if (is_null(static::get($array, $key)))
+        {
+            static::set($array, $key, $value);
+        }
+
+        return $array;
+    }
+
+    /**
+     * Build a new array using a callback.
      *
+     * @param  array     $array
+     * @param  \Closure  $callback
+     * @return array
+     */
+    public static function build($array, Closure $callback)
+    {
+        $results = array();
+
+        foreach ($array as $key => $value)
+        {
+            list($innerKey, $innerValue) = call_user_func($callback, $key, $value);
+
+            $results[$innerKey] = $innerValue;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Divide an array into two arrays. One with keys and the other with values.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function divide($array)
+    {
+        return array(array_keys($array), array_values($array));
+    }
+
+    /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @param  array   $array
+     * @param  string  $prepend
+     * @return array
+     */
+    public static function dot($array, $prepend = '')
+    {
+        $results = array();
+
+        foreach ($array as $key => $value)
+        {
+            if (is_array($value))
+            {
+                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+            }
+            else
+            {
+                $results[$prepend.$key] = $value;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get all of the given array except for a specified array of items.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    public static function except($array, $keys)
+    {
+        return array_diff_key($array, array_flip((array) $keys));
+    }
+
+    /**
+     * Fetch a flattened array of a nested array element.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @return array
+     */
+    public static function fetch($array, $key)
+    {
+        foreach (explode('.', $key) as $segment)
+        {
+            $results = array();
+
+            foreach ($array as $value)
+            {
+                if (array_key_exists($segment, $value = (array) $value))
+                {
+                    $results[] = $value[$segment];
+                }
+            }
+
+            $array = array_values($results);
+        }
+
+        return array_values($results);
+    }
+
+    /**
+     * Return the first element in an array passing a given truth test.
+     *
+     * @param  array     $array
+     * @param  \Closure  $callback
+     * @param  mixed     $default
+     * @return mixed
+     */
+    public static function first($array, $callback, $default = null)
+    {
+        foreach ($array as $key => $value)
+        {
+            if (call_user_func($callback, $key, $value)) return $value;
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Return the last element in an array passing a given truth test.
+     *
+     * @param  array     $array
+     * @param  \Closure  $callback
+     * @param  mixed     $default
+     * @return mixed
+     */
+    public static function last($array, $callback, $default = null)
+    {
+        return static::first(array_reverse($array), $callback, $default);
+    }
+
+    /**
+     * Flatten a multi-dimensional array into a single level.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function flatten($array)
+    {
+        $return = array();
+
+        array_walk_recursive($array, function($x) use (&$return) { $return[] = $x; });
+
+        return $return;
+    }
+
+    /**
+     * Remove one or many array items from a given array using "dot" notation.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
      * @return void
      */
-    public static function set(array &$array, $path, $value)
+    public static function forget(&$array, $keys)
     {
-        $segments = explode('.', $path);
-        while (count($segments) > 1) {
-            $segment = array_shift($segments);
-            if (!isset($array[$segment]) || !is_array($array[$segment])) {
-                $array[$segment] = [];
+        $original =& $array;
+
+        foreach ((array) $keys as $key)
+        {
+            $parts = explode('.', $key);
+
+            while (count($parts) > 1)
+            {
+                $part = array_shift($parts);
+
+                if (isset($array[$part]) && is_array($array[$part]))
+                {
+                    $array =& $array[$part];
+                }
             }
-            $array =& $array[$segment];
+
+            unset($array[array_shift($parts)]);
+
+            // clean up after each pass
+            $array =& $original;
         }
-        $array[array_shift($segments)] = $value;
     }
 
     /**
-     * Search for an array value. Return TRUE if the array key exists and FALSE if not.
+     * Get an item from an array using "dot" notation.
      *
-     * @param array  $array
-     * @param string $path
-     *
-     * @return bool
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
      */
-    public static function has(array $array, $path)
+    public static function get($array, $key, $default = null)
     {
-        $segments = explode('.', $path);
-        foreach ($segments as $segment) {
-            if (!is_array($array) || !isset($array[$segment])) {
-                return false;
-            }
-            $array = $array[$segment];
-        }
+        if (is_null($key)) return $array;
 
-        return true;
-    }
+        if (isset($array[$key])) return $array[$key];
 
-    /**
-     * Return a value from the array.
-     *
-     * @param array  $array
-     * @param string $path
-     * @param mixed  $default
-     *
-     * @return array|null
-     */
-    public static function get(array $array, $path, $default = null)
-    {
-        $segments = explode('.', $path);
-        foreach ($segments as $segment) {
-            if (!is_array($array) || !isset($array[$segment])) {
-                return $default;
+        foreach (explode('.', $key) as $segment)
+        {
+            if ( ! is_array($array) || ! array_key_exists($segment, $array))
+            {
+                return value($default);
             }
+
             $array = $array[$segment];
         }
 
@@ -79,64 +232,159 @@ class Arr
     }
 
     /**
-     * Remove an array value.
+     * Check if an item exists in an array using "dot" notation.
      *
-     * @param   array  $array Array you want to modify
-     * @param   string $path  Array path
-     *
-     * @return  boolean
+     * @param  array   $array
+     * @param  string  $key
+     * @return bool
      */
-    public static function remove(array &$array, $path)
+    public static function has($array, $key)
     {
-        $segments = explode('.', $path);
-        while (count($segments) > 1) {
-            $segment = array_shift($segments);
-            if (!isset($array[$segment]) || !is_array($array[$segment])) {
+        if (empty($array) || is_null($key)) return false;
+
+        if (array_key_exists($key, $array)) return true;
+
+        foreach (explode('.', $key) as $segment)
+        {
+            if ( ! is_array($array) || ! array_key_exists($segment, $array))
+            {
                 return false;
             }
-            $array =& $array[$segment];
+
+            $array = $array[$segment];
         }
-        unset($array[array_shift($segments)]);
 
         return true;
     }
 
     /**
-     * Return a random value from an array.
+     * Get a subset of the items from the given array.
      *
-     * @param   array $array Array you want to pick a random value from
-     *
-     * @return  mixed
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
      */
-    public static function rand(array $array)
+    public static function only($array, $keys)
     {
-        return $array[array_rand($array)];
+        return array_intersect_key($array, array_flip((array) $keys));
     }
 
     /**
-     * Return TRUE if the array is an associative and FALSE if not.
+     * Pluck an array of values from an array.
      *
-     * @param   array $array Array to check
-     *
-     * @return  boolean
+     * @param  array   $array
+     * @param  string  $value
+     * @param  string  $key
+     * @return array
      */
-    public static function isAssoc(array $array)
+    public static function pluck($array, $value, $key = null)
     {
-        return count(array_filter(array_keys($array), 'is_string')) === count($array);
+        $results = array();
+
+        foreach ($array as $item)
+        {
+            $itemValue = is_object($item) ? $item->{$value} : $item[$value];
+
+            // If the key is "null", we will just append the value to the array and keep
+            // looping. Otherwise we will key the array using the value of the key we
+            // received from the developer. Then we'll return the final array form.
+            if (is_null($key))
+            {
+                $results[] = $itemValue;
+            }
+            else
+            {
+                $itemKey = is_object($item) ? $item->{$key} : $item[$key];
+
+                $results[$itemKey] = $itemValue;
+            }
+        }
+
+        return $results;
     }
 
     /**
-     * Return the values from a single column of the input array, identified by the key.
+     * Get a value from the array, and remove it.
      *
-     * @param   array  $array Array to pluck from
-     * @param   string $key   Array key
-     *
-     * @return  array
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
      */
-    public static function value(array $array, $key)
+    public static function pull(&$array, $key, $default = null)
     {
-        return array_map(function ($value) use ($key) {
-            return is_object($value) ? $value->$key : $value[$key];
-        }, $array);
+        $value = static::get($array, $key, $default);
+
+        static::forget($array, $key);
+
+        return $value;
     }
+
+    /**
+     * Set an array item to a given value using "dot" notation.
+     *
+     * If no key is given to the method, the entire array will be replaced.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return array
+     */
+    public static function set(&$array, $key, $value)
+    {
+        if (is_null($key)) return $array = $value;
+
+        $keys = explode('.', $key);
+
+        while (count($keys) > 1)
+        {
+            $key = array_shift($keys);
+
+            // If the key doesn't exist at this depth, we will just create an empty array
+            // to hold the next value, allowing us to create the arrays to hold final
+            // values at the correct depth. Then we'll keep digging into the array.
+            if ( ! isset($array[$key]) || ! is_array($array[$key]))
+            {
+                $array[$key] = array();
+            }
+
+            $array =& $array[$key];
+        }
+
+        $array[array_shift($keys)] = $value;
+
+        return $array;
+    }
+
+    /**
+     * Sort the array using the given Closure.
+     *
+     * @param  array     $array
+     * @param  \Closure  $callback
+     * @return array
+     */
+    public static function sort($array, Closure $callback)
+    {
+        return Collection::make($array)->sortBy($callback)->all();
+    }
+
+    /**
+     * Filter the array using the given Closure.
+     *
+     * @param  array     $array
+     * @param  \Closure  $callback
+     * @return array
+     */
+    public static function where($array, Closure $callback)
+    {
+        $filtered = array();
+
+        foreach ($array as $key => $value)
+        {
+            if (call_user_func($callback, $key, $value)) $filtered[$key] = $value;
+        }
+
+        return $filtered;
+    }
+
 }

--- a/system/Support/Collection.php
+++ b/system/Support/Collection.php
@@ -1,0 +1,720 @@
+<?php
+
+namespace Support;
+
+use Closure;
+use Countable;
+use ArrayAccess;
+use ArrayIterator;
+use CachingIterator;
+use IteratorAggregate;
+use Support\Contracts\JsonableInterface;
+use Support\Contracts\ArrayableInterface;
+
+
+class Collection implements ArrayAccess, ArrayableInterface, Countable, IteratorAggregate, JsonableInterface
+{
+    /**
+     * The items contained in the collection.
+     *
+     * @var array
+     */
+    protected $items = array();
+
+    /**
+     * Create a new collection.
+     *
+     * @param  array  $items
+     * @return void
+     */
+    public function __construct(array $items = array())
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * Create a new collection instance if the value isn't one already.
+     *
+     * @param  mixed  $items
+     * @return \Illuminate\Support\Collection
+     */
+    public static function make($items)
+    {
+        if (is_null($items)) return new static;
+
+        if ($items instanceof Collection) return $items;
+
+        return new static(is_array($items) ? $items : array($items));
+    }
+
+    /**
+     * Get all of the items in the collection.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Collapse the collection items into a single array.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collapse()
+    {
+        $results = array();
+
+        foreach ($this->items as $values)
+        {
+            $results = array_merge($results, $values);
+        }
+
+        return new static($results);
+    }
+
+    /**
+     * Diff the collection with the given items.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Illuminate\Support\Collection
+     */
+    public function diff($items)
+    {
+        return new static(array_diff($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Execute a callback over each item.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function each(Closure $callback)
+    {
+        array_map($callback, $this->items);
+
+        return $this;
+    }
+
+    /**
+     * Fetch a nested element of the collection.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function fetch($key)
+    {
+        return new static(array_fetch($this->items, $key));
+    }
+
+    /**
+     * Run a filter over each of the items.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function filter(Closure $callback)
+    {
+        return new static(array_filter($this->items, $callback));
+    }
+
+    /**
+     * Get the first item from the collection.
+     *
+     * @param  \Closure   $callback
+     * @param  mixed      $default
+     * @return mixed|null
+     */
+    public function first(Closure $callback = null, $default = null)
+    {
+        if (is_null($callback))
+        {
+            return count($this->items) > 0 ? reset($this->items) : null;
+        }
+        else
+        {
+            return array_first($this->items, $callback, $default);
+        }
+    }
+
+    /**
+     * Get a flattened array of the items in the collection.
+     *
+     * @return array
+     */
+    public function flatten()
+    {
+        return new static(array_flatten($this->items));
+    }
+
+    /**
+     * Remove an item from the collection by key.
+     *
+     * @param  mixed  $key
+     * @return void
+     */
+    public function forget($key)
+    {
+        unset($this->items[$key]);
+    }
+
+    /**
+     * Get an item from the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if (array_key_exists($key, $this->items))
+        {
+            return $this->items[$key];
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Group an associative array by a field or Closure value.
+     *
+     * @param  callable|string  $groupBy
+     * @return \Illuminate\Support\Collection
+     */
+    public function groupBy($groupBy)
+    {
+        $results = array();
+
+        foreach ($this->items as $key => $value)
+        {
+            $key = is_callable($groupBy) ? $groupBy($value, $key) : data_get($value, $groupBy);
+
+            $results[$key][] = $value;
+        }
+
+        return new static($results);
+    }
+
+    /**
+     * Determine if an item exists in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->items);
+    }
+
+    /**
+     * Concatenate values of a given key as a string.
+     *
+     * @param  string  $value
+     * @param  string  $glue
+     * @return string
+     */
+    public function implode($value, $glue = null)
+    {
+        if (is_null($glue)) return implode($this->lists($value));
+
+        return implode($glue, $this->lists($value));
+    }
+
+    /**
+     * Intersect the collection with the given items.
+     *
+      * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Illuminate\Support\Collection
+     */
+    public function intersect($items)
+    {
+        return new static(array_intersect($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Determine if the collection is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->items);
+    }
+
+    /**
+    * Get the last item from the collection.
+    *
+    * @return mixed|null
+    */
+    public function last()
+    {
+        return count($this->items) > 0 ? end($this->items) : null;
+    }
+
+    /**
+     * Get an array with the values of a given key.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return array
+     */
+    public function lists($value, $key = null)
+    {
+        return array_pluck($this->items, $value, $key);
+    }
+
+    /**
+     * Run a map over each of the items.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function map(Closure $callback)
+    {
+        return new static(array_map($callback, $this->items, array_keys($this->items)));
+    }
+
+    /**
+     * Merge the collection with the given items.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Illuminate\Support\Collection
+     */
+    public function merge($items)
+    {
+        return new static(array_merge($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Get and remove the last item from the collection.
+     *
+     * @return mixed|null
+     */
+    public function pop()
+    {
+        return array_pop($this->items);
+    }
+
+    /**
+     * Push an item onto the beginning of the collection.
+     *
+     * @param  mixed  $value
+     * @return void
+     */
+    public function prepend($value)
+    {
+        array_unshift($this->items, $value);
+    }
+
+    /**
+     * Push an item onto the end of the collection.
+     *
+     * @param  mixed  $value
+     * @return void
+     */
+    public function push($value)
+    {
+        $this->items[] = $value;
+    }
+
+    /**
+     * Pulls an item from the collection.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pull($key, $default = null)
+    {
+        return array_pull($this->items, $key, $default);
+    }
+
+    /**
+     * Put an item in the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function put($key, $value)
+    {
+        $this->items[$key] = $value;
+    }
+
+    /**
+     * Reduce the collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed  $initial
+     * @return mixed
+     */
+    public function reduce($callback, $initial = null)
+    {
+        return array_reduce($this->items, $callback, $initial);
+    }
+
+    /**
+     * Get one or more items randomly from the collection.
+     *
+     * @param  int $amount
+     * @return mixed
+     */
+    public function random($amount = 1)
+    {
+        $keys = array_rand($this->items, $amount);
+
+        return is_array($keys) ? array_intersect_key($this->items, array_flip($keys)) : $this->items[$keys];
+    }
+
+    /**
+     * Reverse items order.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function reverse()
+    {
+        return new static(array_reverse($this->items));
+    }
+
+    /**
+     * Get and remove the first item from the collection.
+     *
+     * @return mixed|null
+     */
+    public function shift()
+    {
+        return array_shift($this->items);
+    }
+
+    /**
+     * Slice the underlying collection array.
+     *
+     * @param  int   $offset
+     * @param  int   $length
+     * @param  bool  $preserveKeys
+     * @return \Illuminate\Support\Collection
+     */
+    public function slice($offset, $length = null, $preserveKeys = false)
+    {
+        return new static(array_slice($this->items, $offset, $length, $preserveKeys));
+    }
+
+    /**
+     * Chunk the underlying collection array.
+     *
+     * @param  int $size
+     * @param  bool  $preserveKeys
+     * @return \Illuminate\Support\Collection
+     */
+    public function chunk($size, $preserveKeys = false)
+    {
+        $chunks = new static;
+
+        foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk)
+        {
+            $chunks->push(new static($chunk));
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * Sort through each item with a callback.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function sort(Closure $callback)
+    {
+        uasort($this->items, $callback);
+
+        return $this;
+    }
+
+    /**
+     * Sort the collection using the given Closure.
+     *
+     * @param  \Closure|string  $callback
+     * @param  int              $options
+     * @param  bool             $descending
+     * @return \Illuminate\Support\Collection
+     */
+    public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
+    {
+        $results = array();
+
+        if (is_string($callback)) $callback =
+                          $this->valueRetriever($callback);
+
+        // First we will loop through the items and get the comparator from a callback
+        // function which we were given. Then, we will sort the returned values and
+        // and grab the corresponding values for the sorted keys from this array.
+        foreach ($this->items as $key => $value)
+        {
+            $results[$key] = $callback($value);
+        }
+
+        $descending ? arsort($results, $options)
+                    : asort($results, $options);
+
+        // Once we have sorted all of the keys in the array, we will loop through them
+        // and grab the corresponding model so we can set the underlying items list
+        // to the sorted version. Then we'll just return the collection instance.
+        foreach (array_keys($results) as $key)
+        {
+            $results[$key] = $this->items[$key];
+        }
+
+        $this->items = $results;
+
+        return $this;
+    }
+
+    /**
+     * Sort the collection in descending order using the given Closure.
+     *
+     * @param  \Closure|string  $callback
+     * @param  int              $options
+     * @return \Illuminate\Support\Collection
+     */
+    public function sortByDesc($callback, $options = SORT_REGULAR)
+    {
+        return $this->sortBy($callback, $options, true);
+    }
+
+    /**
+     * Splice portion of the underlying collection array.
+     *
+     * @param  int    $offset
+     * @param  int    $length
+     * @param  mixed  $replacement
+     * @return \Illuminate\Support\Collection
+     */
+    public function splice($offset, $length = 0, $replacement = array())
+    {
+        return new static(array_splice($this->items, $offset, $length, $replacement));
+    }
+
+    /**
+     * Get the sum of the given values.
+     *
+     * @param  \Closure  $callback
+     * @param  string  $callback
+     * @return mixed
+     */
+    public function sum($callback)
+    {
+        if (is_string($callback))
+        {
+            $callback = $this->valueRetriever($callback);
+        }
+
+        return $this->reduce(function($result, $item) use ($callback)
+        {
+            return $result += $callback($item);
+
+        }, 0);
+    }
+
+    /**
+     * Take the first or last {$limit} items.
+     *
+     * @param  int  $limit
+     * @return \Illuminate\Support\Collection
+     */
+    public function take($limit = null)
+    {
+        if ($limit < 0) return $this->slice($limit, abs($limit));
+
+        return $this->slice(0, $limit);
+    }
+
+    /**
+     * Transform each item in the collection using a callback.
+     *
+     * @param  Closure  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function transform(Closure $callback)
+    {
+        $this->items = array_map($callback, $this->items);
+
+        return $this;
+    }
+
+    /**
+     * Return only unique items from the collection array.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function unique()
+    {
+        return new static(array_unique($this->items));
+    }
+
+    /**
+     * Reset the keys on the underlying array.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function values()
+    {
+        $this->items = array_values($this->items);
+
+        return $this;
+    }
+
+    /**
+     * Get a value retrieving callback.
+     *
+     * @param  string  $value
+     * @return \Closure
+     */
+    protected function valueRetriever($value)
+    {
+        return function($item) use ($value)
+        {
+            return data_get($item, $value);
+        };
+    }
+
+    /**
+     * Get the collection of items as a plain array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_map(function($value)
+        {
+            return $value instanceof ArrayableInterface ? $value->toArray() : $value;
+
+        }, $this->items);
+    }
+
+    /**
+     * Get the collection of items as JSON.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->toArray(), $options);
+    }
+
+    /**
+     * Get an iterator for the items.
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    /**
+     * Get a CachingIterator instance.
+     *
+     * @return \CachingIterator
+     */
+    public function getCachingIterator($flags = CachingIterator::CALL_TOSTRING)
+    {
+        return new CachingIterator($this->getIterator(), $flags);
+    }
+
+    /**
+     * Count the number of items in the collection.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return array_key_exists($key, $this->items);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  mixed  $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->items[$key];
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        if (is_null($key))
+        {
+            $this->items[] = $value;
+        }
+        else
+        {
+            $this->items[$key] = $value;
+        }
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->items[$key]);
+    }
+
+    /**
+     * Convert the collection to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Results array of items from Collection or ArrayableInterface.
+     *
+       * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
+     * @return array
+     */
+    private function getArrayableItems($items)
+    {
+        if ($items instanceof Collection)
+        {
+            $items = $items->all();
+        }
+        elseif ($items instanceof ArrayableInterface)
+        {
+            $items = $items->toArray();
+        }
+
+        return $items;
+    }
+
+}

--- a/system/Support/Collection.php
+++ b/system/Support/Collection.php
@@ -36,7 +36,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Create a new collection instance if the value isn't one already.
      *
      * @param  mixed  $items
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public static function make($items)
     {
@@ -60,14 +60,13 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Collapse the collection items into a single array.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function collapse()
     {
         $results = array();
 
-        foreach ($this->items as $values)
-        {
+        foreach ($this->items as $values) {
             $results = array_merge($results, $values);
         }
 
@@ -77,8 +76,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Diff the collection with the given items.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Illuminate\Support\Collection
+     * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Support\Collection
      */
     public function diff($items)
     {
@@ -89,7 +88,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Execute a callback over each item.
      *
      * @param  Closure  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function each(Closure $callback)
     {
@@ -102,7 +101,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Fetch a nested element of the collection.
      *
      * @param  string  $key
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function fetch($key)
     {
@@ -113,7 +112,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Run a filter over each of the items.
      *
      * @param  Closure  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function filter(Closure $callback)
     {
@@ -129,12 +128,9 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     public function first(Closure $callback = null, $default = null)
     {
-        if (is_null($callback))
-        {
+        if (is_null($callback)) {
             return count($this->items) > 0 ? reset($this->items) : null;
-        }
-        else
-        {
+        } else {
             return array_first($this->items, $callback, $default);
         }
     }
@@ -169,8 +165,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     public function get($key, $default = null)
     {
-        if (array_key_exists($key, $this->items))
-        {
+        if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
 
@@ -181,14 +176,13 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Group an associative array by a field or Closure value.
      *
      * @param  callable|string  $groupBy
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function groupBy($groupBy)
     {
         $results = array();
 
-        foreach ($this->items as $key => $value)
-        {
+        foreach ($this->items as $key => $value) {
             $key = is_callable($groupBy) ? $groupBy($value, $key) : data_get($value, $groupBy);
 
             $results[$key][] = $value;
@@ -225,8 +219,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Intersect the collection with the given items.
      *
-      * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Illuminate\Support\Collection
+     * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Support\Collection
      */
     public function intersect($items)
     {
@@ -269,7 +263,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Run a map over each of the items.
      *
      * @param  Closure  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function map(Closure $callback)
     {
@@ -279,8 +273,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Merge the collection with the given items.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Illuminate\Support\Collection
+     * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
+     * @return \Support\Collection
      */
     public function merge($items)
     {
@@ -371,7 +365,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Reverse items order.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function reverse()
     {
@@ -394,7 +388,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * @param  int   $offset
      * @param  int   $length
      * @param  bool  $preserveKeys
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function slice($offset, $length = null, $preserveKeys = false)
     {
@@ -406,7 +400,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      *
      * @param  int $size
      * @param  bool  $preserveKeys
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function chunk($size, $preserveKeys = false)
     {
@@ -424,7 +418,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Sort through each item with a callback.
      *
      * @param  Closure  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function sort(Closure $callback)
     {
@@ -439,25 +433,24 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * @param  \Closure|string  $callback
      * @param  int              $options
      * @param  bool             $descending
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
         $results = array();
 
-        if (is_string($callback)) $callback =
-                          $this->valueRetriever($callback);
+        if (is_string($callback)) {
+            $callback = $this->valueRetriever($callback);
+        }
 
         // First we will loop through the items and get the comparator from a callback
         // function which we were given. Then, we will sort the returned values and
         // and grab the corresponding values for the sorted keys from this array.
-        foreach ($this->items as $key => $value)
-        {
+        foreach ($this->items as $key => $value) {
             $results[$key] = $callback($value);
         }
 
-        $descending ? arsort($results, $options)
-                    : asort($results, $options);
+        $descending ? arsort($results, $options) : asort($results, $options);
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
@@ -477,7 +470,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      *
      * @param  \Closure|string  $callback
      * @param  int              $options
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -490,7 +483,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * @param  int    $offset
      * @param  int    $length
      * @param  mixed  $replacement
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function splice($offset, $length = 0, $replacement = array())
     {
@@ -506,15 +499,12 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     public function sum($callback)
     {
-        if (is_string($callback))
-        {
+        if (is_string($callback)) {
             $callback = $this->valueRetriever($callback);
         }
 
-        return $this->reduce(function($result, $item) use ($callback)
-        {
+        return $this->reduce(function($result, $item) use ($callback) {
             return $result += $callback($item);
-
         }, 0);
     }
 
@@ -522,11 +512,13 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function take($limit = null)
     {
-        if ($limit < 0) return $this->slice($limit, abs($limit));
+        if ($limit < 0) {
+            return $this->slice($limit, abs($limit));
+        }
 
         return $this->slice(0, $limit);
     }
@@ -535,7 +527,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      * Transform each item in the collection using a callback.
      *
      * @param  Closure  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function transform(Closure $callback)
     {
@@ -547,7 +539,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Return only unique items from the collection array.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function unique()
     {
@@ -557,7 +549,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     /**
      * Reset the keys on the underlying array.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Support\Collection
      */
     public function values()
     {
@@ -574,8 +566,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     protected function valueRetriever($value)
     {
-        return function($item) use ($value)
-        {
+        return function($item) use ($value) {
             return data_get($item, $value);
         };
     }
@@ -587,10 +578,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     public function toArray()
     {
-        return array_map(function($value)
-        {
+        return array_map(function($value) {
             return $value instanceof ArrayableInterface ? $value->toArray() : $value;
-
         }, $this->items);
     }
 
@@ -666,12 +655,9 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     public function offsetSet($key, $value)
     {
-        if (is_null($key))
-        {
+        if (is_null($key)) {
             $this->items[] = $value;
-        }
-        else
-        {
+        } else {
             $this->items[$key] = $value;
         }
     }
@@ -705,12 +691,9 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
      */
     private function getArrayableItems($items)
     {
-        if ($items instanceof Collection)
-        {
+        if ($items instanceof Collection) {
             $items = $items->all();
-        }
-        elseif ($items instanceof ArrayableInterface)
-        {
+        } else if ($items instanceof ArrayableInterface) {
             $items = $items->toArray();
         }
 

--- a/system/Support/Facades/Paginator.php
+++ b/system/Support/Facades/Paginator.php
@@ -21,7 +21,6 @@ class Paginator
      */
     protected static $factory;
 
-
     /**
      * Return a Pagination Factory instance
      *
@@ -29,15 +28,15 @@ class Paginator
      */
     public static function getFactory()
     {
-        if (! isset(static::$factory)) {
-            $request = Request::instance();
-
-            // Setup the Factory instance.
-            static::$factory = new Factory($request);
+        if (isset(static::$factory)) {
+            return static::$factory;
         }
 
-        // Return the Factory instance.
-        return static::$factory;
+        // Get the Request instance.
+        $request = Request::instance();
+
+        // Setup and return the Factory instance.
+        return static::$factory = new Factory($request);
     }
 
     /**

--- a/system/Support/Facades/Paginator.php
+++ b/system/Support/Facades/Paginator.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Paginator - A Facade to the Pagination Factory.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Support\Facades;
+
+use Pagination\Factory;
+use Support\Facades\Request;
+
+
+class Paginator
+{
+    /**
+     * The Factory instance being handled.
+     *
+     * @var \Pagination\Factory|null
+     */
+    protected static $factory;
+
+
+    /**
+     * Return a Pagination Factory instance
+     *
+     * @return \Pagination\Factory
+     */
+    public static function getFactory()
+    {
+        if (! isset(static::$factory)) {
+            $request = Request::instance();
+
+            // Setup the Factory instance.
+            static::$factory = new Factory($request);
+        }
+
+        // Return the Factory instance.
+        return static::$factory;
+    }
+
+    /**
+     * Magic Method for calling the methods on the default Pagination Factory instance.
+     *
+     * @param $method
+     * @param $params
+     *
+     * @return mixed
+     */
+    public static function __callStatic($method, $params)
+    {
+        $instance = static::getFactory();
+
+        // Call the non-static method from the Pagination Factory instance.
+        return call_user_func_array(array($instance, $method), $params);
+    }
+}

--- a/system/Support/Facades/Request.php
+++ b/system/Support/Facades/Request.php
@@ -8,6 +8,7 @@
 
 namespace Support\Facades;
 
+use Core\Config;
 use Encryption\DecryptException;
 use Http\Request as HttpRequest;
 use Support\Facades\Crypt;
@@ -43,7 +44,7 @@ class Request
         static::$request = $request = HttpRequest::createFromGlobals();
 
         // Decrypt all Cookies present on the Request instance.
-        static::decryptCookies($request);
+        static::processCookies($request);
 
         // Configure the Session instance.
         $session = Session::instance();
@@ -54,8 +55,16 @@ class Request
         return $request;
     }
 
-    protected static function decryptCookies(SymfonyRequest $request)
+    protected static function processCookies(SymfonyRequest $request)
     {
+        // Retrieve the Session configuration.
+        $config = Config::get('session');
+
+        if($config['encrypt'] == false) {
+            // The Cookies encryption is disabled.
+            return;
+        }
+
         foreach ($request->cookies as $name => $cookie) {
             if($name == 'PHPSESSID') {
                 // Leave alone the PHPSESSID.

--- a/system/Support/Facades/Session.php
+++ b/system/Support/Facades/Session.php
@@ -149,7 +149,7 @@ class Session
         static::collectGarbage($session, $config);
 
         // Finally, add all Request and queued Cookies on Response instance.
-        static::processCookies($response);
+        static::processCookies($response, $config);
 
         // Prepare the Response instance for sending.
         $response->prepare($request);
@@ -181,11 +181,16 @@ class Session
      *
      * @return void
      */
-    protected static function processCookies(SymfonyResponse $response)
+    protected static function processCookies(SymfonyResponse $response, array $config)
     {
         // Insert all queued Cookies on the Response instance.
         foreach (Cookie::getQueuedCookies() as $cookie) {
             $response->headers->setCookie($cookie);
+        }
+
+        if($config['encrypt'] == false) {
+            // The Cookies encryption is disabled.
+            return;
         }
 
         // Encrypt all Cookies present on the Response instance.

--- a/system/Support/Facades/Session.php
+++ b/system/Support/Facades/Session.php
@@ -53,7 +53,7 @@ class Session
         // Load the configuration.
         $config = Config::get('session');
 
-        $name = $config['name'];
+        $name = $config['cookie'];
 
         // Get the Session ID from Cookie, fallback to null.
         $id = Cookie::get($name);
@@ -131,7 +131,7 @@ class Session
 
         // Store the Session ID in a Cookie.
         $cookie = Cookie::make(
-            $config['name'],
+            $config['cookie'],
             $session->getId(),
             $config['lifetime'],
             $config['path'],

--- a/system/Support/Traits/MacroableTrait.php
+++ b/system/Support/Traits/MacroableTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Support\Traits;
+
+
+trait MacroableTrait
+{
+    /**
+     * The registered string macros.
+     *
+     * @var array
+     */
+    protected static $macros = array();
+
+    /**
+     * Register a custom macro.
+     *
+     * @param  string    $name
+     * @param  callable  $macro
+     * @return void
+     */
+    public static function macro($name, callable $macro)
+    {
+        static::$macros[$name] = $macro;
+    }
+
+    /**
+     * Checks if macro is registered
+     *
+     * @param  string    $name
+     * @return boolean
+     */
+    public static function hasMacro($name)
+    {
+        return isset(static::$macros[$name]);
+    }
+
+    /**
+     * Dynamically handle calls to the class.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if (static::hasMacro($method))
+        {
+            return call_user_func_array(static::$macros[$method], $parameters);
+        }
+
+        throw new \BadMethodCallException("Method {$method} does not exist.");
+    }
+
+    /**
+     * Dynamically handle calls to the class.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        return static::__callStatic($method, $parameters);
+    }
+
+}

--- a/system/Validation/Validator.php
+++ b/system/Validation/Validator.php
@@ -11,6 +11,7 @@ namespace Validation;
 use Helpers\Inflector;
 use Support\Contracts\MessageProviderInterface;
 use Support\MessageBag;
+
 use Validation\Translator;
 use Validation\DatabasePresenceVerifier;
 


### PR DESCRIPTION
This pull request introduce a new **Pagination API**, in a Laravel-esque style, integrated with the **Database API**, permitting a very simple usage while offering a strong API. 

Example of the **Pagination API** usage:
```php
use DB;

// Get a Paginator instance from the QueryBuilder.
$paginate = DB::table('posts')->paginate(20);

// Add additional query parameters.
$paginate->appends(array(
    'testing' => 1,
    'example' => 'the_example_string',
));

// Get the Pagination Links.
$content = $paginate->links();

// Process the current Page results.
foreach ($paginate->getItems() as $post) {
    $content .= '<h3>' .$post->title .'</h3>';
    $content .= $post->content;
}

echo $content;
```
For a full control on QueryBuilder **paginate()**:
```php
// Get a full customized Paginator instance from the QueryBuilder.
$paginate = DB::table('posts')->paginate(25, array('*')); 
```
Like you see, there is no need to instantiate the **Pagination\Paginator** yourself, the QueryBuilder returning a properly instance, which contains also the expected results for the current Page and accessible with the method **getItems()**, or even using directly the Paginator isntance. For example:
```php
$content = $paginate->links();

// Process the current Page results.
foreach ($paginate as $post) {
    $content .= '<h3>' .$post->title .'</h3>';
    $content .= $post->content;
}

echo $content;
```

For rendering the **Pagination Links**, the **Pagination\Paginator** use the concept of **Presenter**, by default using the native one, **Pagination\Presenter**, compatible with the **Bootstrap 3.x** based templates, but it is possible to extend it and to use a custom Presenter instance, as following:
```php
use App\Pagination\CustomPresenter;
use DB;

// Get a Paginator instance from the QueryBuilder.
$paginate = DB::table('posts')->paginate(20);

// Get a custom Presenter instance and setup it.
$presenter = new CustomPresenter($paginate);

echo $presenter->links();
```
Alternatively, you can setup the custom Presenter instance to be used by the Paginator instance directly by default. 
```php
$paginate->setPresenter($presenter);

// Print the custom Pagination Links.
echo $paginate->links();
```

To note that this **Pagination API** is a new feature of **New Style APIs** only, then it doesn't introduce any API break.