### PR TITLE
A simple but very handily improvement of Core\Controller

### DIFF
--- a/app/Modules/Users/Views/Users/Login.php
+++ b/app/Modules/Users/Views/Users/Login.php
@@ -22,6 +22,10 @@
                 <div class="form-group">
                     <p><input type="password" name="password" id="password" class="form-control input-lg col-xs-12 col-sm-12 col-md-12" placeholder="<?= __d('users', 'Password'); ?>"><br><br></p>
                 </div>
+                <div class="form-group">
+                    <p><input name="remember" type="checkbox"> <?= __d('users', 'Remember me'); ?></p>
+                </div>
+                <hr>
                 <div class="row" style="margin-top: 22px;">
                     <div class="col-xs-6 col-sm-6 col-md-6">
                         <input type="submit" name="submit" class="btn btn-success col-sm-8" value="<?= __d('users', 'Login'); ?>">

--- a/system/Core/BaseView.php
+++ b/system/Core/BaseView.php
@@ -311,7 +311,7 @@ abstract class BaseView implements ArrayAccess
      * Magic Method for handling dynamic functions.
      *
      * @param  string  $method
-     * @param  array   $parames
+     * @param  array   $params
      * @return \Core\BaseView|static|void
      *
      * @throws \BadMethodCallException

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -205,12 +205,12 @@ abstract class Controller
     {
         View::share('title', $title);
     }
-    
+
     /**
      * Return a implicit View instance.
      * @return \Core\View
      */
-    protected function view()
+    protected function makeView()
     {
         // Setup the Controller's properties.
         $className = get_class($this);

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -25,11 +25,32 @@ use Session;
  */
 abstract class Controller
 {
+    /**
+     * The requested Method by Router.
+     *
+     * @var string|null
+     */
     private $method = null;
+
+    /**
+     * The parameters given by Router.
+     *
+     * @var array
+     */
     private $params = array();
 
+    /**
+     * The Module name.
+     *
+     * @var string|null
+     */
     private $module = null;
 
+    /**
+     * The Default View.
+     *
+     * @var string
+     */
     private $defaultView;
 
     /**
@@ -240,9 +261,17 @@ abstract class Controller
     }
 
     /**
+     * @return string
+     */
+    protected function getViewName()
+    {
+        return $this->defaultView;
+    }
+
+    /**
      * @return string|null
      */
-    protected function module()
+    protected function getModule()
     {
         return $this->module;
     }
@@ -250,7 +279,7 @@ abstract class Controller
     /**
      * @return mixed
      */
-    protected function template()
+    protected function getTemplate()
     {
         return $this->template;
     }
@@ -258,7 +287,7 @@ abstract class Controller
     /**
      * @return mixed
      */
-    protected function layout()
+    protected function getLayout()
     {
         return $this->layout;
     }
@@ -266,7 +295,7 @@ abstract class Controller
     /**
      * @return mixed
      */
-    protected function method()
+    protected function getMethod()
     {
         return $this->method;
     }
@@ -274,7 +303,7 @@ abstract class Controller
     /**
      * @return array
      */
-    protected function params()
+    protected function getParams()
     {
         return $this->params;
     }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -196,6 +196,49 @@ abstract class Controller
         return $this->language->get($str, $code);
     }
 
+
+    /**
+     * @return array
+     */
+    protected function getViewAndModule()
+    {
+        // Setup the Controller's properties.
+        $className = get_class($this);
+
+        $method = ucfirst($this->method());
+
+        // Prepare the View Path using the Controller's full Name including its namespace.
+        $classPath = str_replace('\\', '/', ltrim($className, '\\'));
+
+        // First, check on the App path.
+        if (preg_match('#^App/Controllers/(.*)$#i', $classPath, $matches)) {
+            $module = null;
+
+            $view = $matches[1] .DS .$method;
+            // Secondly, check on the Modules path.
+        } else if (preg_match('#^App/Modules/(.+)/Controllers/(.*)$#i', $classPath, $matches)) {
+            $module = $matches[1];
+
+            // The View is in Module sub-directories.
+            $view = $matches[2] .DS .$method;
+        } else {
+            throw new \Exception('Failed to calculate the view and module, for the Class: ' .$className);
+        }
+
+        return array($view, $module);
+    }
+
+    /**
+     * Return a implicit View instance.
+     * @return \Core\View
+     */
+    protected function view()
+    {
+        list($view, $module) = $this->getViewAndModule();
+
+        return View::make($view, array(), $module);
+    }
+
     /**
      * @param  string $title
      *
@@ -238,52 +281,4 @@ abstract class Controller
         return $this->params;
     }
 
-    /**
-     * @return array
-     */
-    protected function getViewAndModule()
-    {
-        // Setup the Controller's properties.
-        $className = get_class($this);
-
-        $method = ucfirst($this->method());
-
-        // Prepare the View Path using the Controller's full Name including its namespace.
-        $classPath = str_replace('\\', '/', ltrim($className, '\\'));
-
-        // First, check on the App path.
-        if (preg_match('#^App/Controllers/(.*)$#i', $classPath, $matches)) {
-            $module = null;
-
-            $view = $matches[1] .DS .$method;
-            // Secondly, check on the Modules path.
-        } else if (preg_match('#^App/Modules/(.+)/Controllers/(.*)$#i', $classPath, $matches)) {
-            $module = $matches[1];
-
-            // The View is in Module sub-directories.
-            $view = $matches[2] .DS .$method;
-        } else {
-            throw new \Exception('Failed to calculate the view and module, for the Class: ' .$className);
-        }
-
-        return array($view, $module);
-    }
-
-     /**
-     * Magic Method for handling dynamic functions.
-     *
-     * @param  string  $method
-     * @param  array   $params
-     * @return \Core\View|static|void
-     *
-     * @throws \BadMethodCallException
-     */
-    public function __call($method, $params)
-    {
-        list($view, $module) = $this->getViewAndModule();
-
-        $instance = View::make($view, array(), $module);
-
-        return call_user_func_array(array($instance, $method), $params);
-    }
 }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -196,11 +196,11 @@ abstract class Controller
         return $this->language->get($str, $code);
     }
 
-
     /**
-     * @return array
+     * Return a implicit View instance.
+     * @return \Core\View
      */
-    protected function getViewAndModule()
+    protected function view()
     {
         // Setup the Controller's properties.
         $className = get_class($this);
@@ -224,17 +224,6 @@ abstract class Controller
         } else {
             throw new \Exception('Failed to calculate the view and module, for the Class: ' .$className);
         }
-
-        return array($view, $module);
-    }
-
-    /**
-     * Return a implicit View instance.
-     * @return \Core\View
-     */
-    protected function view()
-    {
-        list($view, $module) = $this->getViewAndModule();
 
         return View::make($view, array(), $module);
     }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -255,9 +255,9 @@ abstract class Controller
      *
      * @return \Core\View
      */
-    protected function getView()
+    protected function getView(array $data = array())
     {
-        return View::make($this->defaultView, array(), $this->module);
+        return View::make($this->defaultView, $data, $this->module);
     }
 
     /**

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -197,6 +197,16 @@ abstract class Controller
     }
 
     /**
+     * @param  string $title
+     *
+     * @return \Core\Controller
+     */
+    protected function title($title)
+    {
+        View::share('title', $title);
+    }
+    
+    /**
      * Return a implicit View instance.
      * @return \Core\View
      */
@@ -226,16 +236,6 @@ abstract class Controller
         }
 
         return View::make($view, array(), $module);
-    }
-
-    /**
-     * @param  string $title
-     *
-     * @return \Core\Controller
-     */
-    public function title($title)
-    {
-        View::share('title', $title);
     }
 
     /**

--- a/system/Database/ORM/Model.php
+++ b/system/Database/ORM/Model.php
@@ -30,6 +30,7 @@ use Carbon\Carbon;
 
 use ArrayAccess;
 use DateTime;
+use DateTimeInterface;
 use LogicException;
 use PDO;
 
@@ -2250,20 +2251,20 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
     /**
      * Convert a DateTime to a storable string.
      *
-     * @param  \DateTime|int  $value
+     * @param  \DateTimeInterface|int  $value
      * @return string
      */
     public function fromDateTime($value)
     {
         $format = $this->getDateFormat();
 
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTimeInterface) {
             //
         } else if (is_numeric($value)) {
             $value = Carbon::createFromTimestamp($value);
         } else if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value)) {
             $value = Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
-        } else if (! $value instanceof DateTime) {
+        } else if (! $value instanceof DateTimeInterface) {
             $value = Carbon::createFromFormat($format, $value);
         }
 
@@ -2282,7 +2283,7 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
             return Carbon::createFromTimestamp($value);
         } else if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value)) {
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
-        } else if ( ! $value instanceof DateTime) {
+        } else if (! $value instanceof DateTimeInterface) {
             $format = $this->getDateFormat();
 
             return Carbon::createFromFormat($format, $value);


### PR DESCRIPTION
This pull request introduce a simple but very handily improvement of **Core\Controller**, making it capable to transparently call a View instance, if the developers accept to use a implicit View for the Controller's method.

 As a example of the usage for the Controller **App\Controllers\Welcome**:
```php
public function subPage()
{
    $this->title($this->trans('subpageText'));

    return $this->getView()
        ->withWelcomeMessage($this->trans('subpageMessage'));
}
```

Another example, for **App\Modules\Users\Controllers\Users**:
```php
    public function login()
    {
        $error = Session::remove('error', array());

        $this->title(__d('users', 'User Login'));

        return $this->getView()
            ->with('csrfToken', Session::token())
            ->with('error', $error);
    }
```

How it is calculated the implicit View path?

It is the calculated from the Controller complete name (with namespace), replacing **'\Controllers\'** with **'\View\'** and add as the last element, the titled **method**. For example:

**App\Controllers\Welcome@subPage** -> the View: **'Welcome/SubPage'** 

**App\Modules\Users\Controllers\Users@login** -> the View: **'Users/Login'**, the module: **'Users'**

Finally, there is added a new method, called **title()** which is practically a shortcut to adding the title to View's shared data:
```php
    /**
     * @param  string $title
     *
     * @return \Core\Controller
     */
    protected function title($title)
    {
        View::share('title', $title);
    }
``` 