### PR TITLE
Make the Routing configurable via app/Config/Routing.php

### DIFF
--- a/app/Config.example.php
+++ b/app/Config.example.php
@@ -144,6 +144,11 @@ Config::set('recaptcha', array(
 require 'Config/App.php';
 
 /**
+ * Setup the Routing configuration
+ */
+require 'Config/Routing.php';
+
+/**
  * Setup the Language configuration
  */
 require 'Config/Languages.php';

--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -17,8 +17,8 @@ Config::set('routing', array(
         //':hex'    => '[[:xdigit:]]+',
         //':uuidV4' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
     ),
-    'dispatcher' => array(
-        'defaultController' => DEFAULT_CONTROLLER,
-        'defaultMethod'     => DEFAULT_METHOD
+    'default' => array(
+        'controller' => DEFAULT_CONTROLLER,
+        'method'     => DEFAULT_METHOD
     )
 ));

--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Routing Configuration
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+use Core\Config;
+
+
+/**
+ * Routing configuration
+ */
+Config::set('routing', array(
+    'patterns' => array(
+        //':hex'    => '[[:xdigit:]]+',
+        //':uuidV4' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
+    ),
+    'dispatcher' => array(
+        'defaultController' => DEFAULT_CONTROLLER,
+        'defaultMethod'     => DEFAULT_METHOD
+    )
+));

--- a/app/Modules/Users/Models/Users.php
+++ b/app/Modules/Users/Models/Users.php
@@ -15,6 +15,11 @@ use Database\Model as BaseModel;
 
 class Users extends BaseModel
 {
+    protected $table = null;
+
+    protected $primaryKey = 'id';
+
+
     public function __construct()
     {
         parent::__construct();

--- a/app/Modules/Users/Models/Users.php
+++ b/app/Modules/Users/Models/Users.php
@@ -8,20 +8,21 @@
 
 namespace App\Modules\Users\Models;
 
+use Core\Config;
 use Auth\GenericUser;
 use Database\Model as BaseModel;
 
 
 class Users extends BaseModel
 {
-    protected $table = 'users';
-
-    protected $primaryKey = 'id';
-
-
     public function __construct()
     {
         parent::__construct();
+
+        // Configure the Model's table.
+        if($this->table === null) {
+            $this->table = Config::get('auth.table');
+        }
     }
 
     public function updateGenericUser(GenericUser $user)

--- a/system/Routing/ClassicRouter.php
+++ b/system/Routing/ClassicRouter.php
@@ -88,7 +88,7 @@ class ClassicRouter extends BaseRouter
 
         // Search the defined Routes for any matches; invoke the associated Callback, if any.
         foreach ($this->routes as $route) {
-            if ($route->match($uri, $method, false)) {
+            if ($route->match($uri, $method)) {
                 // Found a valid Route; process it.
                 $this->matchedRoute = $route;
 
@@ -143,6 +143,12 @@ class ClassicRouter extends BaseRouter
      */
     public function autoDispatch($uri)
     {
+        // Retrieve the options from configuration.
+        $options = Config::get('routing.dispatcher', array(
+            'defaultController' => DEFAULT_CONTROLLER,
+            'defaultMethod'     => DEFAULT_METHOD
+        ));
+
         // Explode the URI to its parts.
         $parts = explode('/', trim($uri, '/'));
 
@@ -190,12 +196,12 @@ class ClassicRouter extends BaseRouter
         }
 
         // Get the normalized Controller.
-        $defaultOne = !empty($moduleName) ? $moduleName : DEFAULT_CONTROLLER;
+        $defaultOne = !empty($moduleName) ? $moduleName : $options['defaultController'];
 
         $controller = !empty($controller) ? $controller : $defaultOne;
 
         // Get the normalized Method.
-        $method = !empty($parts) ? array_shift($parts) : DEFAULT_METHOD;
+        $method = !empty($parts) ? array_shift($parts) : $options['defaultMethod'];
 
         // Prepare the Controller's class name.
         $controller = str_replace(array('//', '/'), '\\', 'App/'.$basePath.$directory.$controller);

--- a/system/Routing/ClassicRouter.php
+++ b/system/Routing/ClassicRouter.php
@@ -145,9 +145,9 @@ class ClassicRouter extends BaseRouter
     public function autoDispatch($uri)
     {
         // Retrieve the options from configuration.
-        $options = Config::get('routing.dispatcher', array(
-            'defaultController' => DEFAULT_CONTROLLER,
-            'defaultMethod'     => DEFAULT_METHOD
+        $options = Config::get('routing.default', array(
+            'controller' => DEFAULT_CONTROLLER,
+            'method'     => DEFAULT_METHOD
         ));
 
         // Explode the URI to its parts.
@@ -197,12 +197,12 @@ class ClassicRouter extends BaseRouter
         }
 
         // Get the normalized Controller.
-        $defaultOne = !empty($moduleName) ? $moduleName : $options['defaultController'];
+        $defaultOne = !empty($moduleName) ? $moduleName : $options['controller'];
 
         $controller = !empty($controller) ? $controller : $defaultOne;
 
         // Get the normalized Method.
-        $method = !empty($parts) ? array_shift($parts) : $options['defaultMethod'];
+        $method = !empty($parts) ? array_shift($parts) : $options['method'];
 
         // Prepare the Controller's class name.
         $controller = str_replace(array('//', '/'), '\\', 'App/'.$basePath.$directory.$controller);

--- a/system/Routing/ClassicRouter.php
+++ b/system/Routing/ClassicRouter.php
@@ -8,6 +8,7 @@
 
 namespace Core;
 
+use Core\Config;
 use Helpers\Inflector;
 use Helpers\Url;
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -165,14 +165,15 @@ class Route
             return true;
         }
 
+        // Convert the Named Patterns to ANY, e.g. {category}
+        $regex = preg_replace('#\{([a-z]+)\}#', '([^/]+)', $this->pattern);
+
         // Build the regex for matching.
-        if (strpos($this->pattern, ':') !== false) {
+        if (strpos($regex, ':') !== false) {
             $searches = array_merge(array(':any', ':num', ':all'), array_keys($patterns));
             $replaces = array_merge(array('[^/]+', '[0-9]+', '.*'), array_values($patterns));
 
             $regex = str_replace($searches, $replaces, $regex);
-        } else {
-            $regex = $this->pattern;
         }
 
         if ($optionals && (strpos($regex, '(/') !== false)) {

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -148,7 +148,7 @@ class Route
      * @return bool Match status
      * @internal param string $pattern URL pattern
      */
-    public function match($uri, $method, $optionals = true)
+    public function match($uri, $method, $optionals = false, array $patterns = array())
     {
         if (! in_array($method, $this->methods)) {
             return false;
@@ -167,7 +167,10 @@ class Route
 
         // Build the regex for matching.
         if (strpos($this->pattern, ':') !== false) {
-            $regex = str_replace(array(':any', ':num', ':all'), array('[^/]+', '[0-9]+', '.*'), $this->pattern);
+            $searches = array_merge(array(':any', ':num', ':all'), array_keys($patterns));
+            $replaces = array_merge(array('[^/]+', '[0-9]+', '.*'), array_values($patterns));
+
+            $regex = str_replace($searches, $replaces, $regex);
         } else {
             $regex = $this->pattern;
         }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -169,8 +169,8 @@ class Route
         // Build the regex for matching.
 
         if (strpos($this->pattern, '{') !== false) {
-            // Convert the Named Patterns to ANY, e.g. {category}
-            $regex = preg_replace('#\{([a-z]+)\}#', '([^/]+)', $this->pattern);
+            // Convert the Named Patterns to (:any), e.g. {category}
+            $regex = preg_replace('#\{([a-z]+)\}#', '(:any)', $this->pattern);
         } else {
             $regex = $this->pattern;
         }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -173,7 +173,7 @@ class Route
             $regex = preg_replace('#\{([a-z]+)\}#', '(:any)', $this->pattern);
 
             // Convert the Named Patterns to (:num), e.g. {:id}
-            $route = preg_replace('#\{:([a-z]+)\}#', '(:num)', $route);
+            $regex = preg_replace('#\{:([a-z]+)\}#', '(:num)', $regex);
         } else {
             $regex = $this->pattern;
         }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -175,7 +175,7 @@ class Route
             $regex = $this->pattern;
         }
 
-        if ($optionals && (strpos($this->pattern, '(/') !== false)) {
+        if ($optionals && (strpos($regex, '(/') !== false)) {
             $regex = str_replace(array('(/', ')'), array('(?:/', ')?'), $regex);
         }
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -165,10 +165,16 @@ class Route
             return true;
         }
 
-        // Convert the Named Patterns to ANY, e.g. {category}
-        $regex = preg_replace('#\{([a-z]+)\}#', '([^/]+)', $this->pattern);
-
+        //
         // Build the regex for matching.
+
+        if (strpos($this->pattern, '{') !== false) {
+            // Convert the Named Patterns to ANY, e.g. {category}
+            $regex = preg_replace('#\{([a-z]+)\}#', '([^/]+)', $this->pattern);
+        } else {
+            $regex = $this->pattern;
+        }
+
         if (strpos($regex, ':') !== false) {
             $searches = array_merge(array(':any', ':num', ':all'), array_keys($patterns));
             $replaces = array_merge(array('[^/]+', '[0-9]+', '.*'), array_values($patterns));

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -171,6 +171,9 @@ class Route
         if (strpos($this->pattern, '{') !== false) {
             // Convert the Named Patterns to (:any), e.g. {category}
             $regex = preg_replace('#\{([a-z]+)\}#', '(:any)', $this->pattern);
+
+            // Convert the Named Patterns to (:num), e.g. {:id}
+            $route = preg_replace('#\{:([a-z]+)\}#', '(:num)', $route);
         } else {
             $regex = $this->pattern;
         }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -175,7 +175,7 @@ class Route
             $regex = $this->pattern;
         }
 
-        if ($optionals) {
+        if ($optionals && (strpos($this->pattern, '(/') !== false)) {
             $regex = str_replace(array('(/', ')'), array('(?:/', ')?'), $regex);
         }
 

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -8,6 +8,7 @@
 
 namespace Routing;
 
+use Core\Config;
 use Helpers\Inflector;
 use Helpers\Url;
 use Routing\BaseRouter;
@@ -226,6 +227,9 @@ class Router extends BaseRouter
      */
     public function dispatch()
     {
+        // Retrieve the additional Routing Patterns from configuration.
+        $patterns = Config::get('routing.patterns', array());
+
         // Detect the current URI.
         $uri = Url::detectUri();
 
@@ -243,7 +247,7 @@ class Router extends BaseRouter
         }
 
         foreach ($this->routes as $route) {
-            if ($route->match($uri, $method)) {
+            if ($route->match($uri, $method, true, $patterns)) {
                 // Found a valid Route; process it.
                 $this->matchedRoute = $route;
 


### PR DESCRIPTION
This pull request make the Nova's **Routing** configurable via the file **app/Config/Routing.php**, which usually contains:

```php
/**
 * Routing configuration
 */
Config::set('routing', array(
    'patterns' => array(
        //':hex'    => '[[:xdigit:]]+',
        //':uuidV4' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'
    ),
    'default' => array(
        'controller' => DEFAULT_CONTROLLER,
        'method'     => DEFAULT_METHOD
    )
));
```

In the **"patterns"** array entries could be added additional **Routing Patterns** used by the both Routers, while the **"default**" entry is for the **ClassicRouter**.

Finally, this pull request introduce a **small optional feature**: the **Named Patterns** which are practically aliases to **(:any)** and  **(:num)**, but permitting a more fluent definition, for example:
```php
// Using a :ANY based Named Pattern
Router::any('blog/categories/{category}', 'App\Modules\Blog\Controllers\Blog@category');

// Using a :NUM base Named Pattern
Router::any('admin/blog/categories/{:id}', 'App\Modules\Blog\Controllers\Admin\Blog@category');
```