### PR TITLE
 	Split the Application finishing logic from Support\Facades\Session to Support\Facades\App

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -46,6 +46,7 @@ Config::set('classAliases', array(
     'Str'           => '\Support\Str',
 
     // The Support Facades
+    'App'           => '\Support\Facades\App',
     'Auth'          => '\Support\Facades\Auth',
     'Cookie'        => '\Support\Facades\Cookie',
     'Crypt'         => '\Support\Facades\Crypt',

--- a/app/Modules/Users/Views/Admin/Roles/Index.php
+++ b/app/Modules/Users/Views/Admin/Roles/Index.php
@@ -43,10 +43,10 @@
         echo "
 <tr>
     <td style='text-align: center; vertical-align: middle;' width='5%'>" .$role->id ."</td>
-    <td style='text-align: center; vertical-align: middle;' width='15%'>" .$role->name ."</td>
-    <td style='text-align: center; vertical-align: middle;' width='15%'>" .$role->slug ."</td>
-    <td style='text-align: left; vertical-align: middle;' width='45%'>" .$role->description ."</td>
-    <td style='text-align: center; vertical-align: middle;' width='5%'>" .$role->users->count() ."</td>
+    <td style='text-align: center; vertical-align: middle;' width='17%'>" .$role->name ."</td>
+    <td style='text-align: center; vertical-align: middle;' width='17%'>" .$role->slug ."</td>
+    <td style='text-align: left; vertical-align: middle;' width='40%'>" .$role->description ."</td>
+    <td style='text-align: center; vertical-align: middle;' width='6%'>" .$role->users->count() ."</td>
     <td style='text-align: right; vertical-align: middle;' width='15%'>
         <div class='btn-group' role='group' aria-label='...'>
             <a class='btn btn-sm btn-warning' href='" .site_url('admin/roles/' .$role->id). "' title='". __d('users', 'Show the Details') ."' role='button'><i class='fa fa-search'></i></a>

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -16,9 +16,9 @@ use Helpers\Hooks;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+use App;
 use Event;
 use Response;
-use Session;
 
 
 /**
@@ -133,7 +133,7 @@ abstract class Controller
         // The Method returned a Response instance; send it and stop the processing.
         if ($result instanceof SymfonyResponse) {
             // Finish the Session and send the Response.
-            Session::finish($result);
+            App::finish($result);
 
             return true;
         }
@@ -181,7 +181,7 @@ abstract class Controller
             $response = Response::make($content, 200, $headers);
 
             // Finish the Session and send the Response.
-            Session::finish($response);
+            App::finish($response);
 
             return true;
         } else if (! $result instanceof BaseView) {
@@ -199,7 +199,7 @@ abstract class Controller
         $response = Response::make($result);
 
         // Finish the Session and send the Response.
-        Session::finish($response);
+        App::finish($response);
 
         return true;
     }

--- a/system/Helpers/Url.php
+++ b/system/Helpers/Url.php
@@ -12,7 +12,7 @@ use Helpers\Session;
 use Helpers\Inflector;
 
 use Support\Facades\Redirect;
-use Support\Facades\Session as SessionStore;
+use Support\Facades\App;
 
 
 /**
@@ -36,7 +36,7 @@ class Url
         $response = Redirect::to($url, $code);
 
         // Finish the Session (and send the Response).
-        SessionStore::finish($response);
+        App::finish($response);
 
         // Quit the Nova Framework's execution.
         exit();

--- a/system/Routing/BaseRouter.php
+++ b/system/Routing/BaseRouter.php
@@ -16,9 +16,9 @@ use Routing\Route;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
+use App;
 use Console;
 use Response;
-use Session;
 
 
 /**
@@ -157,7 +157,7 @@ abstract class BaseRouter
 
         if($result instanceof SymfonyResponse) {
             // Finsih the Session Store.
-            Session::finish($result);
+            App::finish($result);
 
             // Send the Response.
             $result->send();
@@ -166,7 +166,7 @@ abstract class BaseRouter
             $response = Response::make($result);
 
             // Finish the Session Store.
-            Session::finish($response);
+            App::finish($response);
 
             // Send the Response.
             $response->send();

--- a/system/Routing/ClassicRouter.php
+++ b/system/Routing/ClassicRouter.php
@@ -15,9 +15,9 @@ use Helpers\Url;
 use Routing\BaseRouter;
 use Routing\Route;
 
+use App;
 use Response;
 use Request;
-use Session;
 
 
 /**
@@ -127,7 +127,7 @@ class ClassicRouter extends BaseRouter
         $response = Response::error(404, $data);
 
         // Finish the Session and send the Response.
-        Session::finish($response);
+        App::finish($response);
 
         return false;
     }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -16,9 +16,9 @@ use Routing\Route;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+use App;
 use Response;
 use Request;
-use Session;
 
 
 /**
@@ -256,7 +256,7 @@ class Router extends BaseRouter
 
                 if($result instanceof SymfonyResponse) {
                     // Finish the Session and send the Response.
-                    Session::finish($result);
+                    App::finish($result);
 
                     return true;
                 }
@@ -279,7 +279,7 @@ class Router extends BaseRouter
         $response = Response::error(404, $data);
 
         // Finish the Session and send the Response.
-        Session::finish($response);
+        App::finish($response);
 
         return false;
     }

--- a/system/Support/Facades/App.php
+++ b/system/Support/Facades/App.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class App
 {
-
     /**
      * Initialize the Application instance
      *

--- a/system/Support/Facades/App.php
+++ b/system/Support/Facades/App.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * App - A Facade to the Application.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Support\Facades;
+
+use Core\Config;
+use Forensics\Profiler as QuickProfiler;
+use Http\Response as HttpResponse;
+use Session\SessionInterface;
+
+use Support\Facades\Cookie;
+use Support\Facades\Crypt;
+use Support\Facades\Request;
+use Support\Facades\Session;
+
+use Symfony\Component\HttpFoundation\Cookie as SymfonyCookie;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+
+
+class App
+{
+
+    /**
+     * Initialize the Application instance
+     *
+     * @return void
+     */
+    public static function init()
+    {
+    }
+
+    /**
+     * Finalize the Session Store and send the Response
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @return void
+     */
+    public static function finish(SymfonyResponse $response)
+    {
+        // Get the Session Store configuration.
+        $config = Config::get('session');
+
+        // Get the Request instance.
+        $request = Request::instance();
+
+        // Get the Session Store instance.
+        $session = Session::instance();
+
+        // Store the Session ID in a Cookie.
+        $cookie = Cookie::make(
+            $config['cookie'],
+            $session->getId(),
+            $config['lifetime'],
+            $config['path'],
+            $config['domain'],
+            $config['secure'],
+            false
+        );
+
+        Cookie::queue($cookie);
+
+        // Save the Session Store data.
+        $session->save();
+
+        // Collect the garbage for the Session Store instance.
+        static::collectGarbage($session, $config);
+
+        // Add all Request and queued Cookies.
+        static::processCookies($response, $config);
+
+        // Finally, minify the Response's Content.
+        static::processContent($response);
+
+        // Prepare the Response instance for sending.
+        $response->prepare($request);
+
+        // Send the Response.
+        $response->send();
+    }
+
+    /**
+     * Minify the Response instance Content.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response $response
+     * @return void
+     */
+    protected static function processContent(SymfonyResponse $response)
+    {
+        if (! $response instanceof HttpResponse) {
+            return;
+        }
+
+        $content = $response->getContent();
+
+        if(ENVIRONMENT == 'development') {
+            // Insert the QuickProfiler Widget in the Response's Content.
+
+            $content = str_replace(
+                '<!-- DO NOT DELETE! - Forensics Profiler -->',
+                QuickProfiler::process(true),
+                $content
+            );
+        } else if(ENVIRONMENT == 'production') {
+            // Minify the Response's Content.
+
+            $search = array(
+                '/\>[^\S ]+/s', // Strip whitespaces after tags, except space.
+                '/[^\S ]+\</s', // Strip whitespaces before tags, except space.
+                '/(\s)+/s'      // Shorten multiple whitespace sequences.
+            );
+
+            $replace = array('>', '<', '\\1');
+
+            $content = preg_replace($search, $replace, $content);
+        }
+
+        $response->setContent($content);
+    }
+
+    /**
+     * Remove the garbage from the session if necessary.
+     *
+     * @param  \Illuminate\Session\SessionInterface  $session
+     * @return void
+     */
+    protected static function collectGarbage(SessionInterface $session, array $config)
+    {
+        $lifeTime = $config['lifetime'] * 60; // The option is in minutes.
+
+        // Here we will see if this request hits the garbage collection lottery by hitting
+        // the odds needed to perform garbage collection on any given request. If we do
+        // hit it, we'll call this handler to let it delete all the expired sessions.
+        if (static::configHitsLottery($config))  {
+            $session->getHandler()->gc($lifeTime);
+        }
+    }
+
+    /**
+     * Add all the queued Cookies to Response instance and encrypt all Cookies.
+     *
+     * @return void
+     */
+    protected static function processCookies(SymfonyResponse $response, array $config)
+    {
+        // Insert all queued Cookies on the Response instance.
+        foreach (Cookie::getQueuedCookies() as $cookie) {
+            $response->headers->setCookie($cookie);
+        }
+
+        if($config['encrypt'] == false) {
+            // The Cookies encryption is disabled.
+            return;
+        }
+
+        // Encrypt all Cookies present on the Response instance.
+        foreach ($response->headers->getCookies() as $key => $cookie)  {
+            if($key == 'PHPSESSID') {
+                // Leave alone the PHPSESSID.
+                continue;
+            }
+
+            // Create a new Cookie with the content encrypted.
+            $cookie = new SymfonyCookie(
+                $cookie->getName(),
+                Crypt::encrypt($cookie->getValue()),
+                $cookie->getExpiresTime(),
+                $cookie->getPath(),
+                $cookie->getDomain(),
+                $cookie->isSecure(),
+                $cookie->isHttpOnly()
+            );
+
+            $response->headers->setCookie($cookie);
+        }
+    }
+
+    /**
+     * Determine if the configuration odds hit the lottery.
+     *
+     * @param  array  $config
+     * @return bool
+     */
+    protected static function configHitsLottery(array $config)
+    {
+        return (mt_rand(1, $config['lottery'][1]) <= $config['lottery'][0]);
+    }
+}

--- a/system/Support/Facades/Session.php
+++ b/system/Support/Facades/Session.php
@@ -10,20 +10,10 @@ namespace Support\Facades;
 
 use Core\Config;
 use Core\Template;
-use Core\BaseView as View;
-use Forensics\Profiler as QuickProfiler;
-use Http\Response as HttpResponse;
 use Session\FileSessionHandler;
-use Session\SessionInterface;
 use Session\Store as SessionStore;
 use Support\Facades\Cookie;
-use Support\Facades\Crypt;
-use Support\Facades\Request;
 use Support\MessageBag;
-
-use Symfony\Component\HttpFoundation\Cookie as SymfonyCookie;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-
 
 
 class Session
@@ -113,162 +103,6 @@ class Session
         );
 
         Cookie::queue($cookie);
-    }
-
-    /**
-     * Finalize the Session Store and send the Response
-     *
-     * @param \Symfony\Component\HttpFoundation\Response $response
-     * @return void
-     */
-    public static function finish(SymfonyResponse $response)
-    {
-        // Get the Session Store configuration.
-        $config = Config::get('session');
-
-        // Get the Request instance.
-        $request = Request::instance();
-
-        // Get the Session Store instance.
-        $session = static::getSessionStore();
-
-        // Store the Session ID in a Cookie.
-        $cookie = Cookie::make(
-            $config['cookie'],
-            $session->getId(),
-            $config['lifetime'],
-            $config['path'],
-            $config['domain'],
-            $config['secure'],
-            false
-        );
-
-        Cookie::queue($cookie);
-
-        // Save the Session Store data.
-        $session->save();
-
-        // Collect the garbage for the Session Store instance.
-        static::collectGarbage($session, $config);
-
-        // Add all Request and queued Cookies.
-        static::processCookies($response, $config);
-
-        // Finally, minify the Response's Content.
-        static::processContent($response);
-
-        // Prepare the Response instance for sending.
-        $response->prepare($request);
-
-        // Send the Response.
-        $response->send();
-    }
-
-    /**
-     * Minify the Response instance Content.
-     *
-     * @param  \Symfony\Component\HttpFoundation\Response $response
-     * @return void
-     */
-    protected static function processContent(SymfonyResponse $response)
-    {
-        if (! $response instanceof HttpResponse) {
-            return;
-        }
-
-        $content = $response->getContent();
-
-        if(ENVIRONMENT == 'development') {
-            // Insert the QuickProfiler Widget in the Response's Content.
-
-            $content = str_replace(
-                '<!-- DO NOT DELETE! - Forensics Profiler -->',
-                QuickProfiler::process(true),
-                $content
-            );
-        } else if(ENVIRONMENT == 'production') {
-            // Minify the Response's Content.
-
-            $search = array(
-                '/\>[^\S ]+/s', // Strip whitespaces after tags, except space.
-                '/[^\S ]+\</s', // Strip whitespaces before tags, except space.
-                '/(\s)+/s'      // Shorten multiple whitespace sequences.
-            );
-
-            $replace = array('>', '<', '\\1');
-
-            $content = preg_replace($search, $replace, $content);
-        }
-
-        $response->setContent($content);
-    }
-
-    /**
-     * Remove the garbage from the session if necessary.
-     *
-     * @param  \Illuminate\Session\SessionInterface  $session
-     * @return void
-     */
-    protected static function collectGarbage(SessionInterface $session, array $config)
-    {
-        $lifeTime = $config['lifetime'] * 60; // The option is in minutes.
-
-        // Here we will see if this request hits the garbage collection lottery by hitting
-        // the odds needed to perform garbage collection on any given request. If we do
-        // hit it, we'll call this handler to let it delete all the expired sessions.
-        if (static::configHitsLottery($config))  {
-            $session->getHandler()->gc($lifeTime);
-        }
-    }
-
-    /**
-     * Add all the queued Cookies to Response instance and encrypt all Cookies.
-     *
-     * @return void
-     */
-    protected static function processCookies(SymfonyResponse $response, array $config)
-    {
-        // Insert all queued Cookies on the Response instance.
-        foreach (Cookie::getQueuedCookies() as $cookie) {
-            $response->headers->setCookie($cookie);
-        }
-
-        if($config['encrypt'] == false) {
-            // The Cookies encryption is disabled.
-            return;
-        }
-
-        // Encrypt all Cookies present on the Response instance.
-        foreach ($response->headers->getCookies() as $key => $cookie)  {
-            if($key == 'PHPSESSID') {
-                // Leave alone the PHPSESSID.
-                continue;
-            }
-
-            // Create a new Cookie with the content encrypted.
-            $cookie = new SymfonyCookie(
-                $cookie->getName(),
-                Crypt::encrypt($cookie->getValue()),
-                $cookie->getExpiresTime(),
-                $cookie->getPath(),
-                $cookie->getDomain(),
-                $cookie->isSecure(),
-                $cookie->isHttpOnly()
-            );
-
-            $response->headers->setCookie($cookie);
-        }
-    }
-
-    /**
-     * Determine if the configuration odds hit the lottery.
-     *
-     * @param  array  $config
-     * @return bool
-     */
-    protected static function configHitsLottery(array $config)
-    {
-        return (mt_rand(1, $config['lottery'][1]) <= $config['lottery'][0]);
     }
 
     /**
@@ -413,7 +247,7 @@ class Session
         // Get the Session Store instance.
         $instance = static::getSessionStore();
 
-        // Call the non-static method from the Request instance.
+        // Call the non-static method from the Session Store instance.
         return call_user_func_array(array($instance, $method), $params);
     }
 }


### PR DESCRIPTION
This pull request introduce a split the Application finishing logic from **Support\Facades\Session** to **Support\Facades\App**.

To note that because the affected logic by this change is **internal used API**, there are **no public API changes or breaks**.