### PR TITLE
Improve Database\Connection and its configuration; update the SQL scripts

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -3,32 +3,51 @@
  * Database configuration
  *
  * @author David Carr - dave@daveismyname.com
- * @author Edwin Hoksberg - info@edwinhoksberg.nl
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0
  */
 
 use Core\Config;
 
+use PDO;
+
+
 /**
  * Setup the Database configuration.
  */
 Config::set('database', array(
-    'default' => array(
-        'driver'    => DB_TYPE,
-        'hostname'  => DB_HOST,
-        'database'  => DB_NAME,
-        'username'  => DB_USER,
-        'password'  => DB_PASS,
-        'prefix'    => PREFIX,
-        'charset'   => 'utf8',
-        'collation' => 'utf8_general_ci',
-    ),
-    'custom' => array(
-        'driver'    => 'sqlite',
-        'database'  => APPDIR .'Storage' .DS .'database.sqlite',
-        'prefix'    => PREFIX,
-        'charset'   => 'utf8',
-        'collation' => 'utf8_general_ci',
+    // The PDO Fetch Style.
+    'fetch' => PDO::FETCH_CLASS,
+
+    // The Default Database Connection Name.
+    'default' => 'mysql',
+
+    // The Database Connections.
+    'connections' => array(
+        'sqlite' => array(
+            'driver'    => 'sqlite',
+            'database'  => APPDIR .'Storage' .DS .'database.sqlite',
+            'prefix'    => '',
+        ),
+        'mysql' => array(
+            'driver'    => DB_TYPE,
+            'hostname'  => DB_HOST,
+            'database'  => DB_NAME,
+            'username'  => DB_USER,
+            'password'  => DB_PASS,
+            'prefix'    => PREFIX,
+            'charset'   => 'utf8',
+            'collation' => 'utf8_general_ci',
+        ),
+        'pgsql' => array(
+            'driver'   => 'pgsql',
+            'host'     => 'localhost',
+            'database' => 'database',
+            'username' => 'root',
+            'password' => '',
+            'charset'  => 'utf8',
+            'prefix'   => '',
+            'schema'   => 'public',
+        ),
     ),
 ));

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -77,7 +77,7 @@ class Welcome extends Controller
      * Return a translated string.
      * @return string
      */
-    protected function trans($str)
+    protected function trans($str, $code = LANGUAGE_CODE)
     {
         return $this->language->get($str, $this->code);
     }

--- a/scripts/nova_roles.sql
+++ b/scripts/nova_roles.sql
@@ -3,7 +3,7 @@
 -- http://www.phpmyadmin.net
 --
 -- Host: localhost
--- Generation Time: Jun 05, 2016 at 12:16 PM
+-- Generation Time: Jun 09, 2016 at 10:15 PM
 -- Server version: 10.0.25-MariaDB
 -- PHP Version: 5.6.22
 
@@ -44,8 +44,7 @@ INSERT INTO `nova_roles` (`id`, `name`, `slug`, `description`, `created_at`, `up
 (2, 'Administrator', 'administrator', 'Full access to create, edit, and update companies, and orders.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
 (3, 'Manager', 'manager', 'Ability to create new companies and orders, or edit and update any existing ones.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
 (4, 'Company Manager', 'company-manager', 'Able to manage the company that the user belongs to, including adding sites, creating new users and assigning licences.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
-(5, 'User', 'user', 'A standard user that can have a licence assigned to them. No administrative features.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
-(6, 'Guest', 'guest', 'The Role of an unauthenticated Visitor of the site.', '2016-06-05 10:47:13', '2016-06-05 10:54:12');
+(5, 'User', 'user', 'A standard user that can have a licence assigned to them. No administrative features.', '2016-06-05 01:48:00', '2016-06-05 01:48:00');
 
 --
 -- Indexes for dumped tables

--- a/scripts/nova_testing.sql
+++ b/scripts/nova_testing.sql
@@ -3,7 +3,7 @@
 -- http://www.phpmyadmin.net
 --
 -- Host: localhost
--- Generation Time: Jun 07, 2016 at 11:03 PM
+-- Generation Time: Jun 09, 2016 at 10:16 PM
 -- Server version: 10.0.25-MariaDB
 -- PHP Version: 5.6.22
 
@@ -186,8 +186,7 @@ INSERT INTO `nova_roles` (`id`, `name`, `slug`, `description`, `created_at`, `up
 (2, 'Administrator', 'administrator', 'Full access to create, edit, and update companies, and orders.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
 (3, 'Manager', 'manager', 'Ability to create new companies and orders, or edit and update any existing ones.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
 (4, 'Company Manager', 'company-manager', 'Able to manage the company that the user belongs to, including adding sites, creating new users and assigning licences.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
-(5, 'User', 'user', 'A standard user that can have a licence assigned to them. No administrative features.', '2016-06-05 01:48:00', '2016-06-05 01:48:00'),
-(6, 'Guest', 'guest', 'The Role of an unauthenticated Visitor of the site.', '2016-06-05 10:47:13', '2016-06-05 10:54:12');
+(5, 'User', 'user', 'A standard user that can have a licence assigned to them. No administrative features.', '2016-06-05 01:48:00', '2016-06-05 01:48:00');
 
 -- --------------------------------------------------------
 

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -140,8 +140,13 @@ class Connection
 
         $config = static::getConnectionConfig($name);
 
-        // Create the Connection instance and return it.
-        return static::$instances[$token] = new static($config);
+        // Create the Connection instance.
+        static::$instances[$name] = $connection = new static($config);
+
+        // Setup the Fetch Mode on Connection instance and return it.
+        $fetchMode = Config::get('database.fetch');
+
+        return $connection->setFetchMode($fetchModel);
     }
 
     /**

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -129,29 +129,50 @@ class Connection
      * @return \Database\Connection|null
      * @throws \Exception
      */
-    public static function getInstance($config = 'default')
+    public static function getInstance($name = null)
     {
-        $connection = (is_string($config) && ! empty($config)) ? $config : 'default';
-
-        // Prepare a Token for handling the Connection instances.
-        $token = md5($connection);
+        $name = $name ?: static::getDefaultConnection();
 
         // If there is already a Connection instantiated, return it.
-        if (isset(static::$instances[$token])) {
-            return static::$instances[$token];
+        if (isset(static::$instances[$name])) {
+            return static::$instances[$name];
         }
 
-        // Retrieve the configuration with the specified name.
-        $config = Config::get('database');
-
-        if (isset($config[$connection]) && ! empty($config[$connection])) {
-            $config = $config[$connection];
-        } else {
-            throw new \InvalidArgumentException("Connection '$connection' is not defined in your configuration");
-        }
+        $config = static::getConnectionConfig($name);
 
         // Create the Connection instance and return it.
         return static::$instances[$token] = new static($config);
+    }
+
+    /**
+     * Get the configuration for a Connection.
+     *
+     * @param  string  $name
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected static function getConnectionConfig($name)
+    {
+        $name = $name ?: static::getDefaultConnection();
+
+        $connections = Config::get('database.connections');
+
+        if (is_null($config = array_get($connections, $name))) {
+            throw new \InvalidArgumentException("Database [$name] not configured.");
+        }
+
+        return $config;
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public static function getDefaultConnection()
+    {
+        return Config::get('database.default');
     }
 
     /**

--- a/system/Database/DatabaseManager.php
+++ b/system/Database/DatabaseManager.php
@@ -41,7 +41,7 @@ class DatabaseManager
      * @param  \core\Application  $app
      * @return void
      */
-    public function __construct($app
+    public function __construct($app)
     {
         $this->app = $app;
     }

--- a/system/Database/Model.php
+++ b/system/Database/Model.php
@@ -20,7 +20,7 @@ class Model
      *
      * @var string
      */
-    protected $connection = 'default';
+    protected $connection = null;
 
     /**
      * The database connection instance.
@@ -59,17 +59,14 @@ class Model
      */
     public function __construct($connection = null, $basicSetup = false)
     {
-        if (! is_null($connection)) {
-            // Store the requested Connection name.
-            $this->connection = $connection;
-        }
-
         if(is_null($this->table)) {
             // There is not a Table name specified; try to auto-calculate it.
             $className = get_class($this);
 
             $this->table = Inflector::tableize(class_basename($className));
         }
+
+        $this->connection = $connection;
 
         if (! $basicSetup) {
             // Setup the Connection instance.

--- a/system/Database/ORM/Model.php
+++ b/system/Database/ORM/Model.php
@@ -42,7 +42,7 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
      *
      * @var string
      */
-    protected $connection = 'default';
+    protected $connection = null;
 
     /**
      * The table associated with the Model.
@@ -254,13 +254,8 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(array $attributes = array(), $connection = null)
+    public function __construct(array $attributes = array())
     {
-        if (! is_null($connection)) {
-            // Store the requested Connection name.
-            $this->connection = $connection;
-        }
-
         $this->bootIfNotBooted();
 
         $this->syncOriginal();

--- a/system/Helpers/Database.php
+++ b/system/Helpers/Database.php
@@ -8,6 +8,7 @@
 
 namespace Helpers;
 
+use Core\Config;
 use Database\Connection;
 
 use PDO;
@@ -48,15 +49,17 @@ class Database
      * @param  array $group
      * @return Helpers\Database
      */
-    public static function get($config = 'default')
+    public static function get($name = null)
     {
+        $name = $name ?: Config::get('database.default');
+
         // Check if the instance is the same.
-        if (isset(self::$instances[$config])) {
-            return self::$instances[$config];
+        if (isset(self::$instances[$name])) {
+            return self::$instances[$name];
         }
 
         // Set the Database into $instances to avoid any potential duplication.
-        return self::$instances[$config] = new static($config);
+        return self::$instances[$name] = new static($name);
     }
 
     /**


### PR DESCRIPTION
This pull request improve the logic on **Database\Connection** and make its configuration more versatile.

A typical Database configuration looks now as following:
```php
/**
 * Setup the Database configuration.
 */
Config::set('database', array(
    // The PDO Fetch Style.
    'fetch' => PDO::FETCH_CLASS,

    // The Default Database Connection Name.
    'default' => 'mysql',

    // The Database Connections.
    'connections' => array(
        'sqlite' => array(
            'driver'    => 'sqlite',
            'database'  => APPDIR .'Storage' .DS .'database.sqlite',
            'prefix'    => '',
        ),
        'mysql' => array(
            'driver'    => DB_TYPE,
            'hostname'  => DB_HOST,
            'database'  => DB_NAME,
            'username'  => DB_USER,
            'password'  => DB_PASS,
            'prefix'    => PREFIX,
            'charset'   => 'utf8',
            'collation' => 'utf8_general_ci',
        ),
        'pgsql' => array(
            'driver'   => 'pgsql',
            'host'     => 'localhost',
            'database' => 'database',
            'username' => 'root',
            'password' => '',
            'charset'  => 'utf8',
            'prefix'   => '',
            'schema'   => 'public',
        ),
    ),
));
```
To note that the connections are moved to their array with key called **connections** and now is possible to configure the **PDO Fetch Mode** and the **Default Connection**, which give the name of requested connection.

Also, in the was applied small changes on **Database API** Models to work properly with the changed Database\Connection. 

Finally, to note that **no API changes or breaks are introduced**.