### PR TITLE
Update ReminderServiceProvider.php

### DIFF
--- a/system/Auth/Reminders/ReminderServiceProvider.php
+++ b/system/Auth/Reminders/ReminderServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Auth\Reminders;
 
-use Auth\PasswordBroker;
+use Auth\Reminders\PasswordBroker;
 use Auth\Reminders\ReminderRepository;
 use Support\ServiceProvider;
 


### PR DESCRIPTION
Symfony\Component\Debug\Exception\FatalThrowableError thrown with message "Class 'Auth\PasswordBroker' not found"

Stacktrace:
#0 Symfony\Component\Debug\Exception\FatalThrowableError in /home/sitchi/web/matchme3.ge/system/Auth/Reminders/ReminderServiceProvider.php:46
