### PR TITLE
Disable the Settings when the Config Store is on Files Mode

### DIFF
--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -14,7 +14,6 @@ use Core\Controller;
 use Language;
 use Router;
 use Session;
-use Str;
 
 
 /**

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -14,6 +14,8 @@ use Core\Controller;
 use Language;
 use Router;
 use Session;
+use Str;
+
 
 /**
  * Sample controller showing a construct and 2 methods and their typical usage.

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -15,7 +15,6 @@ use Language;
 use Router;
 use Session;
 
-
 /**
  * Sample controller showing a construct and 2 methods and their typical usage.
  */

--- a/app/Modules/Settings/Views/Admin/Settings/Index.php
+++ b/app/Modules/Settings/Views/Admin/Settings/Index.php
@@ -11,6 +11,8 @@
 
 <?= Session::getMessages(); ?>
 
+<?php if (CONFIG_STORE == 'database') { ?>
+
 <form name='myForm' class="form-horizontal" action="<?= site_url('admin/settings'); ?>" method="POST">
 
 <div class="box box-default">
@@ -159,3 +161,14 @@
 <input type="hidden" name="csrfToken" value="<?= $csrfToken; ?>" />
 
 </form>
+
+<?php } else { ?>
+
+<div class="callout callout-info">
+    <?= __('The Settings are not available while the Config Store is on Files Mode.'); ?>
+</div>
+
+<?php } ?>
+
+</section>
+


### PR DESCRIPTION
This pull request disable the Settings given by the Settings Module, when the Config Store is on (native) Files Mode.