### PR TITLE
Implementation of Routing support for Implicit Controllers

### DIFF
--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -15,6 +15,7 @@ use Core\View;
 use Helpers\Hooks;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 use App;
 use Event;
@@ -250,6 +251,19 @@ abstract class Controller
     protected function getParams()
     {
         return $this->params;
+    }
+
+    /**
+     * Handle calls to missing methods on the controller.
+     *
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function missingMethod($parameters = array())
+    {
+        throw new NotFoundHttpException("Controller method not found.");
     }
 
     /**

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -121,7 +121,7 @@ class ControllerInspector
      */
     public function addUriWildcards($uri)
     {
-        return $uri.'(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any))))))))';
+        return $uri.'/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)))))))';
     }
 
 }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -121,7 +121,7 @@ class ControllerInspector
      */
     public function addUriWildcards($uri)
     {
-        return $uri .'/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)))))))';
+        return $uri .'(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any))))))))';
     }
 
 }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -121,7 +121,7 @@ class ControllerInspector
      */
     public function addUriWildcards($uri)
     {
-        return $uri.'/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)))))))';
+        return $uri .'/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)))))))';
     }
 
 }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -2,6 +2,8 @@
 
 namespace Routing;
 
+use Helpers\Inflector;
+
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -57,7 +59,7 @@ class ControllerInspector
     {
         if ($method->class == 'Core\Controller') return false;
 
-        return starts_with($method->name, $this->verbs);
+        return str_starts_with($method->name, $this->verbs);
     }
 
     /**
@@ -96,7 +98,7 @@ class ControllerInspector
      */
     public function getVerb($name)
     {
-        return head(explode('_', snake_case($name)));
+        return head(explode('_', Inflector::tableize($name)));
     }
 
     /**
@@ -108,7 +110,7 @@ class ControllerInspector
      */
     public function getPlainUri($name, $prefix)
     {
-        return $prefix .'/' .implode('-', array_slice(explode('_', snake_case($name)), 1));
+        return $prefix .'/' .implode('-', array_slice(explode('_', Inflector::tableize($name)), 1));
     }
 
     /**

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Routing;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+
+class ControllerInspector
+{
+    /**
+     * An array of HTTP verbs.
+     *
+     * @var array
+     */
+    protected $verbs = array('any', 'get', 'post', 'put', 'patch', 'delete', 'head', 'options');
+
+    /**
+     * Get the routable methods for a controller.
+     *
+     * @param  string  $controller
+     * @param  string  $prefix
+     * @return array
+     */
+    public function getRoutable($controller, $prefix)
+    {
+        $routable = array();
+
+        $reflection = new ReflectionClass($controller);
+
+        $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        foreach ($methods as $method) {
+            if ($this->isRoutable($method)) {
+                $name = $method->name;
+
+                $data = $this->getMethodData($method, $prefix);
+
+                $routable[$name][] = $data;
+
+                if ($data['plain'] == $prefix .'/index') {
+                    $routable[$name][] = $this->getIndexData($data, $prefix);
+                }
+            }
+        }
+
+        return $routable;
+    }
+
+    /**
+     * Determine if the given controller method is routable.
+     *
+     * @param  \ReflectionMethod  $method
+     * @return bool
+     */
+    public function isRoutable(ReflectionMethod $method)
+    {
+        if ($method->class == 'Nova\Routing\Controller') return false;
+
+        return starts_with($method->name, $this->verbs);
+    }
+
+    /**
+     * Get the method data for a given method.
+     *
+     * @param  \ReflectionMethod  $method
+     * @param  string  $prefix
+     * @return array
+     */
+    public function getMethodData(ReflectionMethod $method, $prefix)
+    {
+        $verb = $this->getVerb($name = $method->name);
+
+        $uri = $this->addUriWildcards($plain = $this->getPlainUri($name, $prefix));
+
+        return compact('verb', 'plain', 'uri');
+    }
+
+    /**
+     * Get the routable data for an index method.
+     *
+     * @param  array   $data
+     * @param  string  $prefix
+     * @return array
+     */
+    protected function getIndexData($data, $prefix)
+    {
+        return array('verb' => $data['verb'], 'plain' => $prefix, 'uri' => $prefix);
+    }
+
+    /**
+     * Extract the verb from a controller action.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function getVerb($name)
+    {
+        return head(explode('_', snake_case($name)));
+    }
+
+    /**
+     * Determine the URI from the given method name.
+     *
+     * @param  string  $name
+     * @param  string  $prefix
+     * @return string
+     */
+    public function getPlainUri($name, $prefix)
+    {
+        return $prefix .'/' .implode('-', array_slice(explode('_', snake_case($name)), 1));
+    }
+
+    /**
+     * Add wildcards to the given URI.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    public function addUriWildcards($uri)
+    {
+        return $uri.'(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any))))))))';
+    }
+
+}

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -55,7 +55,7 @@ class ControllerInspector
      */
     public function isRoutable(ReflectionMethod $method)
     {
-        if ($method->class == 'Nova\Routing\Controller') return false;
+        if ($method->class == 'Core\Controller') return false;
 
         return starts_with($method->name, $this->verbs);
     }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -288,7 +288,6 @@ class Router
      *
      * @param  string  $uri
      * @param  string  $controller
-     * @param  array   $names
      * @return void
      */
     public function controller($uri, $controller)

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -15,6 +15,7 @@ use Events\Dispatcher;
 use Helpers\Inflector;
 use Http\Request;
 //use Http\Response;
+use Routing\ControllerInspector;
 use Routing\Route;
 use Support\Facades\Facade;
 
@@ -35,6 +36,13 @@ use Response;
  */
 class Router
 {
+    /**
+     * The controller inspector instance.
+     *
+     * @var \Routing\ControllerInspector
+     */
+    protected $inspector;
+
     /**
      * Array of routes
      *
@@ -145,6 +153,16 @@ class Router
     }
 
     /**
+     * Get a Controller Inspector instance.
+     *
+     * @return \Routing\ControllerInspector
+     */
+    public function getInspector()
+    {
+        return $this->inspector ?: $this->inspector = new ControllerInspector();
+    }
+
+    /**
      * Return the available Routes.
      *
      * @return Route[]
@@ -250,6 +268,56 @@ class Router
         $this->register('get',                 $basePath .'/(:any)/edit', $controller .'@edit');
         $this->register(array('put', 'patch'), $basePath .'/(:any)',      $controller .'@update');
         $this->register('delete',              $basePath .'/(:any)',      $controller .'@delete');
+    }
+
+    /**
+     * Register an array of controllers with wildcard routing.
+     *
+     * @param  array  $controllers
+     * @return void
+     */
+    public function controllers(array $controllers)
+    {
+        foreach ($controllers as $uri => $name) {
+            $this->controller($uri, $name);
+        }
+    }
+
+    /**
+     * Route a Controller to a URI with wildcard routing.
+     *
+     * @param  string  $uri
+     * @param  string  $controller
+     * @param  array   $names
+     * @return void
+     */
+    public function controller($uri, $controller)
+    {
+        $prepended = $controller;
+
+        // Adjust the Controller's namespace if we are on a Group.
+        if (! empty($this->groupStack)) {
+            $lastGroup = end($this->groupStack);
+
+            $namespace = array_get($lastGroup, 'namespace');
+
+            if (! empty($namespace)) {
+                $prepended = $namespace .'\\' .ltrim($controller, '\\');
+            }
+        }
+
+        // Retrieve the Controller routable methods and associated information.
+        $routable = $this->getInspector()->getRoutable($prepended, $uri);
+
+        foreach ($routable as $method => $routes) {
+            foreach ($routes as $route) {
+                $action = array('uses' => $controller .'@' .$method);
+
+                $this->register($route['verb'], $route['uri'], $action);
+            }
+        }
+
+        $this->register('ANY', $uri .'/(:all)', $controller .'@missingMethod');
     }
 
     /**


### PR DESCRIPTION
This pull request allows you to easily define a single route to handle every action in a controller. 

First, define the route using the Route::controller method:
```php
Route::controller('users', 'App\Controllers\Users');
```

The `Route::controller()` method accepts two arguments. The first is the base URI the controller handles, while the second is the class name of the Controller. Next, just add methods to your Controller, prefixed with the HTTP verb they respond to:
```php
class App\Controllers;

use Core\Controller;

class Users extends Controller 
{
    /**
     * Call the parent construct
     */
    public function __construct()
    {
        parent::__construct();
    }

    public function getIndex()
    {
        //
    }

    public function postProfile()
    {
        //
    }

    public function anyLogin()
    {
        //
    }

}
```
The index methods will respond to the root URI handled by the Controller, which, in this case, is users.

If your Controller action contains multiple words, you may access the action using "dash" syntax in the URI. For example, the following controller action on our **App\Controllers\Users** would respond to the users/admin-profile URI:
```php
public function getAdminProfile() {}
```