### PR TITLE
Implementation of Global Routing Filters and move the Filters to a Events based approach

### DIFF
--- a/app/Filters.php
+++ b/app/Filters.php
@@ -6,6 +6,27 @@
  * @version 3.0
  */
 
+/*
+|--------------------------------------------------------------------------
+| Application & Route Filters
+|--------------------------------------------------------------------------
+|
+| Below you will find the "before" and "after" events for the application
+| which may be used to do any work before or after a request into your
+| application. Here you may also register your custom route filters.
+|
+*/
+
+App::before(function($request)
+{
+    //
+});
+
+
+App::after(function($request, $response)
+{
+    //
+});
 
 /** Define Route Filters. */
 

--- a/system/Foundation/Application.php
+++ b/system/Foundation/Application.php
@@ -432,6 +432,28 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
     }
 
     /**
+     * Register a "before" application filter.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public function before($callback)
+    {
+        return $this['router']->before($callback);
+    }
+
+    /**
+     * Register an "after" application filter.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public function after($callback)
+    {
+        return $this['router']->after($callback);
+    }
+
+    /**
      * Register a "finish" application filter.
      *
      * @param  Closure|string  $callback

--- a/system/Routing/ControllerDispatcher.php
+++ b/system/Routing/ControllerDispatcher.php
@@ -32,11 +32,11 @@ class ControllerDispatcher
      * @param  \Illuminate\Container\Container  $container
      * @return void
      */
-    public function __construct(RouteFiltererInterface $filterer,
-                                Container $container = null)
+    public function __construct(RouteFiltererInterface $filterer, Container $container = null)
     {
         $this->filterer = $filterer;
-        $this->container = $container;
+
+        $this->container = $container ?: new Container();
     }
 
     /**
@@ -76,7 +76,7 @@ class ControllerDispatcher
      */
     protected function call($instance, $route, $method)
     {
-        $parameters = $route->getParams();
+        $parameters = $route->parametersWithoutNulls();
 
         return $instance->execute($method, $parameters);
     }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -49,7 +49,7 @@ class Route
     /**
      * @var array The matched Route parameters
      */
-    private $params = array();
+    private $parameters = array();
 
     /**
      * @var string Matching regular expression
@@ -323,7 +323,7 @@ class Route
                 }
             }
 
-            $this->params = $matches;
+            $this->parameters = $matches;
 
             // Also, store the compiled regex.
             $this->regex = $regex;
@@ -345,6 +345,34 @@ class Route
         $this->pattern = trim($prefix, '/') .'/' .trim($this->pattern, '/');
 
         return $this;
+    }
+
+    /**
+     * Get the key / value list of parameters for the route.
+     *
+     * @return array
+     *
+     * @throws \LogicException
+     */
+    public function parameters()
+    {
+        return array_map(function($value)
+        {
+            return is_string($value) ? rawurldecode($value) : $value;
+        }, $this->parameters);
+    }
+
+    /**
+     * Get the key / value list of parameters without null values.
+     *
+     * @return array
+     */
+    public function parametersWithoutNulls()
+    {
+        return array_filter($this->parameters(), function($value)
+        {
+            return ! is_null($value);
+        });
     }
 
     // Some Getters
@@ -418,7 +446,7 @@ class Route
      */
     public function getParams()
     {
-        return $this->params;
+        return $this->parameters();
     }
 
     /**

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -348,6 +348,18 @@ class Route
     }
 
     /**
+     * Get a given parameter from the route.
+     *
+     * @param  string  $name
+     * @param  mixed   $default
+     * @return string
+     */
+    public function parameter($name, $default = null)
+    {
+        return array_get($this->parameters(), $name, $default);
+    }
+
+    /**
      * Get the key / value list of parameters for the route.
      *
      * @return array

--- a/system/Routing/RouteFiltererInterface.php
+++ b/system/Routing/RouteFiltererInterface.php
@@ -14,4 +14,15 @@ interface RouteFiltererInterface
      */
     public function filter($name, $callback);
 
+    /**
+     * Call the given route filter.
+     *
+     * @param  string  $filter
+     * @param  array  $parameters
+     * @param  \Nova\Routing\Route  $route
+     * @param  \Nova\Http\Request  $request
+     * @param  \Nova\Http\Response|null $response
+     * @return mixed
+     */
+    public function callRouteFilter($filter, $parameters, $route, $request, $response = null);
 }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -40,7 +40,7 @@ class Router implements RouteFiltererInterface
      * @var bool
      */
     protected $filtering = true;
-    
+
     /**
      * The route collection instance.
      *
@@ -394,21 +394,6 @@ class Router implements RouteFiltererInterface
      */
     protected function createRoute($methods, $route, $action)
     {
-        // Prepare the route Methods.
-        if (is_string($methods) && (strtolower($methods) == 'any')) {
-            $methods = static::$methods;
-        } else {
-            $methods = array_map('strtoupper', is_array($methods) ? $methods : array($methods));
-
-            // Ensure the requested Methods are valid ones.
-            $methods = array_intersect($methods, static::$methods);
-        }
-
-        if (empty($methods)) {
-            // If there are no valid Methods defined, fallback to ANY.
-            $methods = static::$methods;
-        }
-
         // Prepare the Route PATTERN.
         $pattern = ltrim($route, '/');
 
@@ -520,11 +505,11 @@ class Router implements RouteFiltererInterface
      * @param  \Http\Request  $request
      * @return mixed
      */
-    public function callRouteFilter($filter, $parameters, Route $route, Request $request)
+    public function callRouteFilter($filter, $parameters, $route, $request, $response = null)
     {
         if ( ! $this->filtering) return null;
 
-        $data = array_merge(array($route, $request), $parameters);
+        $data = array_merge(array($route, $request, $response), $parameters);
 
         return $this->events->until('router.filter: '.$filter, $this->cleanFilterParameters($data));
     }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -551,12 +551,12 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     {
         $this->currentRequest = $request;
 
-        //
+        // Asset Files Dispatching.
         $response = $this->dispatchAssetFile($request);
 
         if (! is_null($response)) return $response;
 
-        //
+        // Request Dispatching to Routes.
         $response = $this->callFilter('before', $request);
 
         if (is_null($response)) {

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -58,6 +58,13 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     protected $currentRoute = null;
 
     /**
+     * Default Route, usually the Catch-All one.
+     *
+     * @var Route $defaultRoute
+     */
+    private $defaultRoute = null;
+
+    /**
      * The event dispatcher instance.
      *
      * @var \Events\Dispatcher
@@ -105,13 +112,6 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      * @var array $groupStack
      */
     private $groupStack = array();
-
-    /**
-     * Default Route, usually the Catch-All one.
-     *
-     * @var Route $defaultRoute
-     */
-    private $defaultRoute = null;
 
     /**
      * An array of HTTP request Methods.

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -369,19 +369,34 @@ class Router implements RouteFiltererInterface
     }
 
     /**
-     * Maps a Method and URL pattern to a Callback.
+     * Add a route to the underlying route collection.
      *
-     * @param string|array $method HTTP metod(s) to match
-     * @param string       $route URL pattern to match
-     * @param callback     $action Callback object
+     * @param  array|string  $methods
+     * @param  string  $uri
+     * @param  \Closure|array|string  $action
+     * @return \Routing\Route
      */
-    protected function addRoute($method, $route, $action = null)
+    protected function addRoute($methods, $route, $action = null)
+    {
+        // Add the current Route instance to the known Routes list.
+        return $this->routes->add($this->createRoute($methods, $route, $action));
+    }
+
+    /**
+     * Create a new route instance.
+     *
+     * @param  array|string  $methods
+     * @param  string  $route
+     * @param  mixed   $action
+     * @return \Routing\Route
+     */
+    protected function createRoute($methods, $route, $action)
     {
         // Prepare the route Methods.
-        if (is_string($method) && (strtolower($method) == 'any')) {
+        if (is_string($methods) && (strtolower($methods) == 'any')) {
             $methods = static::$methods;
         } else {
-            $methods = array_map('strtoupper', is_array($method) ? $method : array($method));
+            $methods = array_map('strtoupper', is_array($methods) ? $methods : array($methods));
 
             // Ensure the requested Methods are valid ones.
             $methods = array_intersect($methods, static::$methods);
@@ -424,10 +439,20 @@ class Router implements RouteFiltererInterface
         }
 
         // Create a Route instance.
-        $route = new Route($methods, $pattern, $action);
+        return $this->newRoute($methods, $pattern, $action);
+    }
 
-        // Add the current Route instance to the known Routes list.
-        $this->routes->add($route);
+    /**
+     * Create a new Route object.
+     *
+     * @param  array|string  $methods
+     * @param  string  $uri
+     * @param  mixed   $action
+     * @return \Routing\Route
+     */
+    protected function newRoute($methods, $uri, $action)
+    {
+        return new Route($methods, $uri, $action);
     }
 
     /**

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -666,7 +666,7 @@ class Router implements RouteFiltererInterface
         // Call the Route's associated Filters.
         $response = $this->callRouteFilters($route, $request);
 
-        if(! $response instanceof SymfonyResponse) {
+        if (is_null($response)) {
             $response = $route->run();
         }
 
@@ -679,7 +679,7 @@ class Router implements RouteFiltererInterface
      * @param  \Http\Request  $request
      * @return \Routing\Route
      */
-    protected function findRoute($request)
+    protected function findRoute(Request $request)
     {
         return $this->currentRoute = $this->routes->match($request);
     }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -492,7 +492,7 @@ class Router implements RouteFiltererInterface
             $callback = $this->filters[$filter];
 
             // If the Callback returns a Response instance, the Filtering will be stopped.
-            if (is_callable($callback)) {
+            if (! is_callable($callback)) {
                 continue;
             }
 


### PR DESCRIPTION
This pull request introduce the implementation of Global Routing Filters and move the Filters to a Events based approach.

The design now permit assigning multiple Filter commands to the same filter, assigning also Global Filters, via `App::before()` and `App::after()`.

No API changes, but introducing new small features. 