### PR TITLE
Split the base processing from Core\Controller to Routing\Controller, for RESTful optimization

### DIFF
--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -42,6 +42,7 @@ abstract class Controller extends BaseController
      */
     public $language;
 
+    
     /**
      * On the initial run, create an instance of the config class and the view class.
      */

--- a/system/Routing/AssetFileDispatcher.php
+++ b/system/Routing/AssetFileDispatcher.php
@@ -37,28 +37,28 @@ class AssetFileDispatcher
 
         if (! in_array($request->method(), array('GET', 'HEAD'))) {
             // No allowed HTTP method on the Request.
-            $filePath = null;
+            $path = null;
         } else if (preg_match('#^assets/(.*)$#i', $uri, $matches)) {
-            $filePath = ROOTDIR .'assets' .DS .$matches[1];
+            $path = ROOTDIR .'assets' .DS .$matches[1];
         } else if (preg_match('#^(templates|modules)/([^/]+)/assets/([^/]+)/(.*)$#i', $uri, $matches)) {
             $module = Inflector::classify($matches[2]);
 
             if(strtolower($matches[1]) == 'modules') {
                 // A Module Asset file.
-                $filePath = $this->getModuleAssetPath($module, $matches[3], $matches[4]);
+                $path = $this->getModuleAssetPath($module, $matches[3], $matches[4]);
             } else {
                 // A Template Asset file.
-                $filePath = $this->getTemplateAssetPath($module, $matches[3], $matches[4]);
+                $path = $this->getTemplateAssetPath($module, $matches[3], $matches[4]);
             }
         } else {
             // The URI is not a Asset File path.
-            $filePath = null;
+            $path = null;
         }
 
         //
         // Serve the specified Asset File.
-        if (! empty($filePath)) {
-            $response = $this->serveFile($filePath);
+        if (! empty($path)) {
+            $response = $this->serveFile($path);
         } else {
             $response = null;
         }
@@ -126,15 +126,15 @@ class AssetFileDispatcher
     /**
      * Serve a File.
      *
-     * @param string $filePath
+     * @param string $path
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function serveFile($filePath)
+    public function serveFile($path)
     {
-        if (! file_exists($filePath)) {
+        if (! file_exists($path)) {
             return new Response('', 404);
-        } else if (! is_readable($filePath)) {
+        } else if (! is_readable($path)) {
             return new Response('', 403);
         }
 
@@ -144,7 +144,7 @@ class AssetFileDispatcher
         // Even the Symfony's HTTP Foundation have troubles with the CSS and JS files?
         //
         // Hard coding the correct mime types for presently needed file extensions.
-        switch ($fileExt = pathinfo($filePath, PATHINFO_EXTENSION)) {
+        switch ($fileExt = pathinfo($path, PATHINFO_EXTENSION)) {
             case 'css':
                 $contentType = 'text/css';
                 break;
@@ -152,12 +152,12 @@ class AssetFileDispatcher
                 $contentType = 'application/javascript';
                 break;
             default:
-                $contentType = $guesser->guess($filePath);
+                $contentType = $guesser->guess($path);
                 break;
         }
 
         // Create a BinaryFileResponse instance.
-        $response = new BinaryFileResponse($filePath, 200, array(), true, 'inline', true, false);
+        $response = new BinaryFileResponse($path, 200, array(), true, 'inline', true, false);
 
         // Set the Content type.
         $response->headers->set('Content-Type', $contentType);

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Controller - base controller
+ *
+ * @author David Carr - dave@novaframework.com
+ * @version 3.0
+ */
+
+namespace Routing;
+
+use Core\Config;
+use Http\Response;
+
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Event;
+
+
+/**
+ * Core controller, all other controllers extend this base controller.
+ */
+abstract class Controller
+{
+    /**
+     * The requested Method by Router.
+     *
+     * @var string|null
+     */
+    private $method = null;
+
+    /**
+     * The parameters given by Router.
+     *
+     * @var array
+     */
+    private $params = array();
+
+    
+    /**
+     * Create a new Controller instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the Controller Method
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throw \Exception
+     */
+    public function execute($method, $params = array())
+    {
+        // Initialise the Controller's variables.
+        $this->method = $method;
+        $this->params = $params;
+
+        // Notify the interested Listeners about the iminent Controller's execution.
+        Event::fire('framework.controller.executing', array($this, $method, $params));
+
+        // Before the Action execution stage.
+        $response = $this->before();
+
+        // When the Before Stage do not return a Symfony Response, execute the requested
+        // Method with the given arguments, capturing its returned value on our response.
+        if (! $response instanceof SymfonyResponse) {
+            $response = call_user_func_array(array($this, $method), $params);
+        }
+
+        // After the Action execution stage.
+        $this->after($response);
+
+        // Do the final post-processing stage and return the response.
+        return $this->processResponse($response);
+    }
+
+    /**
+     * Create from the given result a Response instance and send it.
+     *
+     * @param mixed  $response
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function processResponse($response)
+    {
+        if (! $response instanceof SymfonyResponse) {
+            $response = new Response($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Method automatically invoked before the current Action, stopping the flight
+     * when it returns false. This Method is supposed to be overriden for using it.
+     */
+    protected function before()
+    {
+        // Return true to continue the processing.
+        return true;
+    }
+
+    /**
+     * This method automatically invokes after the current Action and is supposed
+     * to be overriden for using it.
+     *
+     * Note that the Action's returned value is passed to this Method as parameter.
+     */
+    protected function after($result)
+    {
+        //
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * Handle calls to missing methods on the controller.
+     *
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function missingMethod($parameters = array())
+    {
+        throw new NotFoundHttpException("Controller method not found.");
+    }
+
+    /**
+     * Handle calls to missing methods on the controller.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        throw new \BadMethodCallException("Method [$method] does not exist.");
+    }
+
+}

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -17,9 +17,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Event;
 
 
-/**
- * Core controller, all other controllers extend this base controller.
- */
 abstract class Controller
 {
     /**
@@ -36,7 +33,7 @@ abstract class Controller
      */
     private $params = array();
 
-    
+
     /**
      * Create a new Controller instance.
      */

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -74,18 +74,14 @@ abstract class Controller
     }
 
     /**
-     * Create from the given result a Response instance and send it.
+     * Process the response and return it.
      *
      * @param mixed  $response
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return mixed
      */
     protected function processResponse($response)
     {
-        if (! $response instanceof SymfonyResponse) {
-            $response = new Response($response);
-        }
-
         return $response;
     }
 

--- a/system/Routing/ControllerDispatcher.php
+++ b/system/Routing/ControllerDispatcher.php
@@ -53,7 +53,9 @@ class ControllerDispatcher
     {
         $instance = $this->makeController($controller);
 
-        return $this->call($instance, $route, $method);
+        $parameters = $route->parameters();
+
+        return $instance->execute($method, $parameters);
     }
 
     /**
@@ -65,21 +67,6 @@ class ControllerDispatcher
     protected function makeController($controller)
     {
         return $this->container->make($controller);
-    }
-
-    /**
-     * Call the given controller instance method.
-     *
-     * @param  \Routing\Controller  $instance
-     * @param  \Routing\Route  $route
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function call($instance, $route, $method)
-    {
-        $parameters = $route->parametersWithoutNulls();
-
-        return $instance->execute($method, $parameters);
     }
 
 }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -57,7 +57,9 @@ class ControllerInspector
      */
     public function isRoutable(ReflectionMethod $method)
     {
-        if (($method->class == 'Routing\Controller') || ($className == 'Core\Controller')) return false;
+        $className = $method->class;
+
+        if (($className == 'Routing\Controller') || ($className == 'Core\Controller')) return false;
 
         return str_starts_with($method->name, $this->verbs);
     }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -57,7 +57,7 @@ class ControllerInspector
      */
     public function isRoutable(ReflectionMethod $method)
     {
-        if ($method->class == 'Core\Controller') return false;
+        if (($method->class == 'Routing\Controller') || ($className == 'Core\Controller')) return false;
 
         return str_starts_with($method->name, $this->verbs);
     }


### PR DESCRIPTION
This pull request split the base processing from Core\Controller to Routing\Controller, for RESTful optimization.

The new **Routing\Controller** have no theming support, perfect for Controllers which do not generate pages, while **Core\Controller** continue to have support for theming, as usual.

No API changes there, good for a micro version release.