### PR TITLE
Accept any type of response from Before Stage on Routing\Controller

### DIFF
--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -42,7 +42,7 @@ abstract class Controller extends BaseController
      */
     public $language;
 
-    
+
     /**
      * On the initial run, create an instance of the config class and the view class.
      */
@@ -93,8 +93,10 @@ abstract class Controller extends BaseController
             }
 
             // Create a Response instance from gathered information and return it.
-            return new Response($content, 200, $headers);
+            $response = new Response($content, 200, $headers);
         }
+
+        return $response;
     }
 
     /**

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -60,9 +60,8 @@ abstract class Controller
         // Before the Action execution stage.
         $response = $this->before();
 
-        // When the Before Stage do not return a Symfony Response, execute the requested
-        // Method with the given arguments, capturing its returned value on our response.
-        if (! $response instanceof SymfonyResponse) {
+        // When the Before Stage return a null Response, execute the requested Action.
+        if (is_null($response)) {
             $response = call_user_func_array(array($this, $method), $params);
         }
 
@@ -86,13 +85,12 @@ abstract class Controller
     }
 
     /**
-     * Method automatically invoked before the current Action, stopping the flight
-     * when it returns false. This Method is supposed to be overriden for using it.
+     * This method automatically invokes before the current Action and is supposed
+     * to be overriden for using it.
      */
     protected function before()
     {
-        // Return true to continue the processing.
-        return true;
+        //
     }
 
     /**


### PR DESCRIPTION
This pull request introduce a small change on Controller's Middleware behavior, being accepted any type of response from Before Stage.

Basically, the Controller's Action will be executed only when Before Stage return a null response, then permitting to `before()` to return any valid response, for example, a string, a View instance, etc.

No API changes, good for a micro version release.