### PR TITLE
Unify the Named and Unnamed Routes compilation on Routing

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -9,7 +9,6 @@ use Helpers\Password;
 use Helpers\Url;
 
 use App;
-use Config;
 use Event;
 use Validator;
 use Input;
@@ -29,15 +28,6 @@ use DB;
 */
 class Demo extends Controller
 {
-    const REGEX_DELIMITER = '#';
-
-    /**
-     * This string defines the characters that are automatically considered separators in front of
-     * optional placeholders (with default and no static text following). Such a single separator
-     * can be left out together with the optional placeholder from matching and generating URLs.
-     */
-    const SEPARATORS = '/,;.:-_~+*=@|';
-
     /**
      * Define Index method
      */

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -29,13 +29,18 @@ Router::any('demo/paginate',            'App\Controllers\Demo@paginate');
 Router::any('demo/cache',               'App\Controllers\Demo@cache');
 
 //Router::any('demo/request(/(:any)(/(:any)(/(:all))))', 'App\Controllers\Demo@request');
-Router::any('demo/request/{param1?}/{param2?}/{slug:.*:?}', 'App\Controllers\Demo@request');
+Router::any('demo/request/{param1?}/{param2?}/{slug?}', 'App\Controllers\Demo@request')->where('slug', '.*');
 
-//Router::any('demo/test(/(:any)(/(:any)(/(:any)(/(:all)))))',, array(
-Router::any('demo/test/{param1?}/{param2?}/{param3?}/{slug:.*:?}', array(
+/*
+Router::any('demo/test(/(:any)(/(:any)(/(:any)(/(:all)))))', array(
     'before' => 'test',
     'uses'   => 'App\Controllers\Demo@test'
 ));
+*/
+Router::any('demo/test/{param1?}/{param2?}/{param3?}/{slug?}', array(
+    'before' => 'test',
+    'uses'   => 'App\Controllers\Demo@test'
+))->where('slug', '.*');
 
 // The Framework's Language Changer.
 //Router::any('language/(:any)', array(

--- a/system/Routing/RouteCollection.php
+++ b/system/Routing/RouteCollection.php
@@ -38,13 +38,13 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function add(Route $route)
     {
-        $patern = $route->getPattern();
+        $uri = $route->getUri();
 
         foreach ($route->methods() as $method) {
-            $this->routes[$method][$patern] = $route;
+            $this->routes[$method][$uri] = $route;
         }
 
-        $this->allRoutes[$method .$patern] = $route;
+        $this->allRoutes[$method .$uri] = $route;
 
         return $route;
     }

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -398,8 +398,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      */
     protected function createRoute($methods, $route, $action)
     {
-        // Prepare the Route PATTERN.
-        $pattern = ltrim($route, '/');
+        // Prepare the Route URI.
+        $uri = trim($route, '/');
+
+        $uri = ! empty($uri) ? $uri : '/';
 
         // Pre-process the Action information.
         if (! is_array($action)) $action = array('uses' => $action);
@@ -428,7 +430,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
         }
 
         // Create a Route instance.
-        return $this->newRoute($methods, $pattern, $action);
+        return $this->newRoute($methods, $uri, $action);
     }
 
     /**


### PR DESCRIPTION
This pull request introduce on Routing a set of educated Route compilers which manage to give the same pattern for Routes matching for both Named and Unnamed Parameters.

To be read: the Routes matching will always give you named parameters, but in the case of Unnamed Parameters they will be named like "paramX", where X is is a number.

In other hand, the Named Parameters adopt the Nova 4 style for custom patterns - via **where()**s, examples given.

NO API Breaks, just some changes on syntax of the Named Parameters, but who use that yet, excluding me?