### PR TITLE
Rename the property 'pattern' as 'regex' on Routing\Route and improve Routing\RouteCompiler

### DIFF
--- a/app/Controllers/Demo.php
+++ b/app/Controllers/Demo.php
@@ -84,14 +84,14 @@ class Demo extends Controller
         });
 
         //
-        $pattern = $route->compileRoute();
+        $pattern = $route->compileRoute(true);
 
         $content .= '<pre>' .htmlspecialchars($pattern) .'</pre>';
 
         //
         $request = Request::instance();
 
-        if ($route->matches($request)) {
+        if ($route->matches($request, true, true)) {
             $content .= '<pre>' .var_export($route->parameters(), true) .'</pre>';
         }
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -125,9 +125,9 @@ class Route
             return false;
         }
 
-        // Compile the Route pattern for matching.
+        // Compile and retrieve the Route regex for matching.
         $regex = $this->compileRoute();
-        
+
         // Attempt to match the Request URI to the Route pattern.
         if (preg_match($regex, $request->path(), $matches) === 1) {
             $params = array();

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -138,10 +138,11 @@ class Route
                     continue;
                 }
 
+                // A named parameter found.
                 $params[$key] = $value;
             }
 
-            // Store the Route parameters.
+            // Store the Route parameters, also marking this Route as bound.
             $this->parameters = $params;
 
             return true;

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -121,7 +121,7 @@ class Route
     public function matches(Request $request, $includingMethod = true)
     {
         // Compile the Route pattern for matching.
-        $this->compileRoute();
+        $regex = $this->compileRoute();
 
         // Attempt to match the Route Method if it is requested.
         if ($includingMethod && ! in_array($request->method(), $this->methods)) {
@@ -129,7 +129,7 @@ class Route
         }
 
         // Attempt to match the Request URI to the Route pattern.
-        if (preg_match($this->regex(), $request->path(), $matches) === 1) {
+        if (preg_match($regex, $request->path(), $matches) === 1) {
             $params = array();
 
             // Walk over matches, looking for named parameters need to be stored.

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -120,14 +120,14 @@ class Route
      */
     public function matches(Request $request, $includingMethod = true)
     {
-        // Compile the Route pattern for matching.
-        $regex = $this->compileRoute();
-
         // Attempt to match the Route Method if it is requested.
         if ($includingMethod && ! in_array($request->method(), $this->methods)) {
             return false;
         }
 
+        // Compile the Route pattern for matching.
+        $regex = $this->compileRoute();
+        
         // Attempt to match the Request URI to the Route pattern.
         if (preg_match($regex, $request->path(), $matches) === 1) {
             $params = array();

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -62,11 +62,11 @@ class Route
     protected $parameterNames;
 
     /**
-     * The compiled pattern the Route responds to.
+     * The compiled regex the Route responds to.
      *
      * @var string
      */
-    private $pattern;
+    private $regex;
 
     /**
      * Constructor.
@@ -129,7 +129,7 @@ class Route
         }
 
         // Attempt to match the Request URI to the Route pattern.
-        if (preg_match($this->pattern(), $request->path(), $matches) === 1) {
+        if (preg_match($this->regex(), $request->path(), $matches) === 1) {
             $params = array();
 
             // Walk over matches, looking for named parameters need to be stored.
@@ -159,16 +159,16 @@ class Route
 
         if (preg_match('#\(:\w+\)#', $this->uri) === 1) {
             // The Route pattern contains Unnamed Parameters.
-            $this->pattern = $compiler->compileLegacyRoute($this->uri);
+            $this->regex = $compiler->compileLegacyRoute($this->uri);
         } else {
             $optionals = $this->extractOptionalParameters();
 
             $uri = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
 
-            $this->pattern = $compiler->compileRoute($uri, $optionals);
+            $this->regex = $compiler->compileRoute($uri, $optionals);
         }
 
-        return $this->pattern;
+        return $this->regex;
     }
 
     /**
@@ -693,9 +693,9 @@ class Route
      *
      * @return string|null
      */
-    public function getPattern()
+    public function getRegex()
     {
-        return $this->pattern();
+        return $this->regex();
     }
 
     /**
@@ -703,10 +703,10 @@ class Route
      *
      * @return string|null
      */
-    public function pattern()
+    public function regex()
     {
-        if (isset($this->pattern)) return $this->pattern;
+        if (isset($this->regex)) return $this->regex;
 
-        throw new \LogicException("Route pattern is not compiled.");
+        throw new \LogicException("Route regex is not compiled.");
     }
 }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -134,9 +134,11 @@ class Route
 
             // Walk over matches, looking for named parameters need to be stored.
             foreach ($matches as $key => $value) {
-                if (is_string($key)) {
-                    $params[$key] = $value;
+                if (! is_string($key)) {
+                    continue;
                 }
+
+                $params[$key] = $value;
             }
 
             // Store the Route parameters.

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -128,7 +128,7 @@ class Route
         // Compile and retrieve the Route regex for matching.
         $regex = $this->compileRoute();
 
-        // Attempt to match the Request URI to the Route pattern.
+        // Attempt to match the Request URI to the Route regex.
         if (preg_match($regex, $request->path(), $matches) === 1) {
             $params = array();
 

--- a/system/Routing/RouteCompiler.php
+++ b/system/Routing/RouteCompiler.php
@@ -185,7 +185,7 @@ class RouteCompiler
             $pattern .= str_repeat (')?', count($optionals));
         }
 
-        return sprintf('#^%s$#i', $pattern);
+        return sprintf('#^%s$#s', $pattern);
     }
 
 }


### PR DESCRIPTION
This pull request introduce some small improvements on Routing and separate the Named vs. Unnamed Parameters processing via a configuration option on **app/Config/Routing**, defaulting to Named Parameters.

The reason is that auto-switching is not a perfect solution, because a pattern which have mixed styles would never work, even if we claim that Nova 3 support both styles. For example:

```php
Router::any('blog/(:any)/(:any)/{slug?}', 'App\Controllers\Demo@request')->where('slug', '.*');
```
And that could be confusing.

In other hand, looks like our end-users have no problems to assimilate fast the knowledge required by the {named} parameters, also considering that on Nova 4 is the only style applicable, then a application using them will have less issues on porting to the next major version, the configuration default to them, being of course net superior solution. 

To note that the Unnamed Parameters are full supported and via configuration the Routing could be switched to support them (only). No mixing allowed.