### PR TITLE
 	Move the Core\View Facade to namespace Support\Facades and overall small improvements

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -105,7 +105,6 @@ Config::set('app', array(
     'aliases' => array(
         // The Core.
         'Errors'        => 'Core\Error',
-        'View'          => 'Core\View',
 
         // The Helpers.
         'Mail'          => 'Helpers\Mailer',
@@ -128,7 +127,10 @@ Config::set('app', array(
         'Tags'          => 'Helpers\Tags',
 
         // The Forensics Console.
-        'Console'       => '\Forensics\Console',
+        'Console'       => 'Forensics\Console',
+
+        // The Compatibility Support.
+        'Core\View'     => 'Support\Facades\View',
 
         // The Support Classes.
         'Arr'           => 'Support\Arr',
@@ -160,6 +162,7 @@ Config::set('app', array(
         'Log'           => 'Support\Facades\Log',
         'URL'           => 'Support\Facades\URL',
         'Template'      => 'Support\Facades\Template',
+        'View'          => 'Support\Facades\View',
         'Cron'          => 'Support\Facades\Cron',
     ),
 ));

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -129,9 +129,6 @@ Config::set('app', array(
         // The Forensics Console.
         'Console'       => 'Forensics\Console',
 
-        // The Compatibility Support.
-        'Core\View'     => 'Support\Facades\View',
-
         // The Support Classes.
         'Arr'           => 'Support\Arr',
         'Str'           => 'Support\Str',
@@ -164,5 +161,9 @@ Config::set('app', array(
         'Template'      => 'Support\Facades\Template',
         'View'          => 'Support\Facades\View',
         'Cron'          => 'Support\Facades\Cron',
+
+        // The Compatibility Support.
+        'Core\Template' => 'Support\Facades\Template',
+        'Core\View'     => 'Support\Facades\View',
     ),
 ));

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -8,8 +8,9 @@
 
 namespace App\Controllers;
 
-use Core\View;
 use Core\Controller;
+
+use View;
 
 
 /**

--- a/app/Modules/Demos/Controllers/Demos.php
+++ b/app/Modules/Demos/Controllers/Demos.php
@@ -2,26 +2,24 @@
 
 namespace App\Modules\Demos\Controllers;
 
-use Core\View;
 use Core\Controller;
 
-use Helpers\FastCache;
-use Helpers\Password;
-use Helpers\Url;
 use Routing\Route;
 
+use App\Models\User;
+
 use App;
+use Cache;
+use DB;
 use Event;
-use Validator;
+use Hash;
 use Input;
 use Mailer;
 use Redirect;
 use Request;
 use Session;
-
-use App\Models\User;
-
-use DB;
+use Validator;
+use View;
 
 
 /*
@@ -42,7 +40,7 @@ class Demos extends Controller
     {
         $content = '';
 
-        $content .= '<p><b>' .__d('demos', 'Password:') .'</b> : <code>'. Password::make($password) .'</code></p>';
+        $content .= '<p><b>' .__d('demos', 'Password:') .'</b> : <code>'. Hash::make($password) .'</code></p>';
 
         $content .= '<p><b>' .__d('demos', 'Timestamp:') .'</b> : <code>'.time() .'<b></code>';
 
@@ -285,18 +283,15 @@ class Demos extends Controller
 
     public function cache()
     {
-
-        $cache = FastCache::getInstance();
-
         $key = "test_page";
 
-        $content = $cache->get($key);
+        $content = Cache::get($key);
 
         if (is_null($content)) {
             $content = "Files Cache --> Well done !";
 
             // Write products to Cache in 10 minutes with same keyword
-            $cache->set($key, $content, 600);
+            Cache::put($key, $content, 10);
         } else {
             $content = "READ FROM CACHE // " .$content;
         }

--- a/app/Modules/Demos/Routes.php
+++ b/app/Modules/Demos/Routes.php
@@ -28,3 +28,7 @@ Route::group(array('prefix' => 'demo', 'namespace' => 'App\Modules\Demos\Control
     Route::get('test/{param1?}/{param2?}/{param3?}/{slug?}', array('before' => 'test', 'uses' => 'Demos@test'))
         ->where('slug', '(.*)');
 });
+
+
+// A catch-all Route - will match any URI, while using any HTTP Method.
+//Route::any('{slug}', 'App\Controllers\Demo@catchAll')->where('slug', '(.*)');

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -9,6 +9,7 @@ use Routing\FileDispatcher;
 use Auth;
 use Request;
 use Response;
+use View;
 
 
 class Files extends Controller

--- a/app/Modules/System/Controllers/Admin/Dashboard.php
+++ b/app/Modules/System/Controllers/Admin/Dashboard.php
@@ -8,9 +8,9 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use Core\View;
-
 use App\Core\Controller;
+
+use View;
 
 
 class Dashboard extends Controller

--- a/app/Modules/System/Controllers/Admin/Profile.php
+++ b/app/Modules/System/Controllers/Admin/Profile.php
@@ -8,7 +8,6 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use Core\View;
 use App\Core\Controller;
 use App\Models\User;
 
@@ -17,6 +16,7 @@ use Hash;
 use Input;
 use Redirect;
 use Validator;
+use View;
 
 
 class Profile extends Controller

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,7 +8,6 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use Core\View;
 use Helpers\FastCache;
 
 use App\Core\Controller;
@@ -20,6 +19,7 @@ use Session;
 use Redirect;
 use Request;
 use Validator;
+use View;
 
 
 class Settings extends Controller

--- a/app/Modules/System/Controllers/Authorize.php
+++ b/app/Modules/System/Controllers/Authorize.php
@@ -8,7 +8,6 @@
 
 namespace App\Modules\System\Controllers;
 
-use Core\View;
 use Helpers\Url;
 use Helpers\ReCaptcha;
 
@@ -21,6 +20,7 @@ use Password;
 use Redirect;
 use Response;
 use Session;
+use View;
 
 
 class Authorize extends Controller

--- a/app/Modules/System/Controllers/CronRunner.php
+++ b/app/Modules/System/Controllers/CronRunner.php
@@ -3,11 +3,11 @@
 namespace App\Modules\System\Controllers;
 
 use Core\Config;
-use Core\View;
 use Core\Controller;
 
 use Cron;
 use Response;
+use View;
 
 use Carbon\Carbon;
 

--- a/app/Modules/System/Controllers/Language.php
+++ b/app/Modules/System/Controllers/Language.php
@@ -9,6 +9,7 @@ use Helpers\Url;
 use Cookie;
 use Redirect;
 use Session;
+use View;
 
 
 class Language extends Controller

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -9,8 +9,6 @@
 namespace App\Modules\Users\Controllers\Admin;
 
 use Core\Config;
-use Core\View;
-use Helpers\Url;
 use Helpers\ReCaptcha;
 
 use App\Core\Controller;
@@ -24,6 +22,7 @@ use Input;
 use Redirect;
 use Session;
 use Validator;
+use View;
 
 
 class Roles extends Controller

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -8,7 +8,6 @@
 
 namespace App\Modules\Users\Controllers\Admin;
 
-use Core\View;
 use Helpers\ReCaptcha;
 
 use App\Core\Controller;
@@ -23,6 +22,7 @@ use Input;
 use Redirect;
 use Session;
 use Validator;
+use View;
 
 
 class Users extends Controller

--- a/app/Modules/Users/Controllers/Registrar.php
+++ b/app/Modules/Users/Controllers/Registrar.php
@@ -8,8 +8,6 @@
 
 namespace App\Modules\Users\Controllers;
 
-use Core\View;
-use Helpers\Url;
 use Helpers\ReCaptcha;
 
 use App\Core\Controller;
@@ -24,6 +22,7 @@ use Mailer;
 use Redirect;
 use Session;
 use Validator;
+use View;
 
 
 class Registrar extends Controller

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -14,7 +14,4 @@
 Route::get('/',       'App\Controllers\Welcome@index');
 Route::get('subpage', 'App\Controllers\Welcome@subPage');
 
-// A catch-all Route - will match any URI, while using any HTTP Method.
-//Route::any('{slug}', 'App\Controllers\Demo@catchAll')->where('slug', '(.*)');
-
 /** End default Routes */

--- a/system/Cli/ControllerCommand.php
+++ b/system/Cli/ControllerCommand.php
@@ -100,8 +100,10 @@ class ControllerCommand extends Command
         $data = "<?php
 namespace App\Controllers;
 
-use Core\View;
 use Core\Controller;
+
+use View;
+
 
 class ".ucwords($this->controllerName)." extends Controller
 {
@@ -118,7 +120,8 @@ class ".ucwords($this->controllerName)." extends Controller
                 $data .= "
     public function $method()
     {
-       return \$this->getView()->shares('title', '$title');
+       return \$this->getView()
+            ->shares('title', '$title');
     }\n";
             }
         }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -10,11 +10,12 @@ namespace Core;
 
 use Core\Config;
 use Core\Language;
-use Core\View;
 use Http\Response;
 use Routing\Controller as BaseController;
 use Support\Contracts\RenderableInterface as Renderable;
 use Support\Facades\Template;
+
+use View;
 
 
 /**

--- a/system/Database/Model.php
+++ b/system/Database/Model.php
@@ -249,7 +249,7 @@ class Model
      * @param  string  $connection
      * @return \Database\Connection
      */
-    public static function resolveConnection($connection = null)
+    public function resolveConnection($connection = null)
     {
         return static::$resolver->connection($connection);
     }

--- a/system/Database/Model.php
+++ b/system/Database/Model.php
@@ -70,13 +70,16 @@ class Model
      */
     public function __construct($connection = null)
     {
-        if($connection !== false) {
-            // Setup the Connection name.
-            $this->connection = $connection;
-
-            // Setup the Connection instance.
-            $this->db = $this->getConnection();
+        if ($connection === false) {
+            // Is wanted a bare Model instance.
+            return;
         }
+
+        // Setup the Connection name.
+        $this->connection = $connection;
+
+        // Setup the Connection instance.
+        $this->db = $this->getConnection();
     }
 
     /**
@@ -87,7 +90,8 @@ class Model
      */
     public function all($columns = array('*'))
     {
-        return $this->newQuery()->get($columns);
+        return $this->newQuery()
+            ->get($columns);
     }
 
     /**
@@ -99,7 +103,8 @@ class Model
      */
     public function find($id, $columns = array('*'))
     {
-        return $this->newQuery()->find($id, $columns);
+        return $this->newQuery()
+            ->find($id, $columns);
     }
 
     /**
@@ -111,7 +116,8 @@ class Model
      */
     public function findMany($ids, $columns = array('*'))
     {
-        return $this->newQuery()->findMany($ids, $columns);
+        return $this->newQuery()
+            ->findMany($ids, $columns);
     }
 
     /**
@@ -122,7 +128,8 @@ class Model
      */
     public function insert(array $values)
     {
-        return $this->newQuery()->insertGetId($values);
+        return $this->newQuery()
+            ->insertGetId($values);
     }
 
     /**

--- a/system/Helpers/Database.php
+++ b/system/Helpers/Database.php
@@ -255,7 +255,7 @@ class Database
      * @param  string  $connection
      * @return \Database\Connection
      */
-    public static function resolveConnection($connection = null)
+    public function resolveConnection($connection = null)
     {
         return static::$resolver->connection($connection);
     }

--- a/system/Helpers/Profiler.php
+++ b/system/Helpers/Profiler.php
@@ -11,7 +11,6 @@ namespace Helpers;
 use Core\Config;
 
 use DB;
-
 use Request;
 
 

--- a/system/Support/Facades/View.php
+++ b/system/Support/Facades/View.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-namespace Core;
+namespace Support\Facades;
 
 use Support\Facades\Facade;
 


### PR DESCRIPTION
This pull request move the **Core\View Facade** to namespace **Support\Facades** and introduce overall small improvements. 

Also, are provided the compatibility class aliases for **Core\Template** and **Core\View**.

Finally, the Cache demo is moved to using the **Cache Service** instead of **Helpers\FastCache**.

**No API changes**, good for a micro version release.