### PR TITLE
Heavily improve the Routing and Database API, implementation of Filters based Middleware for Controllers

### DIFF
--- a/app/Boot/Start.php
+++ b/app/Boot/Start.php
@@ -13,7 +13,7 @@
 require ROOTDIR .'vendor/autoload.php';
 
 // The used Classes.
-use Core\Config;
+use Config\Config;
 use Config\Repository as ConfigRepository;
 use Foundation\AliasLoader;
 use Foundation\Application;

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -160,8 +160,10 @@ Config::set('app', array(
         'Cron'          => 'Support\Facades\Cron',
 
         // The Compatibility Support.
+        'Errors'        => 'App\Core\LegacyError',
+
+        //
         'Core\Controller' => 'App\Core\LegacyController',
-        'Errors'          => 'App\Core\LegacyError',
         'Core\Model'      => 'App\Core\LegacyModel',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 /**

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -104,7 +104,7 @@ Config::set('app', array(
      */
     'aliases' => array(
         // The Core.
-        'Errors'        => 'Core\Error',
+        'Errors'        => 'App\Core\LegacyError',
 
         // The Helpers.
         'Mail'          => 'Helpers\Mailer',

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -160,11 +160,11 @@ Config::set('app', array(
         'Cron'          => 'Support\Facades\Cron',
 
         // The Compatibility Support.
-        'Errors'        => 'App\Core\LegacyError',
+        'Errors'        => 'App\Legacy\Error',
 
         //
-        'Core\Controller' => 'App\Core\LegacyController',
-        'Core\Model'      => 'App\Core\LegacyModel',
+        'Core\Controller' => 'App\Legacy\Controller',
+        'Core\Model'      => 'App\Legacy\Model',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',
     ),

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -164,7 +164,7 @@ Config::set('app', array(
 
         // The Compatibility Support.
         'Core\Controller' => 'App\Core\Controller',
-        'Core\Model'      => 'App\Core\Model',
+        'Core\Model'      => 'App\Core\LegacyModel',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',
     ),

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -103,9 +103,6 @@ Config::set('app', array(
      * The registered Class Aliases.
      */
     'aliases' => array(
-        // The Core.
-        'Errors'        => 'App\Core\LegacyError',
-
         // The Helpers.
         'Mail'          => 'Helpers\Mailer',
         'Assets'        => 'Helpers\Assets',
@@ -164,6 +161,7 @@ Config::set('app', array(
 
         // The Compatibility Support.
         'Core\Controller' => 'App\Core\LegacyController',
+        'Errors'          => 'App\Core\LegacyError',
         'Core\Model'      => 'App\Core\LegacyModel',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -164,6 +164,7 @@ Config::set('app', array(
 
         // The Compatibility Support.
         'Core\Controller' => 'App\Core\Controller',
+        'Core\Model'      => 'App\Core\Model',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',
     ),

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -163,7 +163,7 @@ Config::set('app', array(
         'Cron'          => 'Support\Facades\Cron',
 
         // The Compatibility Support.
-        'Core\Controller' => 'App\Core\Controller',
+        'Core\Controller' => 'App\Core\LegacyController',
         'Core\Model'      => 'App\Core\LegacyModel',
         'Core\Template'   => 'Support\Facades\Template',
         'Core\View'       => 'Support\Facades\View',

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -163,7 +163,8 @@ Config::set('app', array(
         'Cron'          => 'Support\Facades\Cron',
 
         // The Compatibility Support.
-        'Core\Template' => 'Support\Facades\Template',
-        'Core\View'     => 'Support\Facades\View',
+        'Core\Controller' => 'App\Core\Controller',
+        'Core\Template'   => 'Support\Facades\Template',
+        'Core\View'       => 'Support\Facades\View',
     ),
 ));

--- a/app/Config/Auth.php
+++ b/app/Config/Auth.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('auth', array(

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('cache', array(

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 /**

--- a/app/Config/Languages.php
+++ b/app/Config/Languages.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('languages', array(

--- a/app/Config/Mail.php
+++ b/app/Config/Mail.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('mail', array(

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('modules', array(

--- a/app/Config/Profiler.php
+++ b/app/Config/Profiler.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 /**

--- a/app/Config/ReCaptcha.php
+++ b/app/Config/ReCaptcha.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 /**

--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 /**

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 
 Config::set('session', array(

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -8,7 +8,7 @@
 
 namespace App\Controllers;
 
-use Core\Controller;
+use App\Core\Controller;
 
 use View;
 

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -13,6 +13,9 @@ use Routing\Route;
 
 use App\Core\Controller as BaseController;
 
+use Auth;
+use Redirect;
+
 
 abstract class BackendController extends BaseController
 {

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -8,10 +8,10 @@
 
 namespace App\Core;
 
-use Core\Controller;
+use App\Core\Controller as BaseController;
 
 
-abstract class BackendController extends Controller
+abstract class BackendController extends BaseController
 {
     /**
      * The currently used Template.

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -8,6 +8,9 @@
 
 namespace App\Core;
 
+use Http\Request;
+use Routing\Route;
+
 use App\Core\Controller as BaseController;
 
 
@@ -25,12 +28,26 @@ abstract class BackendController extends BaseController
      *
      * @var mixed
      */
-    protected $layout   = 'backend';
+    protected $layout = 'backend';
 
-
+    /**
+     * Create a new BackendController instance.
+     */
     public function __construct()
     {
         parent::__construct();
     }
 
+    /**
+     * A Before Filter which permit the access to Administrators.
+     */
+    public function adminUsersFilter(Route $route, Request $request)
+    {
+        // Check the User Authorization - while using the Extended Auth Driver.
+        if (! Auth::user()->hasRole('administrator')) {
+            $status = __d('users', 'You are not authorized to access this resource.');
+
+            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
+        }
+    }
 }

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Controller - A base Controller for the included example Modules.
+ * BackendController - A backend Controller for the included example Modules.
  *
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -8,16 +8,23 @@
 
 namespace App\Core;
 
-use Core\Controller as BaseController;
-
-use Request;
-use Session;
-use View;
+use Core\Controller;
 
 
-class Controller extends BaseController
+class BackendController extends Controller
 {
+    /**
+     * The currently used Template.
+     *
+     * @var string
+     */
     protected $template = 'AdminLte';
+
+    /**
+     * The currently used Layout.
+     *
+     * @var mixed
+     */
     protected $layout   = 'backend';
 
 

--- a/app/Core/BackendController.php
+++ b/app/Core/BackendController.php
@@ -11,7 +11,7 @@ namespace App\Core;
 use Core\Controller;
 
 
-class BackendController extends Controller
+abstract class BackendController extends Controller
 {
     /**
      * The currently used Template.

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -14,7 +14,6 @@ use Routing\Controller as BaseController;
 use Support\Contracts\RenderableInterface as Renderable;
 use Template\Template as Layout;
 
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 use Template;

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -2,7 +2,7 @@
 /**
  * Controller - base controller
  *
- * @author David Carr - dave@novaframework.com
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0
  */
 
@@ -19,6 +19,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 use Template;
 use View;
+
+use BadMethodCallException;
 
 
 /**

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -14,6 +14,8 @@ use Support\Contracts\RenderableInterface as Renderable;
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+use BadMethodCallException;
+
 
 /**
  * Core controller, all other controllers extend this base controller.
@@ -50,6 +52,12 @@ abstract class Controller extends BaseController
 
     /**
      * Call the (legacy) Controller Middleware - Before Stage.
+     *
+     * @param \Routing\Route $route
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return mixed|void
+     * @throw \BadMethodCallException
      */
     public function callLegacyBefore(Route $route, SymfonyRequest $request)
     {
@@ -64,6 +72,8 @@ abstract class Controller extends BaseController
 
             // Store the called method name.
             $this->method = $method;
+        } else {
+            throw new BadMethodCallException('No controller found on Route instance');
         }
 
         // Execute the legacy Before Stage.
@@ -72,6 +82,12 @@ abstract class Controller extends BaseController
 
     /**
      * Call the (legacy) Controller Middleware - After Stage.
+     *
+     * @param \Routing\Route $route
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param mixed $response
+     *
+     * @return void
      */
     public function callLegacyAfter(Route $route, SymfonyRequest $request, $response)
     {
@@ -81,6 +97,8 @@ abstract class Controller extends BaseController
 
     /**
      * The (legacy) Middleware called before the Action execution.
+     *
+     * @return mixed|void
      */
     protected function before()
     {
@@ -89,6 +107,10 @@ abstract class Controller extends BaseController
 
     /**
      * The (legacy) Middleware called after the Action execution.
+     *
+     * @param mixed $response
+     *
+     * @return void
      */
     protected function after($response)
     {

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -17,9 +17,6 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use BadMethodCallException;
 
 
-/**
- * Core controller, all other controllers extend this base controller.
- */
 abstract class Controller extends BaseController
 {
     /**

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -23,9 +23,6 @@ use View;
 use BadMethodCallException;
 
 
-/**
- * Core controller, all other controllers extend this base controller.
- */
 abstract class Controller extends BaseController
 {
     /**
@@ -44,7 +41,7 @@ abstract class Controller extends BaseController
 
 
     /**
-     * On the initial run, create an instance of the config class and the view class.
+     * Create a new Controller instance.
      */
     public function __construct()
     {

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-namespace Core;
+namespace App\Core;
 
 use Core\Config;
 use Http\Response;

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -67,7 +67,7 @@ abstract class Controller extends BaseController
         if (isset($action['controller'])) {
             list(, $method) = explode('@', $action['controller']);
 
-            // Store the called method name.
+            // Store the method name.
             $this->method = $method;
         } else {
             throw new BadMethodCallException('No controller found on Route instance');

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Controller - A base controller with legacy Middleware support.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace App\Core;
+
+use Core\Controller as BaseController;
+use Routing\Route;
+use Support\Contracts\RenderableInterface as Renderable;
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+
+/**
+ * Core controller, all other controllers extend this base controller.
+ */
+abstract class Controller extends BaseController
+{
+    /**
+     * The requested Method by Router.
+     *
+     * @var string|null
+     */
+    private $method = null;
+
+    /**
+     * The parameters given by Router.
+     *
+     * @var array
+     */
+    private $params = array();
+
+
+    /**
+     * On the initial run, create an instance of the config class and the view class.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Setup the Controller Middleware; preserve the legacy before/after methods.
+        $this->beforeFilter('@callLegacyBefore');
+
+        $this->afterFilter('@callLegacyAfter');
+    }
+
+    /**
+     * Call the (legacy) Controller Middleware - Before Stage.
+     */
+    public function callLegacyBefore(Route $route, SymfonyRequest $request)
+    {
+        // Setup the call parameters from the Route instance.
+        $this->params = $route->getParams();
+
+        // Setup the called method from the Route instance.
+        $action = $route->getAction();
+
+        if (isset($action['controller'])) {
+            list(, $method) = explode('@', $action['controller']);
+
+            // Store the called method name.
+            $this->method = $method;
+        }
+
+        // Execute the legacy Before Stage.
+        return $this->before();
+    }
+
+    /**
+     * Call the (legacy) Controller Middleware - After Stage.
+     */
+    public function callLegacyAfter(Route $route, SymfonyRequest $request, $response)
+    {
+        // Execute the legacy After Stage.
+        $this->after($response);
+    }
+
+    /**
+     * The (legacy) Middleware called before the Action execution.
+     */
+    protected function before()
+    {
+        //
+    }
+
+    /**
+     * The (legacy) Middleware called after the Action execution.
+     */
+    protected function after($response)
+    {
+        //
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getParams()
+    {
+        return $this->params;
+    }
+
+}

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -8,7 +8,7 @@
 
 namespace App\Core;
 
-use Core\Config;
+use Config\Config;
 use Http\Response;
 use Routing\Controller as BaseController;
 use Support\Contracts\RenderableInterface as Renderable;

--- a/app/Core/LegacyController.php
+++ b/app/Core/LegacyController.php
@@ -146,6 +146,11 @@ abstract class LegacyController extends BaseController
         return parent::processResponse($response);
     }
 
+    /**
+     * Create a Response instance from the legacy View API and return it.
+     *
+     * @return \Http\Response
+     */
     protected function createLegacyResponse()
     {
         $items = View::getItems();
@@ -165,6 +170,7 @@ abstract class LegacyController extends BaseController
 
     /**
      * Return a translated string.
+     *
      * @return string
      */
     protected function trans($str, $code = LANGUAGE_CODE)

--- a/app/Core/LegacyController.php
+++ b/app/Core/LegacyController.php
@@ -14,6 +14,7 @@ use Http\Response;
 use Routing\Route;
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 use BadMethodCallException;
 

--- a/app/Core/LegacyController.php
+++ b/app/Core/LegacyController.php
@@ -8,7 +8,7 @@
 
 namespace App\Core;
 
-use Core\Controller as BaseController;
+use App\Core\Controller as BaseController;
 use Core\Language;
 use Http\Response;
 use Routing\Route;

--- a/app/Core/LegacyController.php
+++ b/app/Core/LegacyController.php
@@ -9,7 +9,7 @@
 namespace App\Core;
 
 use App\Core\Controller as BaseController;
-use Core\Language;
+use Language\Language;
 use Http\Response;
 use Routing\Route;
 

--- a/app/Core/LegacyError.php
+++ b/app/Core/LegacyError.php
@@ -6,12 +6,12 @@
  * @version 3.0
  */
 
-namespace Core;
+namespace App\Core;
 
 /**
  * Error class.
  */
-class Error
+class LegacyError
 {
     /**
      * Display errors.

--- a/app/Core/LegacyModel.php
+++ b/app/Core/LegacyModel.php
@@ -13,7 +13,7 @@ use Helpers\Database;
 /**
  * Base model class. All other models will extend from this base.
  */
-abstract class Model
+abstract class LegacyModel
 {
     /**
      * Hold the database connection.

--- a/app/Core/Model.php
+++ b/app/Core/Model.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-namespace Core;
+namespace App\Core;
 
 use Helpers\Database;
 

--- a/app/Filters.php
+++ b/app/Filters.php
@@ -67,3 +67,12 @@ Route::filter('guest', function($route, $request) {
         return Redirect::to('admin/dashboard');
     }
 });
+
+// Role-based Authorization Filter.
+Route::filter('roles', function($route, $request, $response, $roles = null) {
+    if (! is_null($roles) && ! Auth::user()->hasRole($roles)) {
+         $status = __('You are not authorized to access this resource.');
+
+         return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
+    }
+});

--- a/app/Legacy/Controller.php
+++ b/app/Legacy/Controller.php
@@ -10,9 +10,9 @@ namespace App\Legacy;
 
 use App\Core\Controller as BaseController;
 use Language\Language;
+use Http\Request;
 use Http\Response;
-
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Routing\Route;
 
 use BadMethodCallException;
 
@@ -57,12 +57,18 @@ abstract class Controller extends BaseController
         $this->setupMiddleware();
     }
 
+    /**
+     *  Setup the (legacy) Middleware.
+     *
+     * @return void
+     + @throw \BadMethodCallException
+     */
     private function setupMiddleware()
     {
         $me = $this;
 
         // Get the Route's parameters and method name, optionally call the Before Middleware.
-        $this->beforeFilter(function($route, $request) use ($me)
+        $this->beforeFilter(function(Route $route, Request $request) use ($me)
         {
             // Setup the call parameters from the Route instance.
             $me->params = $route->getParams();
@@ -84,7 +90,7 @@ abstract class Controller extends BaseController
         });
 
         // Setup the Controller's After Middleware.
-        $this->afterFilter(function($route, $request, $response) use ($me)
+        $this->afterFilter(function(Route $route, Request $request, $response) use ($me)
         {
             $me->after($response);
         });

--- a/app/Legacy/Controller.php
+++ b/app/Legacy/Controller.php
@@ -76,13 +76,13 @@ abstract class Controller extends BaseController
             // Setup the called method from the Route instance.
             $action = $route->getAction();
 
-            if (isset($action['controller'])) {
+            if (isset($action['controller']) && str_contains($action['controller'], '@')) {
                 list(, $method) = explode('@', $action['controller']);
 
                 // Store the method name.
                 $me->method = $method;
             } else {
-                throw new BadMethodCallException('No controller found on Route action');
+                throw new BadMethodCallException('No valid Controller found on Route action');
             }
 
             // Execute the Controller's Before Middleware.

--- a/app/Legacy/Controller.php
+++ b/app/Legacy/Controller.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-namespace App\Core;
+namespace App\Legacy;
 
 use App\Core\Controller as BaseController;
 use Language\Language;
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use BadMethodCallException;
 
 
-abstract class LegacyController extends BaseController
+abstract class Controller extends BaseController
 {
     /**
      * The requested Method by Router.

--- a/app/Legacy/Controller.php
+++ b/app/Legacy/Controller.php
@@ -44,7 +44,7 @@ abstract class Controller extends BaseController
 
 
     /**
-     * On the initial run, create an instance of the config class and the view class.
+     * Create a new Controller instance.
      */
     public function __construct()
     {

--- a/app/Legacy/Error.php
+++ b/app/Legacy/Error.php
@@ -6,12 +6,12 @@
  * @version 3.0
  */
 
-namespace App\Core;
+namespace App\Legacy;
 
 /**
  * Error class.
  */
-class LegacyError
+class Error
 {
     /**
      * Display errors.

--- a/app/Legacy/Model.php
+++ b/app/Legacy/Model.php
@@ -6,14 +6,14 @@
  * @version 3.0
  */
 
-namespace App\Core;
+namespace App\Legacy;
 
 use Helpers\Database;
 
 /**
  * Base model class. All other models will extend from this base.
  */
-abstract class LegacyModel
+abstract class Model
 {
     /**
      * Hold the database connection.

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -9,7 +9,9 @@ class Role extends BaseModel
 {
     protected $table = 'roles';
 
-    public $timestamps = true;
+    protected $primaryKey = 'id';
+
+    protected $fillable = array('name', 'slug', 'description');
 
 
     public function users()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,9 +19,9 @@ class User extends BaseModel implements UserInterface, RemindableInterface
 
     protected $primaryKey = 'id';
 
-    protected $hidden = array('password');
+    protected $fillable = array('role_id', 'username', 'password', 'realname', 'email', 'active', 'activation_code');
 
-    public $timestamps = true;
+    protected $hidden = array('password', 'activation_code', 'remember_token');
 
     // Cache for associated Role instance.
     private $cachedRole;

--- a/app/Modules/Demos/Config.php
+++ b/app/Modules/Demos/Config.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 /**
  * Configuration constants and options.

--- a/app/Modules/Demos/Controllers/Demos.php
+++ b/app/Modules/Demos/Controllers/Demos.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\Demos\Controllers;
 
-use Core\Controller;
+use App\Core\Controller;
 
 use Routing\Route;
 

--- a/app/Modules/Demos/Controllers/Demos.php
+++ b/app/Modules/Demos/Controllers/Demos.php
@@ -76,7 +76,11 @@ class Demos extends Controller
         //$uri = '(:all)';
 
         //
-        $route = new Route('GET', $uri, null, false);
+        $route = new Route('GET', $uri, function()
+        {
+            echo 'Hello, World!';
+
+        }, false);
 
         // Match the Route.
         $request = Request::instance();

--- a/app/Modules/Files/Config.php
+++ b/app/Modules/Files/Config.php
@@ -6,12 +6,12 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 /**
  * Configuration constants and options.
  */
- 
+
 Config::set('elFinder', array(
     'locale' => 'en_US.UTF-8',
     'debug'  => false,

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -6,6 +6,7 @@ use App\Core\BackendController;
 
 use Http\Request;
 use Routing\FileDispatcher;
+use Routing\Route;
 
 use Auth;
 use Response;
@@ -34,17 +35,32 @@ class Files extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@setupRequestFilter');
-        $this->beforeFilter('@adminUsersFilter');
+        $this->beforeFilter('@filterRequests');
     }
 
     /**
      * Filter the incoming requests.
      */
-    public function setupRequestFilter(Route $route, Request $request)
+    public function filterRequests(Route $route, Request $request)
     {
         // Store the Request instance for further processing.
         $this->request = $request;
+
+        // Check the User Authorization.
+        if (Auth::user()->hasRole('administrator')) {
+            // The User is authorized; continue the Execution Flow.
+            return null;
+        }
+
+        if ($request->ajax()) {
+            // On an AJAX Request; just return Error 403 (Access denied)
+            return Response::make('', 403);
+        }
+
+        // Redirect the User to his/hers Dashboard with a warning message.
+        $status = __d('files', 'You are not authorized to access this resource.');
+
+        return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
     }
 
     public function index()

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -35,7 +35,6 @@ class Files extends BackendController
 
         //
         $this->beforeFilter('@setupRequestFilter');
-
         $this->beforeFilter('@adminUsersFilter');
     }
 

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -34,7 +34,7 @@ class Files extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@setupRequest');
+        $this->beforeFilter('@setupRequestFilter');
 
         $this->beforeFilter('@adminUsersFilter');
     }
@@ -42,7 +42,7 @@ class Files extends BackendController
     /**
      * Filter the incoming requests.
      */
-    public function setupRequest(Route $route, Request $request)
+    public function setupRequestFilter(Route $route, Request $request)
     {
         // Store the Request instance for further processing.
         $this->request = $request;

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -6,7 +6,6 @@ use App\Core\BackendController;
 
 use Http\Request;
 use Routing\FileDispatcher;
-use Routing\Route;
 
 use Auth;
 use Response;
@@ -15,8 +14,18 @@ use View;
 
 class Files extends BackendController
 {
+    /**
+     * The Request instance.
+     *
+     * @var \Http\Request
+     */
     private $request = null;
 
+    /**
+     * The File Dispatcher instance.
+     *
+     * @var \Routing\FileDispatcher
+     */
     private $dispatcher;
 
 
@@ -25,32 +34,18 @@ class Files extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@filterRequests');
+        $this->beforeFilter('@setupRequest');
+
+        $this->beforeFilter('@adminUsersFilter');
     }
 
     /**
      * Filter the incoming requests.
      */
-    public function filterRequests(Route $route, Request $request)
+    public function setupRequest(Route $route, Request $request)
     {
         // Store the Request instance for further processing.
         $this->request = $request;
-
-        // Check the User Authorization.
-        if (Auth::user()->hasRole('administrator')) {
-            // The User is authorized; continue the Execution Flow.
-            return null;
-        }
-
-        if ($request->ajax()) {
-            // On an AJAX Request; just return Error 403 (Access denied)
-            return Response::make('', 403);
-        }
-
-        // Redirect the User to his/hers Dashboard with a warning message.
-        $status = __d('files', 'You are not authorized to access this resource.');
-
-        return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
     }
 
     public function index()

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\Files\Controllers\Admin;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 
 use Routing\FileDispatcher;
 
@@ -12,7 +12,7 @@ use Response;
 use View;
 
 
-class Files extends Controller
+class Files extends BackendController
 {
     private $dispatcher;
 

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -33,7 +33,7 @@ class Files extends BackendController
      */
     public function filterRequests(Route $route, Request $request)
     {
-        // Store the incomming Request for further processing.
+        // Store the Request instance for further processing.
         $this->request = $request;
 
         // Check the User Authorization.

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -4,28 +4,45 @@ namespace App\Modules\Files\Controllers\Admin;
 
 use App\Core\BackendController;
 
+use Http\Request;
 use Routing\FileDispatcher;
+use Routing\Route;
 
 use Auth;
-use Request;
 use Response;
 use View;
 
 
 class Files extends BackendController
 {
+    private $request = null;
+
     private $dispatcher;
 
 
-    protected function before()
+    public function __construct()
     {
+        parent::__construct();
+
+        //
+        $this->beforeFilter('@filterRequests');
+    }
+
+    /**
+     * Filter the incoming requests.
+     */
+    public function filterRequests(Route $route, Request $request)
+    {
+        // Store the incomming Request for further processing.
+        $this->request = $request;
+
         // Check the User Authorization.
         if (Auth::user()->hasRole('administrator')) {
             // The User is authorized; continue the Execution Flow.
-            return parent::before();
+            return null;
         }
 
-        if (Request::ajax()) {
+        if ($request->ajax()) {
             // On an AJAX Request; just return Error 403 (Access denied)
             return Response::make('', 403);
         }
@@ -75,12 +92,10 @@ class Files extends BackendController
      */
     protected function serveFile($path)
     {
-        $request = Request::instance();
-
         // Get a File Dispatcher instance.
         $dispatcher = $this->getDispatcher();
 
-        return $dispatcher->serve($path, $request);
+        return $dispatcher->serve($path, $this->request);
     }
 
     /**

--- a/app/Modules/System/Config.php
+++ b/app/Modules/System/Config.php
@@ -7,12 +7,12 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 /**
  * Configuration constants and options.
  */
- 
+
 Config::set('cron', array(
     /**
      * The CRON token.

--- a/app/Modules/System/Controllers/Admin/Dashboard.php
+++ b/app/Modules/System/Controllers/Admin/Dashboard.php
@@ -15,6 +15,7 @@ use View;
 
 class Dashboard extends BackendController
 {
+
     public function index()
     {
         return $this->getView()

--- a/app/Modules/System/Controllers/Admin/Dashboard.php
+++ b/app/Modules/System/Controllers/Admin/Dashboard.php
@@ -8,12 +8,12 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 
 use View;
 
 
-class Dashboard extends Controller
+class Dashboard extends BackendController
 {
     public function index()
     {

--- a/app/Modules/System/Controllers/Admin/Profile.php
+++ b/app/Modules/System/Controllers/Admin/Profile.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 use App\Models\User;
 
 use Auth;
@@ -19,7 +19,7 @@ use Validator;
 use View;
 
 
-class Profile extends Controller
+class Profile extends BackendController
 {
 
     protected function validate(array $data, User $user)

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,9 +8,6 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use Http\Request;
-use Routing\Route;
-
 use App\Core\BackendController;
 
 use Auth;
@@ -30,20 +27,7 @@ class Settings extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@filterRequests');
-    }
-
-    /**
-     * Filter the incoming requests.
-     */
-    public function filterRequests(Route $route, Request $request)
-    {
-        // Check the User Authorization - while using the Extended Auth Driver.
-        if (! Auth::user()->hasRole('administrator')) {
-            $status = __d('users', 'You are not authorized to access this resource.');
-
-            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
-        }
+        $this->beforeFilter('@adminUsersFilter');
     }
 
     protected function validate(array $data)

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,9 +8,7 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use Helpers\FastCache;
-
-use App\Core\Controller;
+use App\Core\BackendController;
 
 use Auth;
 use Config;
@@ -22,7 +20,7 @@ use Validator;
 use View;
 
 
-class Settings extends Controller
+class Settings extends BackendController
 {
 
     protected function before()

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,7 +8,11 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
+use Routing\Route;
+
 use App\Core\BackendController;
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Auth;
 use Config;
@@ -23,17 +27,25 @@ use View;
 class Settings extends BackendController
 {
 
-    protected function before()
+    public function __construct()
     {
-        // Check the User Authorization.
+        parent::__construct();
+
+        //
+        $this->beforeFilter('@filterRequests');
+    }
+
+    /**
+     * Filter the incoming requests.
+     */
+    public function filterRequests(Route $route, SymfonyRequest $request)
+    {
+        // Check the User Authorization - while using the Extended Auth Driver.
         if (! Auth::user()->hasRole('administrator')) {
-            $status = __d('system', 'You are not authorized to access this resource.');
+            $status = __d('users', 'You are not authorized to access this resource.');
 
             return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
         }
-
-        // Leave to parent's method the Execution Flow decisions.
-        return parent::before();
     }
 
     protected function validate(array $data)

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,18 +8,16 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
+use Http\Request;
 use Routing\Route;
 
 use App\Core\BackendController;
-
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Auth;
 use Config;
 use Input;
 use Session;
 use Redirect;
-use Request;
 use Validator;
 use View;
 
@@ -38,7 +36,7 @@ class Settings extends BackendController
     /**
      * Filter the incoming requests.
      */
-    public function filterRequests(Route $route, SymfonyRequest $request)
+    public function filterRequests(Route $route, Request $request)
     {
         // Check the User Authorization - while using the Extended Auth Driver.
         if (! Auth::user()->hasRole('administrator')) {

--- a/app/Modules/System/Controllers/Authorize.php
+++ b/app/Modules/System/Controllers/Authorize.php
@@ -11,7 +11,7 @@ namespace App\Modules\System\Controllers;
 use Helpers\Url;
 use Helpers\ReCaptcha;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 
 use Auth;
 use Hash;
@@ -23,7 +23,7 @@ use Session;
 use View;
 
 
-class Authorize extends Controller
+class Authorize extends BackendController
 {
     protected $layout = 'default';
 

--- a/app/Modules/System/Controllers/Authorize.php
+++ b/app/Modules/System/Controllers/Authorize.php
@@ -8,7 +8,6 @@
 
 namespace App\Modules\System\Controllers;
 
-use Helpers\Url;
 use Helpers\ReCaptcha;
 
 use App\Core\BackendController;

--- a/app/Modules/System/Controllers/CronRunner.php
+++ b/app/Modules/System/Controllers/CronRunner.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\System\Controllers;
 
-use Core\Config;
+use Config\Config;
 use App\Core\Controller;
 
 use Cron;

--- a/app/Modules/System/Controllers/CronRunner.php
+++ b/app/Modules/System/Controllers/CronRunner.php
@@ -3,7 +3,7 @@
 namespace App\Modules\System\Controllers;
 
 use Core\Config;
-use Core\Controller;
+use App\Core\Controller;
 
 use Cron;
 use Response;

--- a/app/Modules/System/Controllers/Language.php
+++ b/app/Modules/System/Controllers/Language.php
@@ -3,7 +3,7 @@
 namespace App\Modules\System\Controllers;
 
 use Core\Config;
-use Core\Controller;
+use App\Core\Controller;
 use Helpers\Url;
 
 use Cookie;

--- a/app/Modules/System/Controllers/Language.php
+++ b/app/Modules/System/Controllers/Language.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\System\Controllers;
 
-use Core\Config;
+use Config\Config;
 use App\Core\Controller;
 use Helpers\Url;
 

--- a/app/Modules/Users/Config.php
+++ b/app/Modules/Users/Config.php
@@ -7,7 +7,7 @@
  * @version 3.0
  */
 
-use Core\Config;
+use Config\Config;
 
 /**
  * Configuration constants and options.

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -10,9 +10,12 @@ namespace App\Modules\Users\Controllers\Admin;
 
 use Core\Config;
 use Helpers\ReCaptcha;
+use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Carbon\Carbon;
 
@@ -28,17 +31,25 @@ use View;
 class Roles extends BackendController
 {
 
-    protected function before()
+    public function __construct()
     {
-        // Check the User Authorization.
+        parent::__construct();
+
+        //
+        $this->beforeFilter('@filterRequests');
+    }
+
+    /**
+     * Filter the incoming requests.
+     */
+    public function filterRequests(Route $route, SymfonyRequest $request)
+    {
+        // Check the User Authorization - while using the Extended Auth Driver.
         if (! Auth::user()->hasRole('administrator')) {
             $status = __d('users', 'You are not authorized to access this resource.');
 
             return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
         }
-
-        // Leave to parent's method the Execution Flow decisions.
-        return parent::before();
     }
 
     protected function validate(array $data, $id = null)

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\Users\Controllers\Admin;
 
-use Core\Config;
+use Config\Config;
 use Helpers\ReCaptcha;
 use Routing\Route;
 

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -11,7 +11,7 @@ namespace App\Modules\Users\Controllers\Admin;
 use Core\Config;
 use Helpers\ReCaptcha;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 use App\Models\Role;
 
 use Carbon\Carbon;
@@ -25,7 +25,7 @@ use Validator;
 use View;
 
 
-class Roles extends Controller
+class Roles extends BackendController
 {
 
     protected function before()

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -10,12 +10,11 @@ namespace App\Modules\Users\Controllers\Admin;
 
 use Config\Config;
 use Helpers\ReCaptcha;
+use Http\Request;
 use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
-
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Carbon\Carbon;
 
@@ -42,7 +41,7 @@ class Roles extends BackendController
     /**
      * Filter the incoming requests.
      */
-    public function filterRequests(Route $route, SymfonyRequest $request)
+    public function filterRequests(Route $route, Request $request)
     {
         // Check the User Authorization - while using the Extended Auth Driver.
         if (! Auth::user()->hasRole('administrator')) {

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -10,8 +10,6 @@ namespace App\Modules\Users\Controllers\Admin;
 
 use Config\Config;
 use Helpers\ReCaptcha;
-use Http\Request;
-use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
@@ -35,20 +33,7 @@ class Roles extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@filterRequests');
-    }
-
-    /**
-     * Filter the incoming requests.
-     */
-    public function filterRequests(Route $route, Request $request)
-    {
-        // Check the User Authorization - while using the Extended Auth Driver.
-        if (! Auth::user()->hasRole('administrator')) {
-            $status = __d('users', 'You are not authorized to access this resource.');
-
-            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
-        }
+        $this->beforeFilter('@adminUsersFilter');
     }
 
     protected function validate(array $data, $id = null)

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -10,7 +10,7 @@ namespace App\Modules\Users\Controllers\Admin;
 
 use Helpers\ReCaptcha;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 use App\Models\Role;
 use App\Models\User;
 
@@ -25,7 +25,7 @@ use Validator;
 use View;
 
 
-class Users extends Controller
+class Users extends BackendController
 {
 
     protected function before()

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -9,10 +9,13 @@
 namespace App\Modules\Users\Controllers\Admin;
 
 use Helpers\ReCaptcha;
+use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
 use App\Models\User;
+
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Carbon\Carbon;
 
@@ -28,24 +31,25 @@ use View;
 class Users extends BackendController
 {
 
-    protected function before()
+    public function __construct()
     {
-        // Check the User Authorization.
-        switch ($this->getMethod()) {
-            case 'profile':
-            case 'postProfile':
-                break;
+        parent::__construct();
 
-            default:
-                if (! Auth::user()->hasRole('administrator')) {
-                    $status = __d('users', 'You are not authorized to access this resource.');
+        //
+        $this->beforeFilter('@filterRequests');
+    }
 
-                    return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
-                }
+    /**
+     * Filter the incoming requests.
+     */
+    public function filterRequests(Route $route, SymfonyRequest $request)
+    {
+        // Check the User Authorization - while using the Extended Auth Driver.
+        if (! Auth::user()->hasRole('administrator')) {
+            $status = __d('users', 'You are not authorized to access this resource.');
+
+            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
         }
-
-        // Leave to parent's method the Execution Flow decisions.
-        return parent::before();
     }
 
     protected function validate(array $data, $id = null)

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -9,8 +9,6 @@
 namespace App\Modules\Users\Controllers\Admin;
 
 use Helpers\ReCaptcha;
-use Http\Request;
-use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
@@ -35,20 +33,7 @@ class Users extends BackendController
         parent::__construct();
 
         //
-        $this->beforeFilter('@filterRequests');
-    }
-
-    /**
-     * Filter the incoming requests.
-     */
-    public function filterRequests(Route $route, Request $request)
-    {
-        // Check the User Authorization - while using the Extended Auth Driver.
-        if (! Auth::user()->hasRole('administrator')) {
-            $status = __d('users', 'You are not authorized to access this resource.');
-
-            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
-        }
+        $this->beforeFilter('@adminUsersFilter');
     }
 
     protected function validate(array $data, $id = null)

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -9,13 +9,12 @@
 namespace App\Modules\Users\Controllers\Admin;
 
 use Helpers\ReCaptcha;
+use Http\Request;
 use Routing\Route;
 
 use App\Core\BackendController;
 use App\Models\Role;
 use App\Models\User;
-
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use Carbon\Carbon;
 
@@ -42,7 +41,7 @@ class Users extends BackendController
     /**
      * Filter the incoming requests.
      */
-    public function filterRequests(Route $route, SymfonyRequest $request)
+    public function filterRequests(Route $route, Request $request)
     {
         // Check the User Authorization - while using the Extended Auth Driver.
         if (! Auth::user()->hasRole('administrator')) {

--- a/app/Modules/Users/Controllers/Registrar.php
+++ b/app/Modules/Users/Controllers/Registrar.php
@@ -10,7 +10,7 @@ namespace App\Modules\Users\Controllers;
 
 use Helpers\ReCaptcha;
 
-use App\Core\Controller;
+use App\Core\BackendController;
 use App\Models\Role;
 use App\Models\User;
 
@@ -25,9 +25,8 @@ use Validator;
 use View;
 
 
-class Registrar extends Controller
+class Registrar extends BackendController
 {
-    protected $template = 'AdminLte';
     protected $layout   = 'default';
 
 

--- a/app/Modules/Users/Filters.php
+++ b/app/Modules/Users/Filters.php
@@ -9,11 +9,3 @@
 
 /** Define Route Filters. */
 
-// Role-based Authorization Filter.
-Route::filter('roles', function($route, $request, $response, $roles = null) {
-    if (! is_null($roles) && ! Auth::user()->hasRole($roles)) {
-         $status = __('You are not authorized to access this resource.');
-
-         return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
-    }
-});

--- a/system/Cache/CacheManager.php
+++ b/system/Cache/CacheManager.php
@@ -2,7 +2,7 @@
 
 namespace Cache;
 
-use Core\Config;
+use Config\Config;
 use Cache\ArrayStore;
 use Cache\FastCacheStore;
 use Cache\Repository;

--- a/system/Cache/FastCacheStore.php
+++ b/system/Cache/FastCacheStore.php
@@ -8,7 +8,7 @@
 
 namespace Cache;
 
-use Core\Config;
+use Config\Config;
 use Cache\StoreInterface;
 
 use phpFastCache\CacheManager as FastCacheManager;

--- a/system/Cli/ClearCacheCommand.php
+++ b/system/Cli/ClearCacheCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use Core\Config;
+use Config\Config;
 
 class ClearCacheCommand extends Command
 {

--- a/system/Cli/ClearSessionsCommand.php
+++ b/system/Cli/ClearSessionsCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use Core\Config;
+use Config\Config;
 
 class ClearSessionsCommand extends Command
 {

--- a/system/Cli/ControllerCommand.php
+++ b/system/Cli/ControllerCommand.php
@@ -100,7 +100,7 @@ class ControllerCommand extends Command
         $data = "<?php
 namespace App\Controllers;
 
-use Core\Controller;
+use App\Core\Controller;
 
 use View;
 

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -7,7 +7,7 @@
  * @date April 12th, 2016
  */
 
-namespace Core;
+namespace Config;
 
 
 class Config

--- a/system/Config/FileLoader.php
+++ b/system/Config/FileLoader.php
@@ -8,7 +8,7 @@
  */
 namespace Config;
 
-use Core\Config;
+use Config\Config;
 
 
 class FileLoader implements LoaderInterface

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -51,8 +51,6 @@ abstract class Controller extends BaseController
      */
     public function __construct()
     {
-        parent::__construct();
-
         // Setup the used Template to default, if it is not already defined.
         if (($this->layout !== false) && ! isset($this->template)) {
             $this->template = Config::get('app.template');

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -9,10 +9,7 @@
 namespace Core;
 
 use Core\Config;
-use Core\Language;
-use Http\Response;
 use Routing\Controller as BaseController;
-use Routing\Route;
 use Support\Contracts\RenderableInterface as Renderable;
 use Template\Template as Layout;
 
@@ -41,13 +38,6 @@ abstract class Controller extends BaseController
      */
     protected $layout = 'default';
 
-    /**
-     * Language variable to use the languages class.
-     *
-     * @var string
-     */
-    public $language = null;
-
 
     /**
      * On the initial run, create an instance of the config class and the view class.
@@ -57,11 +47,6 @@ abstract class Controller extends BaseController
         // Setup the used Template to default, if it is not already defined.
         if (($this->layout !== false) && ! isset($this->template)) {
             $this->template = Config::get('app.template');
-        }
-
-        // Initialise the Language object.
-        if ($this->language !== false) {
-            $this->language = Language::getInstance();
         }
     }
 
@@ -79,41 +64,11 @@ abstract class Controller extends BaseController
             // we will assume we want to render it using the Controller's templated environment.
 
             if (($this->layout !== false) && (! $response instanceof Layout)) {
-                return Template::make($this->layout, $this->template)->with('content', $response);
+                $response = Template::make($this->layout, $this->template)->with('content', $response);
             }
-        } else if (is_null($response)) {
-            // If the response which is returned from the Controller's Action is null and we have
-            // View instances on View's Legacy support, we will assume that we are on Legacy Mode.
-
-            $items = View::getItems();
-
-            $headers = View::getHeaders();
-
-            // Render the View instances to response.
-            $response = '';
-
-            foreach ($items as $item) {
-                $response .= $item->render();
-            }
-
-            // Create a Response instance and return it.
-            return new Response($response, 200, $headers);
         }
 
-        return $response;
-    }
-
-    /**
-     * Return a translated string.
-     * @return string
-     */
-    protected function trans($str, $code = LANGUAGE_CODE)
-    {
-        if ($this->language instanceof Language) {
-            return $this->language->get($str, $code);
-        }
-
-        return $str;
+        return parent::processResponse($response);
     }
 
     /**

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -63,27 +63,6 @@ abstract class Controller extends BaseController
         if ($this->language !== false) {
             $this->language = Language::getInstance();
         }
-
-        // Setup the Controller Middleware; preserve the legacy before/after methods.
-        $this->beforeFilter('@before');
-
-        $this->afterFilter('@after');
-    }
-
-    /**
-     * The (legacy) Middleware called before the Action execution.
-     */
-    protected function before(Route $route, SymfonyRequest $request)
-    {
-        //
-    }
-
-    /**
-     * The (legacy) Middleware called after the Action execution.
-     */
-    protected function after(Route $route, SymfonyRequest $request, $response)
-    {
-        //
     }
 
     /**
@@ -181,26 +160,4 @@ abstract class Controller extends BaseController
         return $this->layout;
     }
 
-    /**
-     * Handle calls to missing methods on the Controller.
-     *
-     * @param  string  $method
-     * @param  array   $parameters
-     * @return mixed
-     *
-     * @throws \BadMethodCallException
-     */
-    public function __call($method, $parameters)
-    {
-        switch ($method) {
-            case 'before':
-            case 'after':
-                return call_user_func_array(array($this, $method), $parameters);
-
-            default:
-                break;
-        }
-
-        throw new \BadMethodCallException("Method [$method] does not exist.");
-    }
 }

--- a/system/Core/Controller.php
+++ b/system/Core/Controller.php
@@ -9,11 +9,13 @@
 namespace Core;
 
 use Core\Config;
+use Http\Response;
 use Routing\Controller as BaseController;
 use Support\Contracts\RenderableInterface as Renderable;
 use Template\Template as Layout;
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 use Template;
 use View;
@@ -68,7 +70,12 @@ abstract class Controller extends BaseController
             }
         }
 
-        return parent::processResponse($response);
+        // If the response is not a instance of Symfony Response, create a proper one.
+        if (! $response instanceof SymfonyResponse) {
+            $response = new Response($response);
+        }
+
+        return $response;
     }
 
     /**

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -10,7 +10,7 @@ namespace Database;
 
 use Config\Config;
 use Core\Logger;
-use Database\Connectors\Connector;
+use Database\Connector;
 use Database\Connectors\MySqlConnector;
 use Database\Connectors\PostgresConnector;
 use Database\Connectors\SQLiteConnector;

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -8,7 +8,7 @@
 
 namespace Database;
 
-use Core\Config;
+use Config\Config;
 use Core\Logger;
 use Database\Connectors\Connector;
 use Database\Connectors\MySqlConnector;

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -10,19 +10,26 @@ namespace Database;
 
 use Config\Config;
 use Core\Logger;
-use Database\Connector;
+
 use Database\Connectors\MySqlConnector;
 use Database\Connectors\PostgresConnector;
 use Database\Connectors\SQLiteConnector;
+
 use Database\Query\Grammars\MySqlGrammar;
 use Database\Query\Grammars\PostgresGrammar;
 use Database\Query\Grammars\SQLiteGrammar;
+use Database\Query\Grammars\SqlServerGrammar;
+
 use Database\Query\Processors\MySqlProcessor;
 use Database\Query\Processors\PostgresProcessor;
 use Database\Query\Processors\SQLiteProcessor;
+use Database\Query\Processors\SqlServerProcessor;
+
 use Database\Query\Expression;
 use Database\Query\Grammar;
 use Database\Query\Builder as QueryBuilder;
+
+use Database\Connector;
 use Database\QueryException;
 
 use Closure;
@@ -222,6 +229,9 @@ class Connection
 
             case 'sqlite':
                 return new SQLiteGrammar();
+
+            case 'sqlsrv':
+                return new SqlServerConnector();
         }
 
         throw new \InvalidArgumentException("Unsupported driver [{$this->driver}]");
@@ -246,6 +256,9 @@ class Connection
 
             case 'sqlite':
                 return new SQLiteProcessor();
+
+            case 'sqlsrv':
+                return new SqlServerProcessor();
         }
 
         throw new \InvalidArgumentException("Unsupported driver [{$this->driver}]");

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -14,7 +14,7 @@ use Core\Logger;
 use Database\Query\Expression;
 use Database\Query\Grammar as QueryGrammar;
 use Database\Query\Builder as QueryBuilder;
-use Database\Query\Processor as PostProcessor;
+use Database\Query\Processor as QueryProcessor;
 
 use Database\ConnectionInterface;
 use Database\Connector;
@@ -196,7 +196,7 @@ class Connection implements ConnectionInterface
      */
     protected function getDefaultPostProcessor()
     {
-        return new PostProcessor();
+        return new QueryProcessor();
     }
 
     /**

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -595,7 +595,7 @@ class Connection
      *
      * @return \Database\Query\Processor
      */
-    public function getQueryProcessor()
+    public function getPostProcessor()
     {
         return $this->processor;
     }

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -172,7 +172,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the default query grammar instance.
      *
-     * @return \Database\Query\Grammars\Grammar
+     * @return \Database\Query\Grammar
      */
     protected function getDefaultQueryGrammar()
     {
@@ -192,7 +192,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the default post processor instance.
      *
-     * @return \Database\Query\Processors\Processor
+     * @return \Database\Query\Processor
      */
     protected function getDefaultPostProcessor()
     {
@@ -685,7 +685,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the paginator environment instance.
      *
-     * @return \Illuminate\Pagination\Environment
+     * @return \Pagination\Environment
      */
     public function getPaginator()
     {
@@ -710,7 +710,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the cache manager instance.
      *
-     * @return \Illuminate\Cache\CacheManager
+     * @return \Cache\CacheManager
      */
     public function getCacheManager()
     {

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -14,6 +14,7 @@ use Core\Logger;
 use Database\Connectors\MySqlConnector;
 use Database\Connectors\PostgresConnector;
 use Database\Connectors\SQLiteConnector;
+use Database\Connectors\SqlServerConnector;
 
 use Database\Query\Grammars\MySqlGrammar;
 use Database\Query\Grammars\PostgresGrammar;
@@ -205,6 +206,9 @@ class Connection
 
             case 'sqlite':
                 return new SQLiteConnector();
+
+            case 'sqlsrv':
+                return new SqlServerConnector();
         }
 
         throw new \InvalidArgumentException("Unsupported driver [{$this->driver}]");
@@ -231,7 +235,7 @@ class Connection
                 return new SQLiteGrammar();
 
             case 'sqlsrv':
-                return new SqlServerConnector();
+                return new SqlServerGrammar();
         }
 
         throw new \InvalidArgumentException("Unsupported driver [{$this->driver}]");

--- a/system/Database/Connection.php
+++ b/system/Database/Connection.php
@@ -16,6 +16,7 @@ use Database\Query\Grammar as QueryGrammar;
 use Database\Query\Builder as QueryBuilder;
 use Database\Query\Processor as PostProcessor;
 
+use Database\ConnectionInterface;
 use Database\Connector;
 use Database\QueryException;
 
@@ -24,7 +25,7 @@ use DateTimeInterface;
 use PDO;
 
 
-class Connection
+class Connection implements ConnectionInterface
 {
     /**
      * The Connector instance.
@@ -131,7 +132,7 @@ class Connection
      */
     protected $config = array();
 
-    
+
     /**
      * Create a new Database Connection instance.
      *
@@ -245,7 +246,7 @@ class Connection
      * @param  array   $bindings
      * @return array
      */
-    public function select($query, array $bindings = array())
+    public function select($query, $bindings = array())
     {
         return $this->run($query, $bindings, function($me, $query, $bindings)
         {
@@ -269,7 +270,7 @@ class Connection
      * @param  array   $bindings
      * @return bool
      */
-    public function insert($query, array $bindings = array())
+    public function insert($query, $bindings = array())
     {
         return $this->statement($query, $bindings);
     }
@@ -281,7 +282,7 @@ class Connection
      * @param  array   $bindings
      * @return int
      */
-    public function update($query, array $bindings = array())
+    public function update($query, $bindings = array())
     {
         return $this->affectingStatement($query, $bindings);
     }
@@ -293,7 +294,7 @@ class Connection
      * @param  array   $bindings
      * @return int
      */
-    public function delete($query, array $bindings = array())
+    public function delete($query, $bindings = array())
     {
         return $this->affectingStatement($query, $bindings);
     }
@@ -305,7 +306,7 @@ class Connection
      * @param  array   $bindings
      * @return bool
      */
-    public function statement($query, array $bindings = array())
+    public function statement($query, $bindings = array())
     {
         return $this->run($query, $bindings, function($me, $query, $bindings)
         {
@@ -327,7 +328,7 @@ class Connection
      * @param  array   $bindings
      * @return int
      */
-    public function affectingStatement($query, array $bindings = array())
+    public function affectingStatement($query, $bindings = array())
     {
         return $this->run($query, $bindings, function($me, $query, $bindings)
         {

--- a/system/Database/ConnectionFactory.php
+++ b/system/Database/ConnectionFactory.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Database;
+
+use Container\Container;
+
+use Database\Connections\MySqlConnection;
+use Database\Connections\SQLiteConnection;
+use Database\Connections\PostgresConnection;
+use Database\Connections\SqlServerConnection;
+
+use Database\Connectors\MySqlConnector;
+use Database\Connectors\SQLiteConnector;
+use Database\Connectors\PostgresConnector;
+use Database\Connectors\SqlServerConnector;
+
+use PDO;
+
+
+class ConnectionFactory
+{
+    /**
+     * The IoC container instance.
+     *
+     * @var \Container\Container
+     */
+    protected $container;
+
+    /**
+     * Create a new connection factory instance.
+     *
+     * @param  \Container\Container  $container
+     * @return void
+     */
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Establish a PDO connection based on the configuration.
+     *
+     * @param  array   $config
+     * @param  string  $name
+     * @return \Database\Connection
+     */
+    public function make(array $config, $name = null)
+    {
+        $config = $this->parseConfig($config, $name);
+
+        return $this->createSingleConnection($config);
+    }
+
+    /**
+     * Create a single database connection instance.
+     *
+     * @param  array  $config
+     * @return \Database\Connection
+     */
+    protected function createSingleConnection(array $config)
+    {
+        $pdo = $this->createConnector($config)->connect($config);
+
+        return $this->createConnection($config['driver'], $pdo, $config['database'], $config['prefix'], $config);
+    }
+
+    /**
+     * Parse and prepare the Database configuration.
+     *
+     * @param  array   $config
+     * @param  string  $name
+     * @return array
+     */
+    protected function parseConfig(array $config, $name)
+    {
+        return array_add(array_add($config, 'prefix', ''), 'name', $name);
+    }
+
+    /**
+     * Create a connector instance based on the configuration.
+     *
+     * @param  array  $config
+     * @return \Database\Connectors\ConnectorInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function createConnector(array $config)
+    {
+        if ( ! isset($config['driver'])) {
+            throw new \InvalidArgumentException("A driver must be specified.");
+        }
+
+        if ($this->container->bound($key = "db.connector.{$config['driver']}")) {
+            return $this->container->make($key);
+        }
+
+        switch ($config['driver'])
+        {
+            case 'mysql':
+                return new MySqlConnector();
+
+            case 'pgsql':
+                return new PostgresConnector();
+
+            case 'sqlite':
+                return new SQLiteConnector();
+
+            case 'sqlsrv':
+                return new SqlServerConnector();
+        }
+
+        throw new \InvalidArgumentException("Unsupported driver [{$config['driver']}]");
+    }
+
+    /**
+     * Create a new connection instance.
+     *
+     * @param  string   $driver
+     * @param  \PDO     $connection
+     * @param  string   $database
+     * @param  string   $prefix
+     * @param  array    $config
+     * @return \Database\Connection
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = array())
+    {
+        if ($this->container->bound($key = "db.connection.{$driver}")) {
+            return $this->container->make($key, array($connection, $database, $prefix, $config));
+        }
+
+        switch ($driver) {
+            case 'mysql':
+                return new MySqlConnection($connection, $database, $prefix, $config);
+
+            case 'pgsql':
+                return new PostgresConnection($connection, $database, $prefix, $config);
+
+            case 'sqlite':
+                return new SQLiteConnection($connection, $database, $prefix, $config);
+
+            case 'sqlsrv':
+                return new SqlServerConnection($connection, $database, $prefix, $config);
+        }
+
+        throw new \InvalidArgumentException("Unsupported driver [$driver]");
+    }
+
+}

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -4,6 +4,7 @@ namespace Database;
 
 use Closure;
 
+
 interface ConnectionInterface
 {
     /**

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Database;
+
+use Closure;
+
+interface ConnectionInterface
+{
+    /**
+     * Begin a fluent query against a database table.
+     *
+     * @param  string  $table
+     * @return \Nova\Database\Query\Builder
+     */
+    public function table($table);
+
+    /**
+     * Get a new raw query expression.
+     *
+     * @param  mixed  $value
+     * @return \Nova\Database\Query\Expression
+     */
+    public function raw($value);
+
+    /**
+     * Run a select statement and return a single result.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return mixed
+     */
+    public function selectOne($query, $bindings = array());
+
+    /**
+     * Run a select statement against the database.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return array
+     */
+    public function select($query, $bindings = array());
+
+    /**
+     * Run an insert statement against the database.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return bool
+     */
+    public function insert($query, $bindings = array());
+
+    /**
+     * Run an update statement against the database.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return int
+     */
+    public function update($query, $bindings = array());
+
+    /**
+     * Run a delete statement against the database.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return int
+     */
+    public function delete($query, $bindings = array());
+
+    /**
+     * Execute an SQL statement and return the boolean result.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return bool
+     */
+    public function statement($query, $bindings = array());
+
+    /**
+     * Run an SQL statement and get the number of rows affected.
+     *
+     * @param  string  $query
+     * @param  array   $bindings
+     * @return int
+     */
+    public function affectingStatement($query, $bindings = array());
+
+    /**
+     * Run a raw, unprepared query against the PDO connection.
+     *
+     * @param  string  $query
+     * @return bool
+     */
+    public function unprepared($query);
+
+    /**
+     * Prepare the query bindings for execution.
+     *
+     * @param  array  $bindings
+     * @return array
+     */
+    public function prepareBindings(array $bindings);
+
+    /**
+     * Execute a Closure within a transaction.
+     *
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function transaction(Closure $callback);
+
+    /**
+     * Start a new database transaction.
+     *
+     * @return void
+     */
+    public function beginTransaction();
+
+    /**
+     * Commit the active database transaction.
+     *
+     * @return void
+     */
+    public function commit();
+
+    /**
+     * Rollback the active database transaction.
+     *
+     * @return void
+     */
+    public function rollBack();
+
+    /**
+     * Get the number of active transactions.
+     *
+     * @return int
+     */
+    public function transactionLevel();
+
+    /**
+     * Execute the given callback in "dry run" mode.
+     *
+     * @param  \Closure  $callback
+     * @return array
+     */
+    public function pretend(Closure $callback);
+
+}

--- a/system/Database/ConnectionResolver.php
+++ b/system/Database/ConnectionResolver.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Database;
+
+
+class ConnectionResolver implements ConnectionResolverInterface
+{
+    /**
+     * All of the registered connections.
+     *
+     * @var array
+     */
+    protected $connections = array();
+
+    /**
+     * The default connection name.
+     *
+     * @var string
+     */
+    protected $default;
+
+    /**
+     * Create a new connection resolver instance.
+     *
+     * @param  array  $connections
+     * @return void
+     */
+    public function __construct(array $connections = array())
+    {
+        foreach ($connections as $name => $connection) {
+            $this->addConnection($name, $connection);
+        }
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @param  string  $name
+     * @return \Nova\Database\Connection
+     */
+    public function connection($name = null)
+    {
+        if (is_null($name)) $name = $this->getDefaultConnection();
+
+        return $this->connections[$name];
+    }
+
+    /**
+     * Add a connection to the resolver.
+     *
+     * @param  string  $name
+     * @param  \Nova\Database\Connection  $connection
+     * @return void
+     */
+    public function addConnection($name, Connection $connection)
+    {
+        $this->connections[$name] = $connection;
+    }
+
+    /**
+     * Check if a connection has been registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasConnection($name)
+    {
+        return isset($this->connections[$name]);
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getDefaultConnection()
+    {
+        return $this->default;
+    }
+
+    /**
+     * Set the default connection name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultConnection($name)
+    {
+        $this->default = $name;
+    }
+
+}

--- a/system/Database/Connections/MySqlConnection.php
+++ b/system/Database/Connections/MySqlConnection.php
@@ -17,7 +17,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar());
     }
 
     /**
@@ -27,7 +27,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultPostProcessor()
     {
-        return new QueryProcessor;
+        return new QueryProcessor();
     }
 
 }

--- a/system/Database/Connections/MySqlConnection.php
+++ b/system/Database/Connections/MySqlConnection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Connections;
+
+use Database\Connection;
+use Database\Query\Grammars\MySqlGrammar as QueryGrammar;
+use Database\Query\Processors\MySqlProcessor as QueryProcessor;
+
+
+class MySqlConnection extends Connection
+{
+
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Database\Query\Grammars\MySqlGrammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        return $this->withTablePrefix(new QueryGrammar);
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Database\Query\Processors\Processor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return new QueryProcessor;
+    }
+
+}

--- a/system/Database/Connections/PostgresConnection.php
+++ b/system/Database/Connections/PostgresConnection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Connections;
+
+use Database\Connection;
+use Database\Query\Grammars\PostgresGrammar as QueryGrammar;
+use Database\Query\Processors\PostgresProcessor as QueryProcessor;
+
+
+class PostgresConnection extends Connection
+{
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Database\Query\Grammars\PostgresGrammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        return $this->withTablePrefix(new QueryGrammar);
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Database\Query\Processors\PostgresProcessor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return new QueryProcessor;
+    }
+
+}

--- a/system/Database/Connections/PostgresConnection.php
+++ b/system/Database/Connections/PostgresConnection.php
@@ -16,7 +16,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar());
     }
 
     /**
@@ -26,7 +26,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultPostProcessor()
     {
-        return new QueryProcessor;
+        return new QueryProcessor();
     }
 
 }

--- a/system/Database/Connections/SQLiteConnection.php
+++ b/system/Database/Connections/SQLiteConnection.php
@@ -17,7 +17,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar());
     }
 
     /**
@@ -27,7 +27,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultPostProcessor()
     {
-        return new QueryProcessor;
+        return new QueryProcessor();
     }
 
 }

--- a/system/Database/Connections/SQLiteConnection.php
+++ b/system/Database/Connections/SQLiteConnection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Connections;
+
+use Database\Connection;
+use Database\Query\Grammars\SQLiteGrammar as QueryGrammar;
+use Database\Query\Processors\SQLiteProcessor as QueryProcessor;
+
+
+class SQLiteConnection extends Connection
+{
+
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Database\Query\Grammars\SQLiteGrammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        return $this->withTablePrefix(new QueryGrammar);
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Database\Query\Processors\Processor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return new QueryProcessor;
+    }
+
+}

--- a/system/Database/Connections/SqlServerConnection.php
+++ b/system/Database/Connections/SqlServerConnection.php
@@ -48,7 +48,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar());
     }
 
     /**
@@ -58,7 +58,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultPostProcessor()
     {
-        return new QueryProcessor;
+        return new QueryProcessor();
     }
 
 }

--- a/system/Database/Connections/SqlServerConnection.php
+++ b/system/Database/Connections/SqlServerConnection.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Connections;
+
+use Database\Connection;
+use Database\Query\Grammars\SqlServerGrammar as QueryGrammar;
+use Database\Query\Processors\SqlServerProcessor as QueryProcessor;
+
+use Closure;
+
+
+class SqlServerConnection extends Connection
+{
+
+    /**
+     * Execute a Closure within a transaction.
+     *
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function transaction(Closure $callback)
+    {
+        if ($this->getDriverName() == 'sqlsrv') {
+            return parent::transaction($callback);
+        }
+
+        $this->pdo->exec('BEGIN TRAN');
+
+        try {
+            $result = $callback($this);
+
+            $this->pdo->exec('COMMIT TRAN');
+        } catch (\Exception $e) {
+            $this->pdo->exec('ROLLBACK TRAN');
+
+            throw $e;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Database\Query\Grammars\SqlServerGrammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        return $this->withTablePrefix(new QueryGrammar);
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Database\Query\Processors\Processor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return new QueryProcessor;
+    }
+
+}

--- a/system/Database/Connector.php
+++ b/system/Database/Connector.php
@@ -26,16 +26,10 @@ abstract class Connector
         PDO::ATTR_EMULATE_PREPARES  => false,
     );
 
-    /**
-     * The keyword identifier wrapper format.
-     *
-     * @var string
-     */
-    protected $wrapper = '`%s`';
-
 
     public function __construct()
     {
+        //
     }
 
     /**
@@ -87,26 +81,6 @@ abstract class Connector
     public function setDefaultOptions(array $options)
     {
         $this->options = $options;
-    }
-
-    /**
-     * Get the keyword identifier wrapper format.
-     *
-     * @return string
-     */
-    public function getWrapper()
-    {
-        return $this->wrapper;
-    }
-
-    /**
-     * Get the format for database stored dates.
-     *
-     * @return string
-     */
-    public function getDateFormat()
-    {
-        return 'Y-m-d H:i:s';
     }
 
 }

--- a/system/Database/Connector.php
+++ b/system/Database/Connector.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-namespace Database\Connectors;
+namespace Database;
 
 use PDO;
 

--- a/system/Database/ConnectorInterface.php
+++ b/system/Database/ConnectorInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\Connectors;
+namespace Database;
 
 
 interface ConnectorInterface

--- a/system/Database/Connectors/MySqlConnector.php
+++ b/system/Database/Connectors/MySqlConnector.php
@@ -8,8 +8,8 @@
 
 namespace Database\Connectors;
 
-use Database\Connectors\Connector;
-use Database\Connectors\ConnectorInterface;
+use Database\Connector;
+use Database\ConnectorInterface;
 
 use PDO;
 
@@ -62,7 +62,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
         if (isset($config['port'])) {
             $dsn .= ";port={$port}";
         }
-        
+
         if (isset($config['unix_socket'])) {
             $dsn .= ";unix_socket={$config['unix_socket']}";
         }

--- a/system/Database/Connectors/PostgresConnector.php
+++ b/system/Database/Connectors/PostgresConnector.php
@@ -2,8 +2,8 @@
 
 namespace Database\Connectors;
 
-use Database\Connectors\Connector;
-use Database\Connectors\ConnectorInterface;
+use Database\Connector;
+use Database\ConnectorInterface;
 
 use PDO;
 

--- a/system/Database/Connectors/SQLiteConnector.php
+++ b/system/Database/Connectors/SQLiteConnector.php
@@ -16,13 +16,6 @@ use PDO;
 
 class SQLiteConnector extends Connector implements ConnectorInterface
 {
-    /**
-     * The keyword identifier wrapper format.
-     *
-     * @var string
-     */
-    protected $wrapper = '"%s"';
-
 
     /**
      * Establish a database connection.

--- a/system/Database/Connectors/SQLiteConnector.php
+++ b/system/Database/Connectors/SQLiteConnector.php
@@ -8,8 +8,8 @@
 
 namespace Database\Connectors;
 
-use Database\Connectors\Connector;
-use Database\Connectors\ConnectorInterface;
+use Database\Connector;
+use Database\ConnectorInterface;
 
 use PDO;
 

--- a/system/Database/Connectors/SqlServerConnector.php
+++ b/system/Database/Connectors/SqlServerConnector.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Connectors;
+
+use Database\Connector;
+use Database\ConnectorInterface;
+
+use PDO;
+
+
+class SqlServerConnector extends Connector implements ConnectorInterface
+{
+    /**
+     * The PDO connection options.
+     *
+     * @var array
+     */
+    protected $options = array(
+            PDO::ATTR_CASE => PDO::CASE_NATURAL,
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
+            PDO::ATTR_STRINGIFY_FETCHES => false,
+    );
+
+    /**
+     * Establish a database connection.
+     *
+     * @param  array  $config
+     * @return \PDO
+     */
+    public function connect(array $config)
+    {
+        $options = $this->getOptions($config);
+
+        return $this->createConnection($this->getDsn($config), $config, $options);
+    }
+
+    /**
+     * Create a DSN string from a configuration.
+     *
+     * @param  array   $config
+     * @return string
+     */
+    protected function getDsn(array $config)
+    {
+        extract($config);
+
+        // First we will create the basic DSN setup as well as the port if it is in
+        // in the configuration options. This will give us the basic DSN we will
+        // need to establish the PDO connections and return them back for use.
+        if (in_array('dblib', $this->getAvailableDrivers())) {
+            $port = isset($config['port']) ? ':'.$port : '';
+
+            return "dblib:host={$hostname}{$port};dbname={$database}";
+        }
+
+        $port = isset($config['port']) ? ','.$port : '';
+
+        $dbName = $database != '' ? ";Database={$database}" : '';
+
+        return "sqlsrv:Server={$hostname}{$port}{$dbName}";
+    }
+
+    /**
+     * Get the available PDO drivers.
+     *
+     * @return array
+     */
+    protected function getAvailableDrivers()
+    {
+        return PDO::getAvailableDrivers();
+    }
+
+}

--- a/system/Database/DatabaseServiceProvider.php
+++ b/system/Database/DatabaseServiceProvider.php
@@ -11,7 +11,7 @@ namespace Database;
 use Database\DatabaseManager;
 use Database\ORM\Model;
 use Database\Model as BasicModel;
-use Helpers\Database as DatabaseHelper;
+use Helpers\Database;
 use Support\ServiceProvider;
 
 
@@ -37,7 +37,7 @@ class DatabaseServiceProvider extends ServiceProvider
         BasicModel::setConnectionResolver($db);
 
         // Setup the legacy Database Helper.
-        DatabaseHelper::setConnectionResolver($db);
+        Database::setConnectionResolver($db);
     }
 
     /**

--- a/system/Database/DatabaseServiceProvider.php
+++ b/system/Database/DatabaseServiceProvider.php
@@ -10,7 +10,7 @@ namespace Database;
 
 use Database\DatabaseManager;
 use Database\ORM\Model;
-use Database\Model as SimpleModel;
+use Database\Model as BasicModel;
 use Helpers\Database as DatabaseHelper;
 use Support\ServiceProvider;
 
@@ -28,13 +28,13 @@ class DatabaseServiceProvider extends ServiceProvider
 
         $events = $this->app['events'];
 
-        // Setup the (simple) Model.
-        SimpleModel::setConnectionResolver($db);
-
         // Setup the ORM Model.
         Model::setConnectionResolver($db);
 
         Model::setEventDispatcher($events);
+
+        // Setup the (basic) Model.
+        BasicModel::setConnectionResolver($db);
 
         // Setup the legacy Database Helper.
         DatabaseHelper::setConnectionResolver($db);

--- a/system/Database/DatabaseServiceProvider.php
+++ b/system/Database/DatabaseServiceProvider.php
@@ -8,8 +8,9 @@
 
 namespace Database;
 
-use Database\DatabaseManager;
 use Database\ORM\Model;
+use Database\ConnectionFactory;
+use Database\DatabaseManager;
 use Database\Model as BasicModel;
 use Helpers\Database;
 use Support\ServiceProvider;
@@ -47,9 +48,14 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->bindShared('db.factory', function($app)
+        {
+            return new ConnectionFactory($app);
+        });
+
         $this->app->bindShared('db', function($app)
         {
-            return new DatabaseManager($app);
+            return new DatabaseManager($app, $app['db.factory']);
         });
     }
 

--- a/system/Database/DatabaseServiceProvider.php
+++ b/system/Database/DatabaseServiceProvider.php
@@ -24,16 +24,20 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $db = $this->app['db'];
+
+        $events = $this->app['events'];
+
         // Setup the (simple) Model.
-        SimpleModel::setConnectionResolver($this->app['db']);
+        SimpleModel::setConnectionResolver($db);
 
         // Setup the ORM Model.
-        Model::setConnectionResolver($this->app['db']);
+        Model::setConnectionResolver($db);
 
-        Model::setEventDispatcher($this->app['events']);
+        Model::setEventDispatcher($events);
 
         // Setup the legacy Database Helper.
-        DatabaseHelper::setConnectionResolver($this->app['db']);
+        DatabaseHelper::setConnectionResolver($db);
     }
 
     /**

--- a/system/Database/Grammar.php
+++ b/system/Database/Grammar.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Database;
+
+
+abstract class Grammar
+{
+    /**
+     * The Grammar table prefix.
+     *
+     * @var string
+     */
+    protected $tablePrefix = '';
+
+
+    /**
+     * Wrap an array of values.
+     *
+     * @param  array  $values
+     * @return array
+     */
+    public function wrapArray(array $values)
+    {
+        return array_map(array($this, 'wrap'), $values);
+    }
+
+    /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        if ($this->isExpression($table)) return $this->getValue($table);
+
+        return $this->wrap($this->tablePrefix .$table);
+    }
+
+    /**
+     * Wrap a value in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrap($value)
+    {
+        if ($this->isExpression($value)) return $this->getValue($value);
+
+        if (strpos(strtolower($value), ' as ') !== false) {
+            $segments = explode(' ', $value);
+
+            return $this->wrap($segments[0]) .' as ' .$this->wrapValue($segments[2]);
+        }
+
+        $wrapped = array();
+
+        $segments = explode('.', $value);
+
+        foreach ($segments as $key => $segment) {
+            if (($key == 0) && (count($segments) > 1)) {
+                $wrapped[] = $this->wrapTable($segment);
+            } else {
+                $wrapped[] = $this->wrapValue($segment);
+            }
+        }
+
+        return implode('.', $wrapped);
+    }
+
+    /**
+     * Wrap a single string in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        if ($value === '*') return $value;
+
+        return '"'.str_replace('"', '""', $value).'"';
+    }
+
+    /**
+     * Convert an array of column names into a delimited string.
+     *
+     * @param  array   $columns
+     * @return string
+     */
+    public function columnize(array $columns)
+    {
+        return implode(', ', array_map(array($this, 'wrap'), $columns));
+    }
+
+    /**
+     * Create query parameter place-holders for an array.
+     *
+     * @param  array   $values
+     * @return string
+     */
+    public function parameterize(array $values)
+    {
+        return implode(', ', array_map(array($this, 'parameter'), $values));
+    }
+
+    /**
+     * Get the appropriate query parameter place-holder for a value.
+     *
+     * @param  mixed   $value
+     * @return string
+     */
+    public function parameter($value)
+    {
+        return $this->isExpression($value) ? $this->getValue($value) : '?';
+    }
+
+    /**
+     * Get the value of a raw expression.
+     *
+     * @param  \Nova\Database\Query\Expression  $expression
+     * @return string
+     */
+    public function getValue($expression)
+    {
+        return $expression->getValue();
+    }
+
+    /**
+     * Determine if the given value is a raw expression.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function isExpression($value)
+    {
+        return $value instanceof Query\Expression;
+    }
+
+    /**
+     * Get the format for database stored dates.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * Get the grammar's table prefix.
+     *
+     * @return string
+     */
+    public function getTablePrefix()
+    {
+        return $this->tablePrefix;
+    }
+
+    /**
+     * Set the grammar's table prefix.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function setTablePrefix($prefix)
+    {
+        $this->tablePrefix = $prefix;
+
+        return $this;
+    }
+
+}

--- a/system/Database/ORM/Collection.php
+++ b/system/Database/ORM/Collection.php
@@ -8,7 +8,7 @@ use Support\Collection as BaseCollection;
 class Collection extends BaseCollection
 {
     /**
-     * Find a Model in the collection by key.
+     * Find a model in the collection by key.
      *
      * @param  mixed  $key
      * @param  mixed  $default
@@ -30,8 +30,8 @@ class Collection extends BaseCollection
     /**
      * Load a set of relationships onto the collection.
      *
-     * @param  dynamic  $relations
-     * @return \Database\ORM\Collection
+     * @param  mixed  $relations
+     * @return $this
      */
     public function load($relations)
     {
@@ -50,7 +50,7 @@ class Collection extends BaseCollection
      * Add an item to the collection.
      *
      * @param  mixed  $item
-     * @return \Database\ORM\Collection
+     * @return $this
      */
     public function add($item)
     {
@@ -74,7 +74,7 @@ class Collection extends BaseCollection
      * Fetch a nested element of the collection.
      *
      * @param  string  $key
-     * @return \Support\Collection
+     * @return static
      */
     public function fetch($key)
     {
@@ -122,15 +122,14 @@ class Collection extends BaseCollection
     /**
      * Merge the collection with the given items.
      *
-     * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Support\Collection
+     * @param  \ArrayAccess|array  $items
+     * @return static
      */
-    public function merge($collection)
+    public function merge($items)
     {
         $dictionary = $this->getDictionary();
 
-        foreach ($collection as $item)
-        {
+        foreach ($items as $item) {
             $dictionary[$item->getKey()] = $item;
         }
 
@@ -140,14 +139,14 @@ class Collection extends BaseCollection
     /**
      * Diff the collection with the given items.
      *
-     * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Support\Collection
+     * @param  \ArrayAccess|array  $items
+     * @return static
      */
-    public function diff($collection)
+    public function diff($items)
     {
         $diff = new static;
 
-        $dictionary = $this->getDictionary($collection);
+        $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
             if ( ! isset($dictionary[$item->getKey()])) {
@@ -161,14 +160,14 @@ class Collection extends BaseCollection
     /**
      * Intersect the collection with the given items.
      *
-      * @param  \Support\Collection|\Support\Contracts\ArrayableInterface|array  $items
-     * @return \Support\Collection
+      * @param  \ArrayAccess|array  $items
+     * @return static
      */
-    public function intersect($collection)
+    public function intersect($items)
     {
         $intersect = new static;
 
-        $dictionary = $this->getDictionary($collection);
+        $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
             if (isset($dictionary[$item->getKey()])) {
@@ -182,7 +181,7 @@ class Collection extends BaseCollection
     /**
      * Return only unique items from the collection.
      *
-     * @return \Support\Collection
+     * @return static
      */
     public function unique()
     {
@@ -195,11 +194,11 @@ class Collection extends BaseCollection
      * Returns only the models from the collection with the specified keys.
      *
      * @param  mixed  $keys
-     * @return \Support\Collection
+     * @return static
      */
     public function only($keys)
     {
-        $dictionary = array_only($this->getDictionary($this), $keys);
+        $dictionary = array_only($this->getDictionary(), $keys);
 
         return new static(array_values($dictionary));
     }
@@ -208,11 +207,11 @@ class Collection extends BaseCollection
      * Returns all models in the collection except the models with specified keys.
      *
      * @param  mixed  $keys
-     * @return \Support\Collection
+     * @return static
      */
     public function except($keys)
     {
-        $dictionary = array_except($this->getDictionary($this), $keys);
+        $dictionary = array_except($this->getDictionary(), $keys);
 
         return new static(array_values($dictionary));
     }
@@ -220,16 +219,16 @@ class Collection extends BaseCollection
     /**
      * Get a dictionary keyed by primary keys.
      *
-     * @param  \Support\Collection  $collection
+     * @param  \ArrayAccess|array  $items
      * @return array
      */
-    public function getDictionary($collection = null)
+    public function getDictionary($items = null)
     {
-        $collection = $collection ?: $this;
+        $items = is_null($items) ? $this->items : $items;
 
         $dictionary = array();
 
-        foreach ($collection as $value) {
+        foreach ($items as $value) {
             $dictionary[$value->getKey()] = $value;
         }
 

--- a/system/Database/ORM/Model.php
+++ b/system/Database/ORM/Model.php
@@ -1596,7 +1596,11 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
     {
         $connection = $this->getConnection();
 
-        return new QueryBuilder($connection);
+        $grammar = $connection->getQueryGrammar();
+
+        $processor = $connection->getQueryProcessor();
+
+        return new QueryBuilder($connection, $grammar, $processor);
     }
 
     /**
@@ -2320,7 +2324,7 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
      */
     protected function getDateFormat()
     {
-        return $this->getConnection()->getDateFormat();
+        return $this->getConnection()->getQueryGrammar()->getDateFormat();
     }
 
     /**

--- a/system/Database/ORM/Model.php
+++ b/system/Database/ORM/Model.php
@@ -1598,7 +1598,7 @@ class Model implements ArrayableInterface, JsonableInterface, ArrayAccess
 
         $grammar = $connection->getQueryGrammar();
 
-        $processor = $connection->getQueryProcessor();
+        $processor = $connection->getPostProcessor();
 
         return new QueryBuilder($connection, $grammar, $processor);
     }

--- a/system/Database/ORM/ModelNotFoundException.php
+++ b/system/Database/ORM/ModelNotFoundException.php
@@ -6,29 +6,29 @@ namespace Database\ORM;
 class ModelNotFoundException extends \RuntimeException
 {
     /**
-     * Name of the affected ORM Model.
+     * Name of the affected Eloquent model.
      *
      * @var string
      */
     protected $model;
 
     /**
-     * Set the affected ORM Model.
+     * Set the affected Eloquent model.
      *
      * @param  string   $model
-     * @return ModelNotFoundException
+     * @return $this
      */
     public function setModel($model)
     {
         $this->model = $model;
 
-        $this->message = "No query results for Model [{$model}].";
+        $this->message = "No query results for model [{$model}].";
 
         return $this;
     }
 
     /**
-     * Get the affected ORM model.
+     * Get the affected Eloquent model.
      *
      * @return string
      */

--- a/system/Database/ORM/Relations/HasOne.php
+++ b/system/Database/ORM/Relations/HasOne.php
@@ -4,7 +4,6 @@ namespace Database\ORM\Relations;
 
 use Database\ORM\Collection;
 
-
 class HasOne extends HasOneOrMany
 {
     /**

--- a/system/Database/ORM/Relations/MorphMany.php
+++ b/system/Database/ORM/Relations/MorphMany.php
@@ -3,7 +3,6 @@
 namespace Database\ORM\Relations;
 
 use Database\ORM\Collection;
-use Database\ORM\Relations\MorphOneOrMany;
 
 
 class MorphMany extends MorphOneOrMany

--- a/system/Database/ORM/Relations/MorphOne.php
+++ b/system/Database/ORM/Relations/MorphOne.php
@@ -3,7 +3,6 @@
 namespace Database\ORM\Relations;
 
 use Database\ORM\Collection;
-use Database\ORM\Relations\MorphOneOrMany;
 
 
 class MorphOne extends MorphOneOrMany

--- a/system/Database/ORM/Relations/MorphOneOrMany.php
+++ b/system/Database/ORM/Relations/MorphOneOrMany.php
@@ -4,7 +4,6 @@ namespace Database\ORM\Relations;
 
 use Database\ORM\Model;
 use Database\ORM\Builder;
-use Database\ORM\Relations\HasOneMany;
 
 
 abstract class MorphOneOrMany extends HasOneOrMany
@@ -23,7 +22,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     protected $morphClass;
 
-    
     /**
      * Create a new has many relationship instance.
      *
@@ -32,7 +30,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
-     * @param  string  $morphClass
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $type, $id, $localKey)
@@ -51,8 +48,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function addConstraints()
     {
-        if (static::$constraints)
-        {
+        if (static::$constraints) {
             parent::addConstraints();
 
             $this->query->where($this->morphType, $this->morphClass);
@@ -60,7 +56,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Get the relationship count query.
      *
      * @param  \Database\ORM\Builder  $query
      * @param  \Database\ORM\Builder  $parent
@@ -107,14 +103,9 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function create(array $attributes)
     {
-        $foreign = $this->getForeignAttributesForCreate();
-
-        // When saving a polymorphic relationship, we need to set not only the foreign
-        // key, but also the foreign key type, which is typically the class name of
-        // the parent model. This makes the polymorphic item unique in the table.
-        $attributes = array_merge($attributes, $foreign);
-
         $instance = $this->related->newInstance($attributes);
+
+        $this->setForeignAttributesForCreate($instance);
 
         $instance->save();
 
@@ -122,17 +113,16 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Get the foreign ID and type for creating a related model.
+     * Set the foreign ID and type for creating a related model.
      *
-     * @return array
+     * @param  \Database\ORM\Model  $model
+     * @return void
      */
-    protected function getForeignAttributesForCreate()
+    protected function setForeignAttributesForCreate(Model $model)
     {
-        $foreign = array($this->getPlainForeignKey() => $this->getParentKey());
+        $model->{$this->getPlainForeignKey()} = $this->getParentKey();
 
-        $foreign[last(explode('.', $this->morphType))] = $this->morphClass;
-
-        return $foreign;
+        $model->{last(explode('.', $this->morphType))} = $this->morphClass;
     }
 
     /**

--- a/system/Database/ORM/Relations/MorphPivot.php
+++ b/system/Database/ORM/Relations/MorphPivot.php
@@ -3,7 +3,6 @@
 namespace Database\ORM\Relations;
 
 use Database\ORM\Builder;
-use Database\ORM\Relations\Pivot;
 
 
 class MorphPivot extends Pivot
@@ -18,6 +17,15 @@ class MorphPivot extends Pivot
     protected $morphType;
 
     /**
+     * The value of the polymorphic relation.
+     *
+     * Explicitly define this so it's not included in saved attributes.
+     *
+     * @var string
+     */
+    protected $morphClass;
+
+    /**
      * Set the keys for a save update query.
      *
      * @param  \Database\ORM\Builder  $query
@@ -25,7 +33,7 @@ class MorphPivot extends Pivot
      */
     protected function setKeysForSaveQuery(Builder $query)
     {
-        $query->where($this->morphType, $this->getAttribute($this->morphType));
+        $query->where($this->morphType, $this->morphClass);
 
         return parent::setKeysForSaveQuery($query);
     }
@@ -39,7 +47,7 @@ class MorphPivot extends Pivot
     {
         $query = $this->getDeleteQuery();
 
-        $query->where($this->morphType, $this->getAttribute($this->morphType));
+        $query->where($this->morphType, $this->morphClass);
 
         return $query->delete();
     }
@@ -48,7 +56,7 @@ class MorphPivot extends Pivot
      * Set the morph type for the pivot.
      *
      * @param  string  $morphType
-     * @return \Database\ORM\Relations\MorphPivot
+     * @return $this
      */
     public function setMorphType($morphType)
     {
@@ -56,5 +64,19 @@ class MorphPivot extends Pivot
 
         return $this;
     }
+
+    /**
+     * Set the morph class for the pivot.
+     *
+     * @param  string  $morphClass
+     * @return \Database\ORM\Relations\MorphPivot
+     */
+    public function setMorphClass($morphClass)
+    {
+            $this->morphClass = $morphClass;
+
+            return $this;
+    }
+
 
 }

--- a/system/Database/ORM/Relations/MorphToMany.php
+++ b/system/Database/ORM/Relations/MorphToMany.php
@@ -4,7 +4,6 @@ namespace Database\ORM\Relations;
 
 use Database\ORM\Model;
 use Database\ORM\Builder;
-use Database\ORM\Relations\BelongsToMany;
 
 
 class MorphToMany extends BelongsToMany
@@ -32,7 +31,6 @@ class MorphToMany extends BelongsToMany
      */
     protected $inverse;
 
-    
     /**
      * Create a new has many relationship instance.
      *
@@ -43,15 +41,15 @@ class MorphToMany extends BelongsToMany
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  string  $relationName
-     * @param  bool  $inverse
+     * @param  bool   $inverse
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $otherKey, $relationName = null, $inverse = false)
     {
-        $this->inverse   = $inverse;
+        $this->inverse = $inverse;
         $this->morphType = $name.'_type';
 
-        $this->morphClass = $inverse ? get_class($query->getModel()) : get_class($parent);
+        $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
         parent::__construct($query, $parent, $table, $foreignKey, $otherKey, $relationName);
     }
@@ -59,7 +57,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Set the where clause for the relation query.
      *
-     * @return \Database\ORM\Relations\BelongsToMany
+     * @return $this
      */
     protected function setWhere()
     {
@@ -134,9 +132,9 @@ class MorphToMany extends BelongsToMany
     {
         $pivot = new MorphPivot($this->parent, $attributes, $this->table, $exists);
 
-        $pivot->setPivotKeys($this->foreignKey, $this->otherKey);
-
-        $pivot->setMorphType($this->morphType);
+        $pivot->setPivotKeys($this->foreignKey, $this->otherKey)
+              ->setMorphType($this->morphType)
+              ->setMorphClass($this->morphClass);
 
         return $pivot;
     }

--- a/system/Database/ORM/Relations/Pivot.php
+++ b/system/Database/ORM/Relations/Pivot.php
@@ -9,7 +9,7 @@ use Database\ORM\Builder;
 class Pivot extends Model
 {
     /**
-     * The parent Model of the relationship.
+     * The parent model of the relationship.
      *
      * @var \Database\ORM\Model
      */
@@ -36,7 +36,6 @@ class Pivot extends Model
      */
     protected $guarded = array();
 
-
     /**
      * Create a new pivot model instance.
      *
@@ -50,18 +49,14 @@ class Pivot extends Model
     {
         parent::__construct();
 
-        // The pivot model is a "dynamic" model since we will set the tables dynamically
-        // for the instance. This allows it work for any intermediate tables for the
-        // many to many relationship that are defined by this developer's classes.
-        $this->setRawAttributes($attributes);
+        //
+        $this->setRawAttributes($attributes, true);
 
         $this->setTable($table);
 
         $this->setConnection($parent->getConnectionName());
 
-        // We store off the parent instance so we will access the timestamp column names
-        // for the model, since the pivot model timestamps aren't easily configurable
-        // from the developer's point of view. We can use the parents to get these.
+        //
         $this->parent = $parent;
 
         $this->exists = $exists;
@@ -131,7 +126,7 @@ class Pivot extends Model
      *
      * @param  string  $foreignKey
      * @param  string  $otherKey
-     * @return \Database\ORM\Relations\Pivot
+     * @return $this
      */
     public function setPivotKeys($foreignKey, $otherKey)
     {

--- a/system/Database/ORM/Relations/Relation.php
+++ b/system/Database/ORM/Relations/Relation.php
@@ -2,11 +2,12 @@
 
 namespace Database\ORM\Relations;
 
-use Closure;
 use Database\ORM\Model;
 use Database\ORM\Builder;
 use Database\Query\Expression;
 use Database\ORM\Collection;
+
+use Closure;
 
 
 abstract class Relation
@@ -39,7 +40,6 @@ abstract class Relation
      */
     protected static $constraints = true;
 
-
     /**
      * Create a new relation instance.
      *
@@ -49,9 +49,9 @@ abstract class Relation
      */
     public function __construct(Builder $query, Model $parent)
     {
-        $this->query = $query;
+        $this->query  = $query;
+        $this->parent = $parent;
 
-        $this->parent  = $parent;
         $this->related = $query->getModel();
 
         $this->addConstraints();
@@ -121,16 +121,6 @@ abstract class Relation
     }
 
     /**
-     * Restore all of the soft deleted related models.
-     *
-     * @return int
-     */
-    public function restore()
-    {
-        return $this->query->withTrashed()->restore();
-    }
-
-    /**
      * Run a raw update against the base query.
      *
      * @param  array  $attributes
@@ -167,9 +157,7 @@ abstract class Relation
     {
         static::$constraints = false;
 
-        // When resetting the relation where clause, we want to shift the first element
-        // off of the bindings, leaving only the constraints that the developers put
-        // as "extra" on the relationships, and not original relation constraints.
+        //
         $results = call_user_func($callback);
 
         static::$constraints = true;
@@ -186,11 +174,11 @@ abstract class Relation
      */
     protected function getKeys(array $models, $key = null)
     {
-        return array_values(array_map(function($value) use ($key)
+        return array_unique(array_values(array_map(function($value) use ($key)
         {
             return $key ? $value->getAttribute($key) : $value->getKey();
 
-        }, $models));
+        }, $models)));
     }
 
     /**
@@ -228,7 +216,7 @@ abstract class Relation
      *
      * @return string
      */
-    protected function getQualifiedParentKeyName()
+    public function getQualifiedParentKeyName()
     {
         return $this->parent->getQualifiedKeyName();
     }
@@ -281,7 +269,7 @@ abstract class Relation
      */
     public function wrap($value)
     {
-        return $this->parent->getQuery()->getGrammar()->wrap($value);
+        return $this->parent->newQueryWithoutScopes()->getQuery()->getGrammar()->wrap($value);
     }
 
     /**

--- a/system/Database/ORM/Relations/Relation.php
+++ b/system/Database/ORM/Relations/Relation.php
@@ -281,7 +281,7 @@ abstract class Relation
      */
     public function wrap($value)
     {
-        return $this->parent->getQuery()->getGrammar()->wrap($value);
+        return $this->parent->getQuery()->wrap($value);
     }
 
     /**

--- a/system/Database/ORM/Relations/Relation.php
+++ b/system/Database/ORM/Relations/Relation.php
@@ -39,7 +39,7 @@ abstract class Relation
      */
     protected static $constraints = true;
 
-    
+
     /**
      * Create a new relation instance.
      *
@@ -281,7 +281,7 @@ abstract class Relation
      */
     public function wrap($value)
     {
-        return $this->parent->getQuery()->wrap($value);
+        return $this->parent->getQuery()->getGrammar()->wrap($value);
     }
 
     /**

--- a/system/Database/ORM/ScopeInterface.php
+++ b/system/Database/ORM/ScopeInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\ORM;
+
+
+interface ScopeInterface
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    public function apply(Builder $builder);
+
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    public function remove(Builder $builder);
+
+}

--- a/system/Database/ORM/SoftDeletingScope.php
+++ b/system/Database/ORM/SoftDeletingScope.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Database\ORM;
+
+
+class SoftDeletingScope implements ScopeInterface
+{
+    /**
+     * All of the extensions to be added to the builder.
+     *
+     * @var array
+     */
+    protected $extensions = ['ForceDelete', 'Restore', 'WithTrashed', 'OnlyTrashed'];
+
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    public function apply(Builder $builder)
+    {
+        $model = $builder->getModel();
+
+        $builder->whereNull($model->getQualifiedDeletedAtColumn());
+
+        $this->extend($builder);
+    }
+
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    public function remove(Builder $builder)
+    {
+        $column = $builder->getModel()->getQualifiedDeletedAtColumn();
+
+        $query = $builder->getQuery();
+
+        foreach ((array) $query->wheres as $key => $where) {
+            if ($this->isSoftDeleteConstraint($where, $column)) {
+                unset($query->wheres[$key]);
+
+                $query->wheres = array_values($query->wheres);
+            }
+        }
+    }
+
+    /**
+     * Extend the query builder with the needed functions.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    public function extend(Builder $builder)
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+
+        $builder->onDelete(function(Builder $builder)
+        {
+            $column = $this->getDeletedAtColumn($builder);
+
+            return $builder->update(array(
+                $column => $builder->getModel()->freshTimestampString()
+            ));
+        });
+    }
+
+    /**
+     * Get the "deleted at" column for the builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return string
+     */
+    protected function getDeletedAtColumn(Builder $builder)
+    {
+        if (count($builder->getQuery()->joins) > 0) {
+            return $builder->getModel()->getQualifiedDeletedAtColumn();
+        } else {
+            return $builder->getModel()->getDeletedAtColumn();
+        }
+    }
+
+    /**
+     * Add the force delete extension to the builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    protected function addForceDelete(Builder $builder)
+    {
+        $builder->macro('forceDelete', function(Builder $builder)
+        {
+            return $builder->getQuery()->delete();
+        });
+    }
+
+    /**
+     * Add the restore extension to the builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    protected function addRestore(Builder $builder)
+    {
+        $builder->macro('restore', function(Builder $builder)
+        {
+            $builder->withTrashed();
+
+            return $builder->update(array($builder->getModel()->getDeletedAtColumn() => null));
+        });
+    }
+
+    /**
+     * Add the with-trashed extension to the builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    protected function addWithTrashed(Builder $builder)
+    {
+        $builder->macro('withTrashed', function(Builder $builder)
+        {
+            $this->remove($builder);
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Add the only-trashed extension to the builder.
+     *
+     * @param  \Database\ORM\Builder  $builder
+     * @return void
+     */
+    protected function addOnlyTrashed(Builder $builder)
+    {
+        $builder->macro('onlyTrashed', function(Builder $builder)
+        {
+            $this->remove($builder);
+
+            $builder->getQuery()->whereNotNull($builder->getModel()->getQualifiedDeletedAtColumn());
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Determine if the given where clause is a soft delete constraint.
+     *
+     * @param  array   $where
+     * @param  string  $column
+     * @return bool
+     */
+    protected function isSoftDeleteConstraint(array $where, $column)
+    {
+        return $where['type'] == 'Null' && $where['column'] == $column;
+    }
+
+}

--- a/system/Database/ORM/SoftDeletingTrait.php
+++ b/system/Database/ORM/SoftDeletingTrait.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Database\ORM;
+
+use Database\ORM\SoftDeletingScope;
+
+
+trait SoftDeletingTrait
+{
+    /**
+     * Indicates if the model is currently force deleting.
+     *
+     * @var bool
+     */
+    protected $forceDeleting = false;
+
+    /**
+     * Boot the soft deleting trait for a model.
+     *
+     * @return void
+     */
+    public static function bootSoftDeletingTrait()
+    {
+        static::addGlobalScope(new SoftDeletingScope);
+    }
+
+    /**
+     * Force a hard delete on a soft deleted model.
+     *
+     * @return void
+     */
+    public function forceDelete()
+    {
+        $this->forceDeleting = true;
+
+        $this->delete();
+
+        $this->forceDeleting = false;
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     *
+     * @return void
+     */
+    protected function performDeleteOnModel()
+    {
+        if ($this->forceDeleting) {
+            return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+        }
+
+        return $this->runSoftDelete();
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     *
+     * @return void
+     */
+    protected function runSoftDelete()
+    {
+        $query = $this->newQuery()->where($this->getKeyName(), $this->getKey());
+
+        $this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
+
+        $query->update(array($this->getDeletedAtColumn() => $this->fromDateTime($time)));
+    }
+
+    /**
+     * Restore a soft-deleted model instance.
+     *
+     * @return bool|null
+     */
+    public function restore()
+    {
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getDeletedAtColumn()} = null;
+
+        //
+        $this->exists = true;
+
+        $result = $this->save();
+
+        $this->fireModelEvent('restored', false);
+
+        return $result;
+    }
+
+    /**
+     * Determine if the model instance has been soft-deleted.
+     *
+     * @return bool
+     */
+    public function trashed()
+    {
+        return ! is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
+     * Get a new query builder that includes soft deletes.
+     *
+     * @return \Database\ORM\Builder|static
+     */
+    public static function withTrashed()
+    {
+        return (new static)->newQueryWithoutScope(new SoftDeletingScope);
+    }
+
+    /**
+     * Get a new query builder that only includes soft deletes.
+     *
+     * @return \Database\ORM\Builder|static
+     */
+    public static function onlyTrashed()
+    {
+        $instance = new static;
+
+        $column = $instance->getQualifiedDeletedAtColumn();
+
+        return $instance->newQueryWithoutScope(new SoftDeletingScope)->whereNotNull($column);
+    }
+
+    /**
+     * Register a restoring model event with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function restoring($callback)
+    {
+        static::registerModelEvent('restoring', $callback);
+    }
+
+    /**
+     * Register a restored model event with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function restored($callback)
+    {
+        static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Get the name of the "deleted at" column.
+     *
+     * @return string
+     */
+    public function getDeletedAtColumn()
+    {
+        return defined('static::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
+    }
+
+    /**
+     * Get the fully qualified "deleted at" column.
+     *
+     * @return string
+     */
+    public function getQualifiedDeletedAtColumn()
+    {
+        return $this->getTable() .'.' .$this->getDeletedAtColumn();
+    }
+
+}

--- a/system/Database/Query/Builder.php
+++ b/system/Database/Query/Builder.php
@@ -1516,6 +1516,20 @@ class Builder
     }
 
     /**
+     * Merge an array of where clauses and bindings.
+     *
+     * @param  array  $wheres
+     * @param  array  $bindings
+     * @return void
+     */
+    public function mergeWheres($wheres, $bindings)
+    {
+        $this->wheres = array_merge((array) $this->wheres, (array) $wheres);
+
+        $this->bindings['where'] = array_values(array_merge($this->bindings['where'], (array) $bindings));
+    }
+
+    /**
      * Create a raw Database Expression.
      *
      * @param  mixed  $value

--- a/system/Database/Query/Grammar.php
+++ b/system/Database/Query/Grammar.php
@@ -9,23 +9,11 @@
 namespace Database\Query;
 
 use Database\Query\Builder;
+use Database\Grammar as BaseGrammar;
 
 
-class Grammar
+class Grammar extends BaseGrammar
 {
-    /**
-     * The grammar table prefix.
-     *
-     * @var string
-     */
-    protected $tablePrefix = '';
-
-    /**
-     * The keyword identifier wrapper format.
-     *
-     * @var string
-     */
-    protected $wrapper = '`%s`';
 
     /**
      * The components that make up a select clause.
@@ -46,6 +34,7 @@ class Grammar
         'unions',
         'lock'
     );
+
 
     /**
      * Compile a select query into SQL.
@@ -638,72 +627,6 @@ class Grammar
         return is_string($value) ? $value : '';
     }
 
-    //--------------------------------------------------------------------
-    // Utility Methods
-    //--------------------------------------------------------------------
-
-    /**
-     * Wrap a table in keyword identifiers.
-     *
-     * @param  string  $table
-     * @return string
-     */
-    public function wrapTable($table)
-    {
-        return $this->wrap($this->tablePrefix .$table);
-    }
-
-    /**
-     * Wrap a value in keyword identifiers.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public function wrap($value)
-    {
-        if (strpos(strtolower($value), ' as ') !== false) {
-            $segments = explode(' ', $value);
-
-            return $this->wrap($segments[0]) .' AS ' .$this->wrap($segments[2]);
-        }
-
-        $wrapped = array();
-
-        $segments = explode('.', $value);
-
-        foreach ($segments as $key => $segment) {
-            if (($key == 0) && (count($segments) > 1)) {
-                $wrapped[] = $this->wrapTable($segment);
-            } else {
-                $wrapped[] = $this->wrapValue($segment);
-            }
-        }
-
-        return implode('.', $wrapped);
-    }
-
-    /**
-     * Wrap an array of values.
-     *
-     * @param  array  $values
-     * @return array
-     */
-    public function wrapArray(array $values)
-    {
-        return array_map(array($this, 'wrap'), $values);
-    }
-
-    /**
-     * Wrap a single string in keyword identifiers.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function wrapValue($value)
-    {
-        return ($value !== '*') ? sprintf($this->wrapper, $value) : $value;
-    }
-
     /**
      * Concatenate an array of segments, removing empties.
      *
@@ -718,39 +641,6 @@ class Grammar
     }
 
     /**
-     * Create query parameter place-holders for an array.
-     *
-     * @param  array   $values
-     * @return string
-     */
-    public function parameterize(array $values)
-    {
-        return implode(', ', array_map(array($this, 'parameter'), $values));
-    }
-
-    /**
-     * Get the appropriate query parameter place-holder for a value.
-     *
-     * @param  mixed   $value
-     * @return string
-     */
-    public function parameter($value)
-    {
-        return ($value instanceof Expression) ? $value->get() : '?';
-    }
-
-    /**
-     * Convert an array of column names into a delimited string.
-     *
-     * @param  array   $columns
-     * @return string
-     */
-    public function columnize(array $columns)
-    {
-        return implode(', ', array_map(array($this, 'wrap'), $columns));
-    }
-
-    /**
      * Remove the leading boolean from a statement.
      *
      * @param  string  $value
@@ -761,40 +651,4 @@ class Grammar
         return preg_replace('/AND |OR /', '', $value, 1);
     }
 
-    //--------------------------------------------------------------------
-    // Setters/Getters Methods
-    //--------------------------------------------------------------------
-
-    /**
-     * Get the grammar's table prefix.
-     *
-     * @return string
-     */
-    public function getTablePrefix()
-    {
-        return $this->tablePrefix;
-    }
-
-    /**
-     * Set the grammar's table prefix.
-     *
-     * @param  string  $prefix
-     * @return $this
-     */
-    public function setTablePrefix($prefix)
-    {
-        $this->tablePrefix = $prefix;
-
-        return $this;
-    }
-
-    /**
-     * Get the format for database stored dates.
-     *
-     * @return string
-     */
-    public function getDateFormat()
-    {
-        return 'Y-m-d H:i:s';
-    }
 }

--- a/system/Database/Query/Grammar.php
+++ b/system/Database/Query/Grammar.php
@@ -1,0 +1,800 @@
+<?php
+/**
+ * Grammar - A simple Grammar for the QueryBuilder.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Database\Query;
+
+use Database\Query\Builder;
+
+
+class Grammar
+{
+    /**
+     * The grammar table prefix.
+     *
+     * @var string
+     */
+    protected $tablePrefix = '';
+
+    /**
+     * The keyword identifier wrapper format.
+     *
+     * @var string
+     */
+    protected $wrapper = '`%s`';
+
+    /**
+     * The components that make up a select clause.
+     *
+     * @var array
+     */
+    protected $selectComponents = array(
+        'aggregate',
+        'columns',
+        'from',
+        'joins',
+        'wheres',
+        'groups',
+        'havings',
+        'orders',
+        'limit',
+        'offset',
+        'unions',
+        'lock'
+    );
+
+    /**
+     * Compile a select query into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileSelect(Builder $query)
+    {
+        if (is_null($query->columns)) {
+            $query->columns = array('*');
+        }
+
+        return trim($this->concatenate($this->compileComponents($query)));
+    }
+
+    /**
+     * Compile the components necessary for a select clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return array
+     */
+    protected function compileComponents(Builder $query)
+    {
+        $sql = array();
+
+        foreach ($this->selectComponents as $component) {
+            if (! is_null($query->{$component})) {
+                $method = 'compile' .ucfirst($component);
+
+                $sql[$component] = call_user_func(array($this, $method), $query, $query->{$component});
+            }
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Compile an aggregated select clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $aggregate
+     * @return string
+     */
+    protected function compileAggregate(Builder $query, $aggregate)
+    {
+        $column = $this->columnize($aggregate['columns']);
+
+        if ($query->distinct && ($column !== '*')) {
+            $column = 'DISTINCT ' .$column;
+        }
+
+        return 'SELECT ' .$aggregate['function'] .'(' .$column .') AS aggregate';
+    }
+
+    /**
+     * Compile the "SELECT *" portion of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $columns
+     * @return string
+     */
+    protected function compileColumns(Builder $query, $columns)
+    {
+        if (is_null($query->aggregate)) {
+            $select = $query->distinct ? 'SELECT DISTINCT ' : 'SELECT ';
+
+            return $select .$this->columnize($columns);
+        }
+
+        return '';
+    }
+
+    /**
+     * Compile the "FROM" portion of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  string  $table
+     * @return string
+     */
+    protected function compileFrom(Builder $query, $table)
+    {
+        return 'FROM ' .$this->wrapTable($table);
+    }
+
+    /**
+     * Compile the "JOIN" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $joins
+     * @return string
+     */
+    protected function compileJoins(Builder $query, $joins)
+    {
+        $sql = array();
+
+        foreach ($joins as $join) {
+            $table = $this->wrapTable($join->table);
+
+            $clauses = array();
+
+            foreach ($join->clauses as $clause) {
+                $clauses[] = $this->compileJoinConstraint($clause);
+            }
+
+            $clauses[0] = $this->removeLeadingBoolean($clauses[0]);
+
+            $clauses = implode(' ', $clauses);
+
+            $type = $join->type;
+
+            $sql[] = "$type JOIN $table ON $clauses";
+        }
+
+        return implode(' ', $sql);
+    }
+
+    /**
+     * Create a join clause constraint segment.
+     *
+     * @param  array   $clause
+     * @return string
+     */
+    protected function compileJoinConstraint(array $clause)
+    {
+        $first = $this->wrap($clause['first']);
+
+        $second = $clause['where'] ? '?' : $this->wrap($clause['second']);
+
+        $boolean = strtoupper($clause['boolean']);
+
+        return "$boolean $first {$clause['operator']} $second";
+    }
+
+    /**
+     * Compile the "WHERE" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileWheres(Builder $query)
+    {
+        $sql = array();
+
+        if (is_null($query->wheres)) {
+            return '';
+        }
+
+        foreach ($query->wheres as $where) {
+            $method = "where{$where['type']}";
+
+            $sql[] = strtoupper($where['boolean']) .' ' .$this->$method($query, $where);
+        }
+
+        if (count($sql) > 0) {
+            $sql = implode(' ', $sql);
+
+            return 'WHERE ' .preg_replace('/AND |OR /', '', $sql, 1);
+        }
+
+        return '';
+    }
+
+    /**
+     * Compile a nested where clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNested(Builder $query, $where)
+    {
+        $nested = $where['query'];
+
+        return '(' .substr($this->compileWheres($nested), 6) .')';
+    }
+
+    /**
+     * Compile a where condition with a sub-select.
+     *
+     * @param  array   $where
+     * @return string
+     */
+    protected function whereSub(Builder $query, $where)
+    {
+        $select = $this->compileSelect($where['query']);
+
+        return $this->wrap($where['column']) .' ' .$where['operator'] ." ($select)";
+    }
+
+    /**
+     * Compile a basic where clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBasic(Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+
+        return $this->wrap($where['column']) .' ' .$where['operator'] .' ' .$value;
+    }
+
+    /**
+     * Compile a "BETWEEN" where clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetween(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'NOT BETWEEN' : 'BETWEEN';
+
+        return $this->wrap($where['column']) .' ' .$between .' ? AND ?';
+    }
+
+    /**
+     * Compile a "WHERE IN" clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereIn(Builder $query, $where)
+    {
+        $values = $this->parameterize($where['values']);
+
+        return $this->wrap($where['column']) .' IN (' .$values .')';
+    }
+
+    /**
+     * Compile a "WHERE NOT IN" clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotIn(Builder $query, $where)
+    {
+        $values = $this->parameterize($where['values']);
+
+        return $this->wrap($where['column']) .' NOT IN (' .$values .')';
+    }
+
+    /**
+     * Compile a where in sub-select clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereInSub(Builder $query, $where)
+    {
+        $select = $this->compileSelect($where['query']);
+
+        return $this->wrap($where['column']) .' IN (' .$select .')';
+    }
+
+    /**
+     * Compile a where not in sub-select clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotInSub(Builder $query, $where)
+    {
+        $select = $this->compileSelect($where['query']);
+
+        return $this->wrap($where['column']) .' NOT IN (' .$select .')';
+    }
+
+    /**
+     * Compile a "WHERE NULL" clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNull(Builder $query, $where)
+    {
+        return $this->wrap($where['column']) .' IS NULL';
+    }
+
+    /**
+     * Compile a "WHERE NOT NULL" clause.
+     *
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotNull(Builder $query, $where)
+    {
+        return $this->wrap($where['column']) .' IS NOT NULL';
+    }
+
+    /**
+     * Compile a "WHERE DAY" clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDay(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('day', $query, $where);
+    }
+
+    /**
+     * Compile a "WHERE MONTH" clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereMonth(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('month', $query, $where);
+    }
+
+    /**
+     * Compile a "WHERE YEAR" clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereYear(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('year', $query, $where);
+    }
+
+    /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhere($type, Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+
+        return $type .'(' .$this->wrap($where['column']) .') ' .$where['operator'] .' ' .$value;
+    }
+
+    /**
+     * Compile a raw "WHERE" clause.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereRaw(Builder $query, $where)
+    {
+        return $where['sql'];
+    }
+
+    /**
+     * Compile the GROUP BY clause for a query.
+     *
+     * @param  Query   $query
+     * @return string
+     */
+    protected function compileGroups(Builder $query, $groups)
+    {
+        return 'GROUP BY '.$this->columnize($groups);
+    }
+
+    /**
+     * Compile the "HAVING" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $havings
+     * @return string
+     */
+    protected function compileHavings(Builder $query, $havings)
+    {
+        $sql = implode(' ', array_map(array($this, 'compileHaving'), $havings));
+
+        return 'HAVING ' .preg_replace('/AND /', '', $sql, 1);
+    }
+
+    /**
+     * Compile a single having clause.
+     *
+     * @param  array   $having
+     * @return string
+     */
+    protected function compileHaving(array $having)
+    {
+        if ($having['type'] === 'Raw') {
+            return $having['boolean'].' '.$having['sql'];
+        }
+
+        return $this->compileBasicHaving($having);
+    }
+
+    /**
+     * Compile a basic having clause.
+     *
+     * @param  array   $having
+     * @return string
+     */
+    protected function compileBasicHaving($having)
+    {
+        $column = $this->wrap($having['column']);
+
+        $parameter = $this->parameter($having['value']);
+
+        return 'AND ' .$column .' ' .$having['operator'] .' ' .$parameter;
+    }
+
+    /**
+     * Compile the "ORDER BY" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $orders
+     * @return string
+     */
+    protected function compileOrders(Builder $query, $orders)
+    {
+        $me = $this;
+
+        return 'ORDER BY ' .implode(', ', array_map(function($order) use ($me) {
+            if (isset($order['sql'])) return $order['sql'];
+
+            return $me->wrap($order['column']).' '.$order['direction'];
+        }, $orders));
+    }
+
+    /**
+     * Compile the "LIMIT" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  int  $limit
+     * @return string
+     */
+    protected function compileLimit(Builder $query, $limit)
+    {
+        return 'LIMIT ' .(int) $limit;
+    }
+
+    /**
+     * Compile the "OFFSET" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  int  $offset
+     * @return string
+     */
+    protected function compileOffset(Builder $query, $offset)
+    {
+        return 'OFFSET ' .(int) $offset;
+    }
+
+    /**
+     * Compile the "UNION" queries attached to the main query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUnions(Builder $query)
+    {
+        $sql = '';
+
+        foreach ($query->unions as $union) {
+            $sql .= $this->compileUnion($query, $union);
+        }
+
+        if (isset($query->unionOrders)) {
+            $sql .= ' ' .$this->compileOrders($query, $query->unionOrders);
+        }
+
+        if (isset($query->unionLimit)) {
+            $sql .= ' ' .$this->compileLimit($query, $query->unionLimit);
+        }
+
+        if (isset($query->unionOffset)) {
+            $sql .= ' ' .$this->compileOffset($query, $query->unionOffset);
+        }
+
+        return ltrim($sql);
+    }
+
+    /**
+     * Compile a single "UNION" statement.
+     *
+     * @param  array  $union
+     * @return string
+     */
+    protected function compileUnion(array $union)
+    {
+        $joiner = isset($union['all']) ? ' UNION ALL ' : ' UNION ';
+
+        return $joiner .$union['query']->toSql();
+    }
+
+    /**
+     * Compile an insert statement into SQL.
+     *
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsert(Builder $query, array $values)
+    {
+        $table = $this->wrapTable($this->from);
+
+        if (! is_array(reset($values))) {
+            $values = array($values);
+        }
+
+        $columns = $this->columnize(array_keys(reset($values)));
+
+        $parameters = $this->parameterize(reset($values));
+
+        $value = array_fill(0, count($values), "($parameters)");
+
+        $parameters = implode(', ', $value);
+
+        return "INSERT INTO $table ($columns) VALUES $parameters";
+    }
+
+    /**
+     * Compile an update statement into SQL.
+     *
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdate(Builder $query, $values)
+    {
+        $table = $this->wrapTable($this->from);
+
+        $columns = array();
+
+        foreach ($values as $key => $value) {
+            $columns[] = $this->wrap($key) .' = ' .$this->parameter($value);
+        }
+
+        $columns = implode(', ', $columns);
+
+        if (isset($this->joins)) {
+            $joins = ' ' .$this->compileJoins($this, $this->joins);
+        } else {
+            $joins = '';
+        }
+
+        $where = $this->compileWheres($this);
+
+        $sql = trim("UPDATE {$table}{$joins} SET $columns $where");
+
+        if (isset($this->orders)) {
+            $sql .= ' ' .$this->compileOrders($this, $this->orders);
+        }
+
+        if (isset($this->limit)) {
+            $sql .= ' ' .$this->compileLimit($this, $this->limit);
+        }
+
+        return rtrim($sql);
+    }
+
+    /**
+     * Compile a delete statement into SQL.
+     *
+     * @return string
+     */
+    public function compileDelete(Builder $query)
+    {
+        $table = $this->wrapTable($query->from);
+
+        $where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+
+        return trim("DELETE FROM $table " .$where);
+    }
+
+    /**
+     * Compile a truncate table statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return array
+     */
+    public function compileTruncate(Builder $query)
+    {
+        return array('TRUNCATE ' .$this->wrapTable($query->from) => array());
+    }
+
+    /**
+     * Compile the lock into SQL.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  bool|string  $value
+     * @return string
+     */
+    protected function compileLock(Builder $query, $value)
+    {
+        return is_string($value) ? $value : '';
+    }
+
+    //--------------------------------------------------------------------
+    // Utility Methods
+    //--------------------------------------------------------------------
+
+    /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        return $this->wrap($this->tablePrefix .$table);
+    }
+
+    /**
+     * Wrap a value in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function wrap($value)
+    {
+        if (strpos(strtolower($value), ' as ') !== false) {
+            $segments = explode(' ', $value);
+
+            return $this->wrap($segments[0]) .' AS ' .$this->wrap($segments[2]);
+        }
+
+        $wrapped = array();
+
+        $segments = explode('.', $value);
+
+        foreach ($segments as $key => $segment) {
+            if (($key == 0) && (count($segments) > 1)) {
+                $wrapped[] = $this->wrapTable($segment);
+            } else {
+                $wrapped[] = $this->wrapValue($segment);
+            }
+        }
+
+        return implode('.', $wrapped);
+    }
+
+    /**
+     * Wrap an array of values.
+     *
+     * @param  array  $values
+     * @return array
+     */
+    public function wrapArray(array $values)
+    {
+        return array_map(array($this, 'wrap'), $values);
+    }
+
+    /**
+     * Wrap a single string in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        return ($value !== '*') ? sprintf($this->wrapper, $value) : $value;
+    }
+
+    /**
+     * Concatenate an array of segments, removing empties.
+     *
+     * @param  array   $segments
+     * @return string
+     */
+    protected function concatenate($segments)
+    {
+        return implode(' ', array_filter($segments, function($value) {
+            return (string) ($value !== '');
+        }));
+    }
+
+    /**
+     * Create query parameter place-holders for an array.
+     *
+     * @param  array   $values
+     * @return string
+     */
+    public function parameterize(array $values)
+    {
+        return implode(', ', array_map(array($this, 'parameter'), $values));
+    }
+
+    /**
+     * Get the appropriate query parameter place-holder for a value.
+     *
+     * @param  mixed   $value
+     * @return string
+     */
+    public function parameter($value)
+    {
+        return ($value instanceof Expression) ? $value->get() : '?';
+    }
+
+    /**
+     * Convert an array of column names into a delimited string.
+     *
+     * @param  array   $columns
+     * @return string
+     */
+    public function columnize(array $columns)
+    {
+        return implode(', ', array_map(array($this, 'wrap'), $columns));
+    }
+
+    /**
+     * Remove the leading boolean from a statement.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function removeLeadingBoolean($value)
+    {
+        return preg_replace('/AND |OR /', '', $value, 1);
+    }
+
+    //--------------------------------------------------------------------
+    // Setters/Getters Methods
+    //--------------------------------------------------------------------
+
+    /**
+     * Get the grammar's table prefix.
+     *
+     * @return string
+     */
+    public function getTablePrefix()
+    {
+        return $this->tablePrefix;
+    }
+
+    /**
+     * Set the grammar's table prefix.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function setTablePrefix($prefix)
+    {
+        $this->tablePrefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Get the format for database stored dates.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s';
+    }
+}

--- a/system/Database/Query/Grammars/MySqlGrammar.php
+++ b/system/Database/Query/Grammars/MySqlGrammar.php
@@ -121,4 +121,17 @@ class MySqlGrammar extends Grammar
         return trim("DELETE FROM $table $where");
     }
 
+    /**
+     * Wrap a single string in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        if ($value === '*') return $value;
+
+        return '`'.str_replace('`', '``', $value).'`';
+    }
+
 }

--- a/system/Database/Query/Grammars/MySqlGrammar.php
+++ b/system/Database/Query/Grammars/MySqlGrammar.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * MySqlGrammar - A simple MySQL Grammar for the QueryBuilder.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Database\Query\Grammars;
+
+use Database\Query\Builder;
+use Database\Query\Grammar;
+
+
+class MySqlGrammar extends Grammar
+{
+    /**
+     * The components that make up a select clause.
+     *
+     * @var array
+     */
+    protected $selectComponents = array(
+        'aggregate',
+        'columns',
+        'from',
+        'joins',
+        'wheres',
+        'groups',
+        'havings',
+        'orders',
+        'limit',
+        'offset',
+        'lock'
+    );
+
+
+    /**
+     * Compile a select query into SQL.
+     *
+     * @param  \Database\Query\Builder
+     * @return string
+     */
+    public function compileSelect(Builder $query)
+    {
+        $sql = parent::compileSelect($query);
+
+        if ($query->unions) {
+            $sql = '(' .$sql .') ' .$this->compileUnions($query);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Compile a single union statement.
+     *
+     * @param  array  $union
+     * @return string
+     */
+    protected function compileUnion(array $union)
+    {
+        $joiner = $union['all'] ? ' UNION ALL ' : ' UNION ';
+
+        return $joiner .'(' .$union['query']->toSql() .')';
+    }
+
+    /**
+     * Compile the lock into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  bool|string  $value
+     * @return string
+     */
+    protected function compileLock(Builder $query, $value)
+    {
+        if (is_string($value)) return $value;
+
+        return $value ? 'FOR UPDATE' : 'LOCK IN SHARE MODE';
+    }
+
+    /**
+     * Compile an update statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdate(Builder $query, $values)
+    {
+        $sql = parent::compileUpdate($query, $values);
+
+        if (isset($query->orders)) {
+            $sql .= ' ' .$this->compileOrders($query, $query->orders);
+        }
+
+        if (isset($query->limit)) {
+            $sql .= ' ' .$this->compileLimit($query, $query->limit);
+        }
+
+        return rtrim($sql);
+    }
+
+    /**
+     * Compile a delete statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileDelete(Builder $query)
+    {
+        $table = $this->wrapTable($query->from);
+
+        $where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+
+        if (isset($query->joins)) {
+            $joins = ' '.$this->compileJoins($query, $query->joins);
+
+            return trim("DELETE $table FROM {$table}{$joins} $where");
+        }
+
+        return trim("DELETE FROM $table $where");
+    }
+
+}

--- a/system/Database/Query/Grammars/PostgresGrammar.php
+++ b/system/Database/Query/Grammars/PostgresGrammar.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * PostgresGrammar - A simple PostgresSQL Grammar for the QueryBuilder.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Database\Query\Grammars;
+
+use Database\Query\Builder;
+use Database\Query\Grammar;
+
+
+class PostgresGrammar extends Grammar
+{
+    /**
+     * All of the available clause operators.
+     *
+     * @var array
+     */
+    protected $operators = array(
+        '=', '<', '>', '<=', '>=', '<>', '!=',
+        'like', 'not like', 'between', 'ilike',
+        '&', '|', '#', '<<', '>>',
+    );
+
+
+    /**
+     * Compile the lock into SQL.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  bool|string  $value
+     * @return string
+     */
+    protected function compileLock(Builder $query, $value)
+    {
+        if (is_string($value)) return $value;
+
+        return $value ? 'FOR UPDATE' : 'FOR SHARE';
+    }
+
+    /**
+     * Compile an update statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdate(Builder $query, $values)
+    {
+        $table = $this->wrapTable($query->from);
+
+        $columns = $this->compileUpdateColumns($values);
+
+        $from = $this->compileUpdateFrom($query);
+
+        $where = $this->compileUpdateWheres($query);
+
+        return trim("update {$table} set {$columns}{$from} $where");
+    }
+
+    /**
+     * Compile the columns for the update statement.
+     *
+     * @param  array   $values
+     * @return string
+     */
+    protected function compileUpdateColumns($values)
+    {
+        $columns = array();
+
+        foreach ($values as $key => $value) {
+            $columns[] = $this->wrap($key).' = '.$this->parameter($value);
+        }
+
+        return implode(', ', $columns);
+    }
+
+    /**
+     * Compile the "from" clause for an update with a join.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUpdateFrom(Builder $query)
+    {
+        if ( ! isset($query->joins)) return '';
+
+        $froms = array();
+
+        foreach ($query->joins as $join) {
+            $froms[] = $this->wrapTable($join->table);
+        }
+
+        if (count($froms) > 0) return ' FROM '.implode(', ', $froms);
+    }
+
+    /**
+     * Compile the additional where clauses for updates with joins.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUpdateWheres(Builder $query)
+    {
+        $baseWhere = $this->compileWheres($query);
+
+        if ( ! isset($query->joins)) return $baseWhere;
+
+        $joinWhere = $this->compileUpdateJoinWheres($query);
+
+        if (trim($baseWhere) == '') {
+            return 'WHERE '.$this->removeLeadingBoolean($joinWhere);
+        }
+
+        return $baseWhere .' ' .$joinWhere;
+    }
+
+    /**
+     * Compile the "join" clauses for an update.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUpdateJoinWheres(Builder $query)
+    {
+        $joinWheres = array();
+
+        foreach ($query->joins as $join) {
+            foreach ($join->clauses as $clause) {
+                $joinWheres[] = $this->compileJoinConstraint($clause);
+            }
+        }
+
+        return implode(' ', $joinWheres);
+    }
+
+    /**
+     * Compile an insert and get ID statement into SQL.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array   $values
+     * @param  string  $sequence
+     * @return string
+     */
+    public function compileInsertGetId(Builder $query, $values, $sequence)
+    {
+        if (is_null($sequence)) $sequence = 'id';
+
+        return $this->compileInsert($query, $values).' RETURNING '.$this->wrap($sequence);
+    }
+
+    /**
+     * Compile a truncate table statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return array
+     */
+    public function compileTruncate(Builder $query)
+    {
+        return array('TRUNCATE ' .$this->wrapTable($query->from) .' RESTART identity' => array());
+    }
+}
+

--- a/system/Database/Query/Grammars/SQLiteGrammar.php
+++ b/system/Database/Query/Grammars/SQLiteGrammar.php
@@ -26,14 +26,6 @@ class SQLiteGrammar extends Grammar
     );
 
     /**
-     * The keyword identifier wrapper format.
-     *
-     * @var string
-     */
-    protected $wrapper = '"%s"';
-
-
-    /**
      * Compile an insert statement into SQL.
      *
      * @param  \Nova\Database\Query\Builder  $query

--- a/system/Database/Query/Grammars/SQLiteGrammar.php
+++ b/system/Database/Query/Grammars/SQLiteGrammar.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * SQLiteGrammar - A simple SQLite Grammar for the QueryBuilder.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+namespace Database\Query\Grammars;
+
+use Database\Query\Builder;
+use Database\Query\Grammar;
+
+
+class SQLiteGrammar extends Grammar
+{
+    /**
+     * All of the available clause operators.
+     *
+     * @var array
+     */
+    protected $operators = array(
+        '=', '<', '>', '<=', '>=', '<>', '!=',
+        'like', 'not like', 'between', 'ilike',
+        '&', '|', '<<', '>>',
+    );
+
+    /**
+     * The keyword identifier wrapper format.
+     *
+     * @var string
+     */
+    protected $wrapper = '"%s"';
+
+
+    /**
+     * Compile an insert statement into SQL.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsert(Builder $query, array $values)
+    {
+        $table = $this->wrapTable($query->from);
+
+        if ( ! is_array(reset($values))) {
+            $values = array($values);
+        }
+
+        if (count($values) == 1) {
+            return parent::compileInsert($query, reset($values));
+        }
+
+        $names = $this->columnize(array_keys(reset($values)));
+
+        $columns = array();
+
+        foreach (array_keys(reset($values)) as $column) {
+            $columns[] = '? as '.$this->wrap($column);
+        }
+
+        $columns = array_fill(0, count($values), implode(', ', $columns));
+
+        return "INSERT INTO $table ($names) SELECT ".implode(' UNION SELECT ', $columns);
+    }
+
+    /**
+     * Compile a truncate table statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return array
+     */
+    public function compileTruncate(Builder $query)
+    {
+        $sql = array(
+            'DELETE FROM sqlite_sequence WHERE name = ?'  => array($query->from),
+            'DELETE FROM ' .$this->wrapTable($query->from) => array()
+        );
+
+        return $sql;
+    }
+
+    /**
+     * Compile a "where day" clause.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDay(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%d', $query, $where);
+    }
+
+    /**
+     * Compile a "where month" clause.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereMonth(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%m', $query, $where);
+    }
+
+    /**
+     * Compile a "where year" clause.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereYear(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%Y', $query, $where);
+    }
+
+    /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhere($type, Builder $query, $where)
+    {
+        $value = str_pad($where['value'], 2, '0', STR_PAD_LEFT);
+
+        $value = $this->parameter($value);
+
+        return 'strftime(\'' .$type .'\', ' .$this->wrap($where['column']).') ' .$where['operator'] .' ' .$value;
+    }
+}

--- a/system/Database/Query/Grammars/SqlServerGrammar.php
+++ b/system/Database/Query/Grammars/SqlServerGrammar.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Database\Query\Grammars;
+
+use Database\Query\Builder;
+use Database\Query\Grammar;
+
+
+class SqlServerGrammar extends Grammar
+{
+    /**
+     * All of the available clause operators.
+     *
+     * @var array
+     */
+    protected $operators = array(
+        '=', '<', '>', '<=', '>=', '!<', '!>', '<>', '!=',
+        'like', 'not like', 'between', 'ilike',
+        '&', '&=', '|', '|=', '^', '^=',
+    );
+
+    /**
+     * Compile a select query into SQL.
+     *
+     * @param  \Database\Query\Builder
+     * @return string
+     */
+    public function compileSelect(Builder $query)
+    {
+        $components = $this->compileComponents($query);
+
+        if ($query->offset > 0) {
+            return $this->compileAnsiOffset($query, $components);
+        }
+
+        return $this->concatenate($components);
+    }
+
+    /**
+     * Compile the "select *" portion of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $columns
+     * @return string
+     */
+    protected function compileColumns(Builder $query, $columns)
+    {
+        if ( ! is_null($query->aggregate)) return;
+
+        $select = $query->distinct ? 'SELECT DISTINCT ' : 'SELECT ';
+
+        if (($query->limit > 0) && ($query->offset <= 0)) {
+            $select .= 'top '.$query->limit.' ';
+        }
+
+        return $select.$this->columnize($columns);
+    }
+
+    /**
+     * Compile the "from" portion of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  string  $table
+     * @return string
+     */
+    protected function compileFrom(Builder $query, $table)
+    {
+        $from = parent::compileFrom($query, $table);
+
+        if (is_string($query->lock)) return $from.' '.$query->lock;
+
+        if ( ! is_null($query->lock)) {
+            return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
+        }
+
+        return $from;
+    }
+
+    /**
+     * Create a full ANSI offset clause for the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $components
+     * @return string
+     */
+    protected function compileAnsiOffset(Builder $query, $components)
+    {
+        if ( ! isset($components['orders'])) {
+            $components['orders'] = 'ORDER BY (SELECT 0)';
+        }
+
+        $orderings = $components['orders'];
+
+        $components['columns'] .= $this->compileOver($orderings);
+
+        unset($components['orders']);
+
+        $constraint = $this->compileRowConstraint($query);
+
+        $sql = $this->concatenate($components);
+
+        return $this->compileTableExpression($sql, $constraint);
+    }
+
+    /**
+     * Compile the over statement for a table expression.
+     *
+     * @param  string  $orderings
+     * @return string
+     */
+    protected function compileOver($orderings)
+    {
+        return ", row_number() OVER ({$orderings}) AS row_num";
+    }
+
+    /**
+     * Compile the limit / offset row constraint for a query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileRowConstraint($query)
+    {
+        $start = $query->offset + 1;
+
+        if ($query->limit > 0)
+        {
+            $finish = $query->offset + $query->limit;
+
+            return "BETWEEN {$start} AND {$finish}";
+        }
+
+        return ">= {$start}";
+    }
+
+    /**
+     * Compile a common table expression for a query.
+     *
+     * @param  string  $sql
+     * @param  string  $constraint
+     * @return string
+     */
+    protected function compileTableExpression($sql, $constraint)
+    {
+        return "SELECT * FROM ({$sql}) AS temp_table WHERE row_num {$constraint}";
+    }
+
+    /**
+     * Compile the "limit" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  int  $limit
+     * @return string
+     */
+    protected function compileLimit(Builder $query, $limit)
+    {
+        return '';
+    }
+
+    /**
+     * Compile the "offset" portions of the query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  int  $offset
+     * @return string
+     */
+    protected function compileOffset(Builder $query, $offset)
+    {
+        return '';
+    }
+
+    /**
+     * Compile a truncate table statement into SQL.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @return array
+     */
+    public function compileTruncate(Builder $query)
+    {
+        return array('TRUNCATE TABLE ' .$this->wrapTable($query->from) => array());
+    }
+
+    /**
+     * Get the format for database stored dates.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s.000';
+    }
+
+    /**
+     * Wrap a single string in keyword identifiers.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapValue($value)
+    {
+        if ($value === '*') return $value;
+
+        return '[' .str_replace(']', ']]', $value).']';
+    }
+
+}

--- a/system/Database/Query/Processor.php
+++ b/system/Database/Query/Processor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Query;
+
+use Database\Query\Builder;
+
+
+class Processor
+{
+    /**
+     * Process the results of a "select" query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  array  $results
+     * @return array
+     */
+    public function processSelect(Builder $query, $results)
+    {
+        return $results;
+    }
+
+    /**
+     * Process an  "insert get ID" query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  string  $sql
+     * @param  array   $values
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
+    {
+        $query->getConnection()->insert($sql, $values);
+
+        $id = $query->getConnection()->getPdo()->lastInsertId($sequence);
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
+
+    /**
+     * Process the results of a column listing query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processColumnListing($results)
+    {
+        return $results;
+    }
+
+}

--- a/system/Database/Query/Processors/MySqlProcessor.php
+++ b/system/Database/Query/Processors/MySqlProcessor.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Query\Processors;
+
+use Database\Query\Processor;
+
+
+class MySqlProcessor extends Processor
+{
+    /**
+     * Process the results of a column listing query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processColumnListing($results)
+    {
+        return array_map(function($r) { $r = (object) $r; return $r->column_name; }, $results);
+    }
+
+}

--- a/system/Database/Query/Processors/PostgresProcessor.php
+++ b/system/Database/Query/Processors/PostgresProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Query\Processors;
+
+use Database\Query\Builder;
+use Database\Query\Processor;
+
+
+class PostgresProcessor extends Processor
+{
+    /**
+     * Process an "insert get ID" query.
+     *
+     * @param  \Database\Query\Builder  $query
+     * @param  string  $sql
+     * @param  array   $values
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
+    {
+        $results = $query->getConnection()->selectFromWriteConnection($sql, $values);
+
+        $sequence = $sequence ?: 'id';
+
+        $result = (array) $results[0];
+
+        $id = $result[$sequence];
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
+
+    /**
+     * Process the results of a column listing query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processColumnListing($results)
+    {
+        return array_values(array_map(function($r) { $r = (object) $r; return $r->column_name; }, $results));
+    }
+
+}

--- a/system/Database/Query/Processors/SQLiteProcessor.php
+++ b/system/Database/Query/Processors/SQLiteProcessor.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Query\Processors;
+
+use Database\Query\Processor;
+
+
+class SQLiteProcessor extends Processor
+{
+    /**
+     * Process the results of a column listing query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processColumnListing($results)
+    {
+        return array_values(array_map(function($r) { $r = (object) $r; return $r->name; }, $results));
+    }
+
+}

--- a/system/Database/Query/Processors/SqlServerProcessor.php
+++ b/system/Database/Query/Processors/SqlServerProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Nova\Database\Query\Processors;
+
+use Database\Query\Builder;
+use Database\Query\Processor;
+
+
+class SqlServerProcessor extends Processor
+{
+    /**
+     * Process an "insert get ID" query.
+     *
+     * @param  \Nova\Database\Query\Builder  $query
+     * @param  string  $sql
+     * @param  array   $values
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
+    {
+        $query->getConnection()->insert($sql, $values);
+
+        $id = $query->getConnection()->getPdo()->lastInsertId();
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
+
+    /**
+     * Process the results of a column listing query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processColumnListing($results)
+    {
+        return array_values(array_map(function($r) { return $r->name; }, $results));
+    }
+
+}

--- a/system/Forensics/Profiler.php
+++ b/system/Forensics/Profiler.php
@@ -24,7 +24,7 @@
 
 namespace Forensics;
 
-use Core\Config;
+use Config\Config;
 
 use Forensics\Console;
 use Forensics\PdoDebugger;

--- a/system/Helpers/Cookie.php
+++ b/system/Helpers/Cookie.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 use Encryption\DecryptException;
 use Support\Facades\Crypt;
 

--- a/system/Helpers/Database.php
+++ b/system/Helpers/Database.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 use Database\ConnectionResolverInterface as Resolver;
 
 use DB;

--- a/system/Helpers/Encrypter.php
+++ b/system/Helpers/Encrypter.php
@@ -9,7 +9,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 
 
 class Encrypter

--- a/system/Helpers/FastCache.php
+++ b/system/Helpers/FastCache.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 
 use phpFastCache\CacheManager;
 

--- a/system/Helpers/Profiler.php
+++ b/system/Helpers/Profiler.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 
 use DB;
 use Request;

--- a/system/Helpers/ReCaptcha.php
+++ b/system/Helpers/ReCaptcha.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 
 use Request;
 

--- a/system/Helpers/Url.php
+++ b/system/Helpers/Url.php
@@ -8,7 +8,7 @@
 
 namespace Helpers;
 
-use Core\Config;
+use Config\Config;
 use Exception\RedirectToException;
 use Helpers\Session;
 use Helpers\Inflector;

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -6,10 +6,9 @@
  * @version 3.0
  */
 
-namespace Core;
+namespace Language;
 
 use Core\Config;
-use Core\Error;
 use Helpers\Inflector;
 
 use Cookie;

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -8,7 +8,7 @@
 
 namespace Language;
 
-use Core\Config;
+use Config\Config;
 use Helpers\Inflector;
 
 use Cookie;

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -263,7 +263,7 @@ abstract class Controller
     }
 
     /**
-     * Handle calls to missing methods on the controller.
+     * Handle calls to missing methods on the Controller.
      *
      * @param  array   $parameters
      * @return mixed
@@ -276,7 +276,7 @@ abstract class Controller
     }
 
     /**
-     * Handle calls to missing methods on the controller.
+     * Handle calls to missing methods on the Controller.
      *
      * @param  string  $method
      * @param  array   $parameters

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -112,7 +112,9 @@ abstract class Controller
      */
     protected function registerInstanceFilter($filter)
     {
-        $this->getFilterer()->filter($filter, array($this, substr($filter, 1)));
+        $method = substr($filter, 1);
+
+        $this->getFilterer()->filter($filter, array($this, $method));
 
         return $filter;
     }
@@ -128,7 +130,9 @@ abstract class Controller
     protected function isInstanceFilter($filter)
     {
         if (is_string($filter) && str_starts_with($filter, '@')) {
-            if (method_exists($this, substr($filter, 1))) return true;
+            $method = substr($filter, 1);
+
+            if (method_exists($this, $method)) return true;
 
             throw new \InvalidArgumentException("Filter method [$filter] does not exist.");
         }

--- a/system/Routing/Controller.php
+++ b/system/Routing/Controller.php
@@ -1,120 +1,265 @@
 <?php
-/**
- * Controller - base controller
- *
- * @author David Carr - dave@novaframework.com
- * @version 3.0
- */
 
 namespace Routing;
 
-use Core\Config;
 use Http\Response;
+use View\View;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-use Event;
+use BadMethodCallException;
+use Closure;
 
 
 abstract class Controller
 {
     /**
-     * The requested Method by Router.
+     * The currently used Layout.
      *
-     * @var string|null
+     * @var mixed
      */
-    private $method = null;
+    protected $layout;
 
     /**
-     * The parameters given by Router.
+     * The "before" filters registered on the controller.
      *
      * @var array
      */
-    private $params = array();
+    protected $beforeFilters = array();
+
+    /**
+     * The "after" filters registered on the controller.
+     *
+     * @var array
+     */
+    protected $afterFilters = array();
+
+    /**
+     * The route filterer implementation.
+     *
+     * @var \Routing\RouteFiltererInterface
+     */
+    protected static $filterer;
 
 
     /**
-     * Create a new Controller instance.
+     * Register a "before" filter on the controller.
+     *
+     * @param  \Closure|string  $filter
+     * @param  array  $options
+     * @return void
      */
-    public function __construct()
+    public function beforeFilter($filter, array $options = array())
     {
-        //
+        $this->beforeFilters[] = $this->parseFilter($filter, $options);
     }
 
     /**
-     * Execute the Controller Method
-     * @return \Symfony\Component\HttpFoundation\Response
+     * Register an "after" filter on the controller.
      *
-     * @throw \Exception
+     * @param  \Closure|string  $filter
+     * @param  array  $options
+     * @return void
      */
-    public function execute($method, $params = array())
+    public function afterFilter($filter, array $options = array())
     {
-        // Initialise the Controller's variables.
-        $this->method = $method;
-        $this->params = $params;
+        $this->afterFilters[] = $this->parseFilter($filter, $options);
+    }
 
-        // Before the Action execution stage.
-        $response = $this->before();
+    /**
+     * Parse the given filter and options.
+     *
+     * @param  \Closure|string  $filter
+     * @param  array  $options
+     * @return array
+     */
+    protected function parseFilter($filter, array $options)
+    {
+        $parameters = array();
 
-        // When the Before Stage return a null Response, execute the requested Action.
-        if (is_null($response)) {
-            $response = call_user_func_array(array($this, $method), $params);
+        $original = $filter;
+
+        if ($filter instanceof Closure) {
+            $filter = $this->registerClosureFilter($filter);
+        } else if ($this->isInstanceFilter($filter)) {
+            $filter = $this->registerInstanceFilter($filter);
+        } else {
+            list($filter, $parameters) = Route::parseFilter($filter);
         }
 
-        // After the Action execution stage.
-        $this->after($response);
+        return compact('original', 'filter', 'parameters', 'options');
+    }
 
-        // Do the final post-processing stage and return the response.
+    /**
+     * Register an anonymous controller filter Closure.
+     *
+     * @param  \Closure  $filter
+     * @return string
+     */
+    protected function registerClosureFilter(Closure $filter)
+    {
+        $this->getFilterer()->filter($name = spl_object_hash($filter), $filter);
+
+        return $name;
+    }
+
+    /**
+     * Register a controller instance method as a filter.
+     *
+     * @param  string  $filter
+     * @return string
+     */
+    protected function registerInstanceFilter($filter)
+    {
+        $this->getFilterer()->filter($filter, array($this, substr($filter, 1)));
+
+        return $filter;
+    }
+
+    /**
+     * Determine if a filter is a local method on the controller.
+     *
+     * @param  mixed  $filter
+     * @return boolean
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function isInstanceFilter($filter)
+    {
+        if (is_string($filter) && str_starts_with($filter, '@')) {
+            if (method_exists($this, substr($filter, 1))) return true;
+
+            throw new \InvalidArgumentException("Filter method [$filter] does not exist.");
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove the given before filter.
+     *
+     * @param  string  $filter
+     * @return void
+     */
+    public function forgetBeforeFilter($filter)
+    {
+        $this->beforeFilters = $this->removeFilter($filter, $this->getBeforeFilters());
+    }
+
+    /**
+     * Remove the given after filter.
+     *
+     * @param  string  $filter
+     * @return void
+     */
+    public function forgetAfterFilter($filter)
+    {
+        $this->afterFilters = $this->removeFilter($filter, $this->getAfterFilters());
+    }
+
+    /**
+     * Remove the given controller filter from the provided filter array.
+     *
+     * @param  string  $removing
+     * @param  array  $current
+     * @return array
+     */
+    protected function removeFilter($removing, $current)
+    {
+        return array_filter($current, function($filter) use ($removing)
+        {
+            return $filter['original'] != $removing;
+        });
+    }
+
+    /**
+     * Get the registered "before" filters.
+     *
+     * @return array
+     */
+    public function getBeforeFilters()
+    {
+        return $this->beforeFilters;
+    }
+
+    /**
+     * Get the registered "after" filters.
+     *
+     * @return array
+     */
+    public function getAfterFilters()
+    {
+        return $this->afterFilters;
+    }
+
+    /**
+     * Get the route filterer implementation.
+     *
+     * @return \Routing\RouteFiltererInterface
+     */
+    public static function getFilterer()
+    {
+        return static::$filterer;
+    }
+
+    /**
+     * Set the route filterer implementation.
+     *
+     * @param  \Routing\RouteFiltererInterface  $filterer
+     * @return void
+     */
+    public static function setFilterer(RouteFiltererInterface $filterer)
+    {
+        static::$filterer = $filterer;
+    }
+
+    /**
+     * Create the layout used by the controller.
+     *
+     * @return void
+     */
+    protected function setupLayout() {}
+
+    /**
+     * Execute an action on the controller.
+     *
+     * @param string  $method
+     * @param array   $params
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function callAction($method, $parameters)
+    {
+        $this->setupLayout();
+
+        // Execute the requested Method with the given arguments.
+        $response = call_user_func_array(array($this, $method), $parameters);
+
+        // If no response is returned from the controller action and a layout is being
+        // used we will assume we want to just return the Layout view as any nested
+        // Views were probably bound on this view during this Controller actions.
+        if (is_null($response) && ($this->layout instanceof View)) {
+            $response = $this->layout;
+        }
+
+        // Process the Response and return it.
         return $this->processResponse($response);
     }
 
     /**
-     * Process the response and return it.
+     * Process the response given by the controller action.
      *
-     * @param mixed  $response
+     * @param mixed $response
      *
      * @return mixed
      */
     protected function processResponse($response)
     {
+        if (! $response instanceof SymfonyResponse) {
+            $response = new Response($response);
+        }
+
         return $response;
-    }
-
-    /**
-     * This method automatically invokes before the current Action and is supposed
-     * to be overriden for using it.
-     */
-    protected function before()
-    {
-        //
-    }
-
-    /**
-     * This method automatically invokes after the current Action and is supposed
-     * to be overriden for using it.
-     *
-     * Note that the Action's returned value is passed to this Method as parameter.
-     */
-    protected function after($result)
-    {
-        //
-    }
-
-    /**
-     * @return mixed
-     */
-    protected function getMethod()
-    {
-        return $this->method;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getParams()
-    {
-        return $this->params;
     }
 
     /**

--- a/system/Routing/ControllerDispatcher.php
+++ b/system/Routing/ControllerDispatcher.php
@@ -2,12 +2,10 @@
 
 namespace Routing;
 
-use Closure;
 use Http\Request;
-use Routing\RouteFiltererInterface;
-
 use Container\Container;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+use Closure;
 
 
 class ControllerDispatcher
@@ -33,7 +31,7 @@ class ControllerDispatcher
      * @param  \Container\Container  $container
      * @return void
      */
-    public function __construct(RouteFiltererInterface $filterer, Container $container)
+    public function __construct(RouteFiltererInterface $filterer, Container $container = null)
     {
         $this->filterer = $filterer;
 
@@ -51,11 +49,23 @@ class ControllerDispatcher
      */
     public function dispatch(Route $route, Request $request, $controller, $method)
     {
+        // First we will make an instance of this controller via the IoC container instance
+        // so that we can call the methods on it. We will also apply any "after" filters
+        // to the route so that they will be run by the routers after this processing.
         $instance = $this->makeController($controller);
 
-        $parameters = $route->parameters();
+        $this->assignAfter($instance, $route, $request, $method);
 
-        return $instance->execute($method, $parameters);
+        $response = $this->before($instance, $route, $request, $method);
+
+        // If no before filters returned a response we'll call the method on the controller
+        // to get the response to be returned to the router. We will then return it back
+        // out for processing by this router and the after filters can be called then.
+        if (is_null($response)) {
+            $response = $this->call($instance, $route, $method);
+        }
+
+        return $response;
     }
 
     /**
@@ -66,7 +76,165 @@ class ControllerDispatcher
      */
     protected function makeController($controller)
     {
+        Controller::setFilterer($this->filterer);
+
         return $this->container->make($controller);
+    }
+
+    /**
+     * Call the given controller instance method.
+     *
+     * @param  \Routing\Controller  $instance
+     * @param  \Routing\Route  $route
+     * @param  string  $method
+     * @return mixed
+     */
+    protected function call($instance, $route, $method)
+    {
+        $parameters = $route->parametersWithoutNulls();
+
+        return $instance->callAction($method, $parameters);
+    }
+
+    /**
+     * Call the "before" filters for the controller.
+     *
+     * @param  \Routing\Controller  $instance
+     * @param  \Routing\Route  $route
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return mixed
+     */
+    protected function before($instance, $route, $request, $method)
+    {
+        foreach ($instance->getBeforeFilters() as $filter) {
+            if ($this->filterApplies($filter, $request, $method)) {
+                // Here we will just check if the filter applies. If it does we will call the filter
+                // and return the responses if it isn't null. If it is null, we will keep hitting
+                // them until we get a response or are finished iterating through this filters.
+                $response = $this->callFilter($filter, $route, $request);
+
+                if ( ! is_null($response)) return $response;
+            }
+        }
+    }
+
+    /**
+     * Apply the applicable after filters to the route.
+     *
+     * @param  \Routing\Controller  $instance
+     * @param  \Routing\Route  $route
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return mixed
+     */
+    protected function assignAfter($instance, $route, $request, $method)
+    {
+        foreach ($instance->getAfterFilters() as $filter) {
+            // If the filter applies, we will add it to the route, since it has already been
+            // registered on the filterer by the controller, and will just let the normal
+            // router take care of calling these filters so we do not duplicate logics.
+            if ($this->filterApplies($filter, $request, $method)) {
+                $route->after($this->getAssignableAfter($filter));
+            }
+        }
+    }
+
+    /**
+     * Get the assignable after filter for the route.
+     *
+     * @param  \Closure|string  $filter
+     * @return string
+     */
+    protected function getAssignableAfter($filter)
+    {
+        return ($filter['original'] instanceof Closure) ? $filter['filter'] : $filter['original'];
+    }
+
+    /**
+     * Determine if the given filter applies to the request.
+     *
+     * @param  array  $filter
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return bool
+     */
+    protected function filterApplies($filter, $request, $method)
+    {
+        foreach (array('Only', 'Except', 'On') as $type) {
+            if ($this->{"filterFails{$type}"}($filter, $request, $method)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the filter fails the "only" constraint.
+     *
+     * @param  array  $filter
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return bool
+     */
+    protected function filterFailsOnly($filter, $request, $method)
+    {
+        if ( ! isset($filter['options']['only'])) return false;
+
+        return ! in_array($method, (array) $filter['options']['only']);
+    }
+
+    /**
+     * Determine if the filter fails the "except" constraint.
+     *
+     * @param  array  $filter
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return bool
+     */
+    protected function filterFailsExcept($filter, $request, $method)
+    {
+        if ( ! isset($filter['options']['except'])) return false;
+
+        return in_array($method, (array) $filter['options']['except']);
+    }
+
+    /**
+     * Determine if the filter fails the "on" constraint.
+     *
+     * @param  array  $filter
+     * @param  \Http\Request  $request
+     * @param  string  $method
+     * @return bool
+     */
+    protected function filterFailsOn($filter, $request, $method)
+    {
+        $on = array_get($filter, 'options.on');
+
+        if (is_null($on)) return false;
+
+        // If the "on" is a string, we will explode it on the pipe so you can set any
+        // amount of methods on the filter constraints and it will still work like
+        // you specified an array. Then we will check if the method is in array.
+        if (is_string($on)) $on = explode('|', $on);
+
+        return ! in_array(strtolower($request->getMethod()), $on);
+    }
+
+    /**
+     * Call the given controller filter method.
+     *
+     * @param  array  $filter
+     * @param  \Routing\Route  $route
+     * @param  \Http\Request  $request
+     * @return mixed
+     */
+    protected function callFilter($filter, $route, $request)
+    {
+        extract($filter);
+
+        return $this->filterer->callRouteFilter($filter, $parameters, $route, $request);
     }
 
 }

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -71,7 +71,7 @@ class ControllerInspector
     {
         switch ($method->class) {
             case 'Routing\Controller':
-            case 'Core\Controller':
+            case 'App\Core\Controller':
                 return false;
 
             default:

--- a/system/Routing/ControllerInspector.php
+++ b/system/Routing/ControllerInspector.php
@@ -17,13 +17,6 @@ class ControllerInspector
      */
     protected $verbs = array('any', 'get', 'post', 'put', 'patch', 'delete', 'head', 'options');
 
-    /**
-     * Boolean indicating the use of Named Parameters on not.
-     *
-     * @var bool $namedParams
-     */
-    protected $namedParams = true;
-
 
     /**
      * ControllerInspector constructor.
@@ -31,9 +24,9 @@ class ControllerInspector
      * @param bool $namedParams Wheter or not are used the Named Parameters
      * @codeCoverageIgnore
      */
-    public function __construct($namedParams = true)
+    public function __construct()
     {
-        $this->namedParams = $namedParams;
+        //
     }
 
     /**
@@ -147,11 +140,7 @@ class ControllerInspector
      */
     public function addUriWildcards($uri)
     {
-        if ($this->namedParams) {
-            return $uri .'/{one?}/{two?}/{three?}/{four?}/{five?}/{six?}/{seven?}';
-        }
-
-        return $uri .'(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any)(/(:any))))))))';
+        return $uri .'/{one?}/{two?}/{three?}/{four?}/{five?}/{six?}/{seven?}';
     }
 
 }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -214,7 +214,7 @@ class Route
      */
     protected function parseAction($action)
     {
-        if (is_null($action) || is_string($action) || is_callable($action)) {
+        if (is_string($action) || is_callable($action)) {
             // A null, string or Closure is given as Action.
             return array('uses' => $action);
         } else if (! isset($action['uses'])) {

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -890,7 +890,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      */
     protected function prefix($uri)
     {
-        return trim(trim($this->getLastGroupPrefix(), '/').'/'.trim($uri, '/'), '/') ?: '/';
+        $prefix = $this->getLastGroupPrefix();
+
+        return trim(trim($prefix, '/') .'/' .trim($uri, '/'), '/') ?: '/';
     }
 
     /**

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -781,7 +781,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace']) && isset($old['namespace'])) {
-            return trim(array_get($old, 'namespace'), '\\').'\\'.trim($new['namespace'], '\\');
+            return trim(array_get($old, 'namespace'), '\\') .'\\' .trim($new['namespace'], '\\');
         } else if (isset($new['namespace'])) {
             return trim($new['namespace'], '\\');
         }
@@ -799,7 +799,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     protected static function formatGroupPrefix($new, $old)
     {
         if (isset($new['prefix'])) {
-            return trim(array_get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
+            return trim(array_get($old, 'prefix'), '/') .'/' .trim($new['prefix'], '/');
         }
 
         return array_get($old, 'prefix');

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -28,6 +28,9 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+use Closure;
+use BadMethodCallException;
+
 
 /**
  * Router class will load requested Controller / Closure based on URL.
@@ -110,6 +113,13 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      * @var array $methods
      */
     public static $methods = array('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS');
+
+    /**
+     * The default actions for a resourceful controller.
+     *
+     * @var array
+     */
+    protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'destroy');
 
     /**
      * Boolean indicating the use of Named Parameters on not.
@@ -253,60 +263,6 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     }
 
     /**
-     * Defines a Route Group.
-     *
-     * @param string $group The scope of the current Routes Group
-     * @param callback $callback Callback object called to define the Routes.
-     */
-    public function group($group, $callback)
-    {
-        if (is_string($group)) $group = array('prefix' => $group);
-
-        // Add the Route Group to the array.
-        array_push($this->groupStack, $group);
-
-        // Call the Callback, to define the Routes on the current Group.
-        call_user_func($callback);
-
-        // Removes the last Route Group from the array.
-        array_pop($this->groupStack);
-    }
-
-    /* The Resourceful Routes in the Laravel Style.
-
-    Method     |  Path                 |  Action   |
-    ------------------------------------------------
-    GET        |  /photo               |  index    |
-    GET        |  /photo/create        |  create   |
-    POST       |  /photo               |  store    |
-    GET        |  /photo/{photo}       |  show     |
-    GET        |  /photo/{photo}/edit  |  edit     |
-    PUT/PATCH  |  /photo/{photo}       |  update   |
-    DELETE     |  /photo/{photo}       |  destroy  |
-
-    */
-
-    /**
-     * Defines a Resourceful Routes Group to a target Controller.
-     *
-     * @param string $basePath The base path of the resourceful routes group
-     * @param string $controller The target Resourceful Controller's name.
-     */
-    public function resource($basePath, $controller)
-    {
-        $param = $this->namedParams ? '{id}' : '(:any)';
-
-        //
-        $this->addRoute('GET',                 $basePath,                       $controller .'@index');
-        $this->addRoute('GET',                 $basePath .'/create',            $controller .'@create');
-        $this->addRoute('POST',                $basePath,                       $controller .'@store');
-        $this->addRoute('GET',                 $basePath .'/' .$param,          $controller .'@show');
-        $this->addRoute('GET',                 $basePath .'/' .$param .'/edit', $controller .'@edit');
-        $this->addRoute(array('PUT', 'PATCH'), $basePath .'/' .$param,          $controller .'@update');
-        $this->addRoute('DELETE',              $basePath .'/' .$param,          $controller .'@delete');
-    }
-
-    /**
      * Register an array of controllers with wildcard routing.
      *
      * @param  array  $controllers
@@ -324,10 +280,16 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      *
      * @param  string  $uri
      * @param  string  $controller
+     * @param  array   $names
      * @return void
+     * @throw  \BadMethodCallException
      */
-    public function controller($uri, $controller)
+    public function controller($uri, $controller, $names = array())
     {
+        if (! $this->namedParams) {
+            throw new BadMethodCallException("The method is not available while using Unnamed Parameters.");
+        }
+
         $inspector = $this->getInspector();
 
         //
@@ -342,13 +304,32 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
 
         foreach ($routable as $method => $routes) {
             foreach ($routes as $route) {
-                $action = array('uses' => $controller .'@' .$method);
-
-                $this->addRoute($route['verb'], $route['uri'], $action);
+                $this->registerInspected($route, $controller, $method, $names);
             }
         }
 
         $this->addFallthroughRoute($controller, $uri);
+    }
+
+    /**
+     * Register an inspected controller route.
+     *
+     * @param  array   $route
+     * @param  string  $controller
+     * @param  string  $method
+     * @param  array   $names
+     * @return void
+     */
+    protected function registerInspected($route, $controller, $method, &$names)
+    {
+        $action = array('uses' => $controller.'@'.$method);
+
+        // If a given controller method has been named, we will assign the name to the
+        // controller action array, which provides for a short-cut to method naming
+        // so you don't have to define an individual route for these controllers.
+        $action['as'] = array_get($names, $method);
+
+        $this->{$route['verb']}($route['uri'], $action);
     }
 
     /**
@@ -357,16 +338,487 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      * @param  string  $controller
      * @param  string  $uri
      * @return void
+     * @throw  \BadMethodCallException
      */
     protected function addFallthroughRoute($controller, $uri)
     {
-        if ($this->namedParams) {
-            $route = $this->any($uri .'/{_missing}', $controller .'@missingMethod');
+        $route = $this->any($uri .'/{_missing}', $controller .'@missingMethod');
 
-            $route->where('_missing', '(.*)');
-        } else {
-            $this->any($uri .'/(:all)', $controller .'@missingMethod');
+        $route->where('_missing', '(.*)');
+    }
+
+    /**
+     * Route a resource to a controller.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array   $options
+     * @return void
+     */
+    public function resource($name, $controller, array $options = array())
+    {
+        if (! $this->namedParams) {
+            throw new BadMethodCallException("The method is not available while using Unnamed Parameters.");
         }
+
+        // If the resource name contains a slash, we will assume the developer wishes to
+        // register these resource routes with a prefix so we will set that up out of
+        // the box so they don't have to mess with it. Otherwise, we will continue.
+        if (str_contains($name, '/')) {
+            $this->prefixedResource($name, $controller, $options);
+
+            return;
+        }
+
+        // We need to extract the base resource from the resource name. Nested resources
+        // are supported in the framework, but we need to know what name to use for a
+        // place-holder on the route wildcards, which should be the base resources.
+        $base = $this->getResourceWildcard(last(explode('.', $name)));
+
+        $defaults = $this->resourceDefaults;
+
+        foreach ($this->getResourceMethods($defaults, $options) as $method) {
+            $this->{'addResource'.ucfirst($method)}($name, $base, $controller, $options);
+        }
+    }
+
+    /**
+     * Build a set of prefixed resource routes.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array   $options
+     * @return void
+     */
+    protected function prefixedResource($name, $controller, array $options)
+    {
+        list($name, $prefix) = $this->getResourcePrefix($name);
+
+        // We need to extract the base resource from the resource name. Nested resources
+        // are supported in the framework, but we need to know what name to use for a
+        // place-holder on the route wildcards, which should be the base resources.
+        $callback = function($me) use ($name, $controller, $options)
+        {
+            $me->resource($name, $controller, $options);
+        };
+
+        return $this->group(compact('prefix'), $callback);
+    }
+
+    /**
+     * Extract the resource and prefix from a resource name.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    protected function getResourcePrefix($name)
+    {
+        $segments = explode('/', $name);
+
+        // To get the prefix, we will take all of the name segments and implode them on
+        // a slash. This will generate a proper URI prefix for us. Then we take this
+        // last segment, which will be considered the final resources name we use.
+        $prefix = implode('/', array_slice($segments, 0, -1));
+
+        $name = end($segments);
+
+        return array($name, $prefix);
+    }
+
+    /**
+     * Get the applicable resource methods.
+     *
+     * @param  array  $defaults
+     * @param  array  $options
+     * @return array
+     */
+    protected function getResourceMethods($defaults, $options)
+    {
+        if (isset($options['only'])) {
+            return array_intersect($defaults, (array) $options['only']);
+        } else if (isset($options['except'])) {
+            return array_diff($defaults, (array) $options['except']);
+        }
+
+        return $defaults;
+    }
+
+    /**
+     * Get the base resource URI for a given resource.
+     *
+     * @param  string  $resource
+     * @return string
+     */
+    public function getResourceUri($resource)
+    {
+        if ( ! str_contains($resource, '.')) return $resource;
+
+        // Once we have built the base URI, we'll remove the wildcard holder for this
+        // base resource name so that the individual route adders can suffix these
+        // paths however they need to, as some do not have any wildcards at all.
+        $segments = explode('.', $resource);
+
+        $uri = $this->getNestedResourceUri($segments);
+
+        return str_replace('/{'.$this->getResourceWildcard(last($segments)).'}', '', $uri);
+    }
+
+    /**
+     * Get the URI for a nested resource segment array.
+     *
+     * @param  array   $segments
+     * @return string
+     */
+    protected function getNestedResourceUri(array $segments)
+    {
+        // We will spin through the segments and create a place-holder for each of the
+        // resource segments, as well as the resource itself. Then we should get an
+        // entire string for the resource URI that contains all nested resources.
+        return implode('/', array_map(function($segment)
+        {
+            return $segment .'/{'.$this->getResourceWildcard($segment).'}';
+
+        }, $segments));
+    }
+
+    /**
+     * Get the action array for a resource route.
+     *
+     * @param  string  $resource
+     * @param  string  $controller
+     * @param  string  $method
+     * @param  array   $options
+     * @return array
+     */
+    protected function getResourceAction($resource, $controller, $method, $options)
+    {
+        $name = $this->getResourceName($resource, $method, $options);
+
+        return array('as' => $name, 'uses' => $controller .'@' .$method);
+    }
+
+    /**
+     * Get the name for a given resource.
+     *
+     * @param  string  $resource
+     * @param  string  $method
+     * @param  array   $options
+     * @return string
+     */
+    protected function getResourceName($resource, $method, $options)
+    {
+        if (isset($options['names'][$method])) return $options['names'][$method];
+
+        // If a global prefix has been assigned to all names for this resource, we will
+        // grab that so we can prepend it onto the name when we create this name for
+        // the resource action. Otherwise we'll just use an empty string for here.
+        $prefix = isset($options['as']) ? $options['as'] .'.' : '';
+
+        if (empty($this->groupStack)) {
+            return $prefix .$resource .'.' .$method;
+        }
+
+        return $this->getGroupResourceName($prefix, $resource, $method);
+    }
+
+    /**
+     * Get the resource name for a grouped resource.
+     *
+     * @param  string  $prefix
+     * @param  string  $resource
+     * @param  string  $method
+     * @return string
+     */
+    protected function getGroupResourceName($prefix, $resource, $method)
+    {
+        $group = str_replace('/', '.', $this->getLastGroupPrefix());
+
+        if (empty($group)) {
+            return trim("{$prefix}{$resource}.{$method}", '.');
+        }
+
+        return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
+    }
+
+    /**
+     * Format a resource wildcard for usage.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function getResourceWildcard($value)
+    {
+        return str_replace('-', '_', $value);
+    }
+
+    /**
+     * Add the index method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceIndex($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name);
+
+        $action = $this->getResourceAction($name, $controller, 'index', $options);
+
+        return $this->get($uri, $action);
+    }
+
+    /**
+     * Add the create method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceCreate($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/create';
+
+        $action = $this->getResourceAction($name, $controller, 'create', $options);
+
+        return $this->get($uri, $action);
+    }
+
+    /**
+     * Add the store method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceStore($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name);
+
+        $action = $this->getResourceAction($name, $controller, 'store', $options);
+
+        return $this->post($uri, $action);
+    }
+
+    /**
+     * Add the show method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceShow($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $action = $this->getResourceAction($name, $controller, 'show', $options);
+
+        return $this->get($uri, $action);
+    }
+
+    /**
+     * Add the edit method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceEdit($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+
+        $action = $this->getResourceAction($name, $controller, 'edit', $options);
+
+        return $this->get($uri, $action);
+    }
+
+    /**
+     * Add the update method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return void
+     */
+    protected function addResourceUpdate($name, $base, $controller, $options)
+    {
+        $this->addPutResourceUpdate($name, $base, $controller, $options);
+
+        return $this->addPatchResourceUpdate($name, $base, $controller);
+    }
+
+    /**
+     * Add the update method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addPutResourceUpdate($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $action = $this->getResourceAction($name, $controller, 'update', $options);
+
+        return $this->put($uri, $action);
+    }
+
+    /**
+     * Add the update method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @return void
+     */
+    protected function addPatchResourceUpdate($name, $base, $controller)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $this->patch($uri, $controller.'@update');
+    }
+
+    /**
+     * Add the destroy method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Nova\Routing\Route
+     */
+    protected function addResourceDestroy($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $action = $this->getResourceAction($name, $controller, 'destroy', $options);
+
+        return $this->delete($uri, $action);
+    }
+
+    /**
+     * Create a route group with shared attributes.
+     *
+     * @param  array     $attributes
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function group(array $attributes, Closure $callback)
+    {
+        $this->updateGroupStack($attributes);
+
+        // Once we have updated the group stack, we will execute the user Closure and
+        // merge in the groups attributes when the route is created. After we have
+        // run the callback, we will pop the attributes off of this group stack.
+        call_user_func($callback, $this);
+
+        array_pop($this->groupStack);
+    }
+
+    /**
+     * Update the group stack with the given attributes.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    protected function updateGroupStack(array $attributes)
+    {
+        if ( ! empty($this->groupStack)) {
+            $attributes = static::mergeGroup($attributes, last($this->groupStack));
+        }
+
+        $this->groupStack[] = $attributes;
+    }
+
+    /**
+     * Merge the given array with the last group stack.
+     *
+     * @param  array  $new
+     * @return array
+     */
+    public function mergeWithLastGroup($new)
+    {
+        $old = last($this->groupStack);
+
+        return static::mergeGroup($new, $old);
+    }
+
+    /**
+     * Merge the given group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return array
+     */
+    public static function mergeGroup($new, $old)
+    {
+        $new['namespace'] = static::formatUsesPrefix($new, $old);
+
+        $new['prefix'] = static::formatGroupPrefix($new, $old);
+
+        return array_merge_recursive(array_except($old, array('namespace', 'prefix')), $new);
+    }
+
+    /**
+     * Format the uses prefix for the new group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return string
+     */
+    protected static function formatUsesPrefix($new, $old)
+    {
+        if (isset($new['namespace']) && isset($old['namespace'])) {
+            return trim(array_get($old, 'namespace'), '\\').'\\'.trim($new['namespace'], '\\');
+        } else if (isset($new['namespace'])) {
+            return trim($new['namespace'], '\\');
+        }
+
+        return array_get($old, 'namespace');
+    }
+
+    /**
+     * Format the prefix for the new group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return string
+     */
+    protected static function formatGroupPrefix($new, $old)
+    {
+        if (isset($new['prefix'])) {
+            return trim(array_get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
+        }
+
+        return array_get($old, 'prefix');
+    }
+
+    /**
+     * Get the prefix from the last group on the stack.
+     *
+     * @return string
+     */
+    protected function getLastGroupPrefix()
+    {
+        if ( ! empty($this->groupStack)) {
+            $last = end($this->groupStack);
+
+            return isset($last['prefix']) ? $last['prefix'] : '';
+        }
+
+        return '';
     }
 
     /**
@@ -389,45 +841,32 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      * Create a new route instance.
      *
      * @param  array|string  $methods
-     * @param  string  $route
+     * @param  string  $uri
      * @param  mixed   $action
      * @return \Routing\Route
      */
-    protected function createRoute($methods, $route, $action)
+    protected function createRoute($methods, $uri, $action)
     {
-        // Pre-process the Action data.
-        if (! is_array($action)) $action = array('uses' => $action);
-
-        // Adjust the Prefix according with the Groups stack.
-        if (! empty($this->groupStack)) {
-            $parts = array();
-
-            foreach ($this->groupStack as $group) {
-                // Add the current prefix to the prefix list.
-                array_push($parts, trim($group['prefix'], '/'));
-            }
-
-            if (isset($action['prefix'])) {
-                array_push($parts, trim($action['prefix'], '/'));
-            }
-
-            // Adjust the Route PREFIX, if it is needed.
-            $parts = array_filter($parts, function($value)
-            {
-                return ! empty($value);
-            });
-
-            if (! empty($parts)) {
-                $action['prefix'] = implode('/', $parts);
-            }
-        }
-
+        // If the route is routing to a controller we will parse the route action into
+        // an acceptable array format before registering it and creating this route
+        // instance itself. We need to build the Closure that will call this out.
         if ($this->routingToController($action)) {
             $action = $this->getControllerAction($action);
         }
 
-        // Create a Route instance and return it.
-        return $this->newRoute($methods, $route, $action);
+        // Prefix the current route pattern.
+        $uri = $this->prefix($uri);
+
+        $route = $this->newRoute($methods, $uri, $action);
+
+        // If we have groups that need to be merged, we will merge them now after this
+        // route has already been created and is ready to go. After we're done with
+        // the merge we will be ready to return the route back out to the caller.
+        if (! empty($this->groupStack)) {
+            $this->mergeController($route);
+        }
+
+        return $route;
     }
 
     /**
@@ -441,6 +880,30 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
     protected function newRoute($methods, $uri, $action)
     {
         return new Route($methods, $uri, $action, $this->namedParams);
+    }
+
+    /**
+     * Prefix the given URI with the last prefix.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    protected function prefix($uri)
+    {
+        return trim(trim($this->getLastGroupPrefix(), '/').'/'.trim($uri, '/'), '/') ?: '/';
+    }
+
+    /**
+     * Merge the group stack with the controller action.
+     *
+     * @param  \Nova\Routing\Route  $route
+     * @return void
+     */
+    protected function mergeController($route)
+    {
+        $action = $this->mergeWithLastGroup($route->getAction());
+
+        $route->setAction($action);
     }
 
     /**
@@ -804,7 +1267,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface
      */
     public function getInspector()
     {
-        return $this->inspector ?: $this->inspector = new ControllerInspector($this->namedParams);
+        return $this->inspector ?: $this->inspector = new ControllerInspector();
     }
 
     /**

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -9,7 +9,7 @@
 namespace Routing;
 
 use Core\Config;
-use Core\Controller;
+use App\Core\Controller;
 use Events\Dispatcher;
 
 use Helpers\Inflector;

--- a/system/Routing/Router.php
+++ b/system/Routing/Router.php
@@ -8,7 +8,7 @@
 
 namespace Routing;
 
-use Core\Config;
+use Config\Config;
 use App\Core\Controller;
 use Events\Dispatcher;
 

--- a/system/Support/Facades/Language.php
+++ b/system/Support/Facades/Language.php
@@ -8,7 +8,7 @@
 
 namespace Support\Facades;
 
-use Core\Language as CoreLanguage;
+use Language\Language as CoreLanguage;
 
 use ReflectionMethod;
 use ReflectionException;
@@ -26,7 +26,7 @@ class Language
      */
     public static function __callStatic($method, $params)
     {
-        // First handle the static Methods from Core\Language.
+        // First handle the static Methods from Language\Language.
         try {
             $reflection = new ReflectionMethod(CoreLanguage::class, $method);
 
@@ -38,7 +38,7 @@ class Language
             // Nothing to do.
         }
 
-        // Get a Core\Language instance.
+        // Get a Language\Language instance.
         $instance = CoreLanguage::getInstance();
 
         // Call the non-static method from the Language instance.

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -2,16 +2,16 @@
 
 namespace Support\Facades;
 
-use Core\View;
 use Http\JsonResponse;
 use Http\Response as HttpResponse;
 use Support\Contracts\ArrayableInterface;
-use Support\Facades\Template;
-
-use Str;
 
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+use Str;
+use Template;
+use View;
 
 
 class Response

--- a/system/Template/Factory.php
+++ b/system/Template/Factory.php
@@ -3,7 +3,7 @@
 namespace Template;
 
 use Core\Config;
-use Core\Language;
+use Language\Language;
 use Support\Contracts\ArrayableInterface as Arrayable;
 use Template\Template;
 use View\Factory as ViewFactory;

--- a/system/Template/Factory.php
+++ b/system/Template/Factory.php
@@ -2,7 +2,7 @@
 
 namespace Template;
 
-use Core\Config;
+use Config\Config;
 use Language\Language;
 use Support\Contracts\ArrayableInterface as Arrayable;
 use Template\Template;

--- a/system/Validation/Translator.php
+++ b/system/Validation/Translator.php
@@ -10,7 +10,7 @@
 
 namespace Validation;
 
-use Core\Config;
+use Config\Config;
 
 
 class Translator

--- a/system/Validation/Translator.php
+++ b/system/Validation/Translator.php
@@ -2,7 +2,7 @@
 /**
  * Translator - Class to handle a Laravel-esque style Translations.
  *
- * NOTE: The real strings translation is made via the new \Core\Language API.
+ * NOTE: The real strings translation is made via the new \Language\Language API.
  *
  * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
  * @version 3.0

--- a/system/View/FileViewFinder.php
+++ b/system/View/FileViewFinder.php
@@ -87,7 +87,7 @@ class FileViewFinder implements ViewFinderInterface
     {
         return array_map(function($extension) use ($name)
         {
-            return str_replace('.', '/', $name) .'.' .$extension;
+            return str_replace('/', DS, $name) .'.' .$extension;
 
         }, $this->extensions);
     }

--- a/system/functions.php
+++ b/system/functions.php
@@ -648,6 +648,40 @@ function class_basename($class)
 }
 
 /**
+ * Returns all traits used by a trait and its traits
+ *
+ * @param  string  $trait
+ * @return array
+ */
+function trait_uses_recursive($trait)
+{
+    $traits = class_uses($trait);
+
+    foreach ($traits as $trait) {
+        $traits += trait_uses_recursive($trait);
+    }
+
+    return $traits;
+}
+
+/**
+ * Returns all traits used by a class, it's subclasses and trait of their traits
+ *
+ * @param  string  $class
+ * @return array
+ */
+function class_uses_recursive($class)
+{
+    $results = [];
+
+    foreach (array_merge([$class => $class], class_parents($class)) as $class) {
+        $results += trait_uses_recursive($class);
+    }
+
+    return array_unique($results);
+}
+
+/**
  * Determine if the given object has a toString method.
  *
  * @param  object  $object

--- a/system/functions.php
+++ b/system/functions.php
@@ -7,7 +7,7 @@
  * @date April 12th, 2016
  */
 
-use Core\Config;
+use Config\Config;
 use Helpers\Url;
 use Support\Str;
 use Support\Facades\Crypt;


### PR DESCRIPTION
This pull request introduce a significant improvement of the Resourceful Controllers handling on Routing and the implementation of **Filters based Middleware** for Controllers, similar with one from **Nova 4**.

To note that from now, the Routing command `Route::resource()` and `Route::controller()` use exclusive the Named Parameters, and they will throw a Exception when calling them while the Unnamed Parameters are setup for Routing. 

Also, to note that all other Routing commands preserve the working on the both Named and Unnamed Parameters Mode.

The big visible change on this pull request is  implementation of Filters based Middleware for Controllers, which permit a improved handling on Controller Middleware and multiple filters for both Before and After Stage.

The new Controller Middleware require a different approach of implementation on Controllers. For example, the old Middleware:
```php
    public function __construct()
    {
        parent::__construct();
    }

    protected function before()
    {
        // Check the User Authorization.
        if (! Auth::user()->hasRole('administrator')) {
            $status = __d('system', 'You are not authorized to access this resource.');

            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
        }

        // Leave to parent's method the Execution Flow decisions.
        return parent::before();
    }
```
Should be replaced with a code similar with:
```php
    public function __construct()
    {
        parent::__construct();

        //
        $this->beforeFilter('@filterRequests');
    }

    /**
     * Filter the incoming requests.
     */
    public function filterRequests(Route $route, Request $request)
    {
        // Check the User Authorization - while using the Extended Auth Driver.
        if (! Auth::user()->hasRole('administrator')) {
            $status = __d('users', 'You are not authorized to access this resource.');

            return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
        }
    }
```
If one prefer to use a **Closure** for the Middleware Filter, the following code demonstrate this way:
```php
    public function __construct()
    {
        parent::__construct();

        $this->beforeFilter(function(Route $route, Request $request)
        {
            // Check the User Authorization - while using the Extended Auth Driver.
            if (! Auth::user()->hasRole('administrator')) {
                $status = __d('users', 'You are not authorized to access this resource.');

                return Redirect::to('admin/dashboard')->withStatus($status, 'warning');
            }
        });
    }
```
Like is possible to be seen, the new Controller Middleware is similar with the Routing one, and eventually the methods from the Controller Middleware's Filters can be even called on Routing. For further usage examples, there are the shipped Modules at disposition.

Also, to note that it **is possible now to register multiple Filters** on the Controller Middleware, both for Before and After Stage.

In other hand, the Controllers flow is heavily optimized, for both RESTful and standard mode, the setup of View shared variables required by the example Backend is moved to a Event, while all Controllers from the example Modules are now children of the new `App\Core\BackendController`.

Finally, a new Controller called  `App\Legacy\Controller` is provided for API preservation and a simple transition to the new Routing and Controllers API, while preserving the optimization of Controllers flow.

This new Controller offer several (now legacy) APIs support: 

- A compatibility layer for the previous Controller Middleware style, proper setting up the variables and running the `before()` and `after()` methods with no changes required.
- The support for legacy Language instance on Controllers, for the old SMVC style translations.
- The support for processing the Views added using the old SMVC style like `View::render()` and `View::renderTemplate()` 

This pull request also introduce a consolidation and improvement of Database API, a better handling of the **Database Connections** and a enhanced QueryBuilder, driven now by Query Grammars and Processors.

Overall, the Framework's APIs are preserved, specially via the `App\Legacy\Controller` and are required very simple changes to port the existent code to the Design given by this pull-request. And those changes are needed only when the existent code use legacy APIs and/or the previous Controllers Middleware style.

Good for a minor version release.