### PR TITLE
Bugfix on Database ORM, consolidate the Routing - no domain option and custom patterns are allowed while using Unnamed Parameters

### DIFF
--- a/system/Database/ORM/Relations/BelongsToMany.php
+++ b/system/Database/ORM/Relations/BelongsToMany.php
@@ -809,7 +809,7 @@ class BelongsToMany extends Relation
      */
     protected function guessInverseRelation()
     {
-        return Str::camel(str_plural(class_basename($this->getParent())));
+        return Str::camel(Str::plural(class_basename($this->getParent())));
     }
 
     /**

--- a/system/Database/ORM/Relations/BelongsToMany.php
+++ b/system/Database/ORM/Relations/BelongsToMany.php
@@ -809,7 +809,9 @@ class BelongsToMany extends Relation
      */
     protected function guessInverseRelation()
     {
-        return Str::camel(Str::plural(class_basename($this->getParent())));
+        $name = Str::plural(class_basename($this->getParent()));
+
+        return Str::camel($name);
     }
 
     /**

--- a/system/Database/ORM/Relations/BelongsToMany.php
+++ b/system/Database/ORM/Relations/BelongsToMany.php
@@ -809,9 +809,9 @@ class BelongsToMany extends Relation
      */
     protected function guessInverseRelation()
     {
-        $name = Str::plural(class_basename($this->getParent()));
+        $relation = Str::plural(class_basename($this->getParent()));
 
-        return Str::camel($name);
+        return Str::camel($relation);
     }
 
     /**

--- a/system/Routing/Legacy/RouteParser.php
+++ b/system/Routing/Legacy/RouteParser.php
@@ -17,16 +17,16 @@ class RouteParser
     const SEPARATORS = '/,;.:-_~+*=@|';
 
 
-    public static function parse($route, array $patterns = array())
+    public static function parse($route)
     {
         preg_match_all('#\(:\w+\)#', $route, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 
         //
-        $patterns = array_merge($patterns, array(
+        $patterns = array(
             ':any' => '[^/]++',
             ':num' => '([0-9]+)',
             ':all' => '(.*)'
-        ));
+        );
 
         //
         $optionals = array();

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -174,6 +174,8 @@ class Route
      */
     public function compileRoute()
     {
+        $domain = $this->domain();
+
         if ($this->namedParams) {
             // The Route use the (default) Named Parameters.
             $optionals = $this->extractOptionalParameters();
@@ -181,8 +183,6 @@ class Route
             $this->pattern = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
         } else {
             // The Route use the (legacy) Unnamed Parameters.
-            $domain = $this->domain();
-
             if (! is_null($domain)) {
                 throw new \LogicException("The domain option is not allowed while using Unnamed Parameters.");
             }
@@ -191,7 +191,7 @@ class Route
         }
 
         $this->compiled = with(
-            new SymfonyRoute($this->pattern, $optionals, $this->wheres, array(), $this->domain() ?: '')
+            new SymfonyRoute($this->pattern, $optionals, $this->wheres, array(), $domain ?: '')
         )->compile();
     }
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -128,8 +128,12 @@ class Route
             $this->prefix($this->action['prefix']);
         }
 
-        //
-        $this->namedParams = $namedParams;
+        if (! $namedParams) {
+            // The 'domain' option is not allowed while using Unnamed Parameters.
+            unset($this->action['domain']);
+
+            $this->namedParams = false;
+        }
     }
 
     /**
@@ -176,22 +180,16 @@ class Route
     {
         if ($this->namedParams) {
             // The Route use the (default) Named Parameters.
-            $this->pattern = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
-
             $optionals = $this->extractOptionalParameters();
 
-            // The requirements for the compiled Symfony Route are just the wheres.
-            $requirements = $this->wheres;
+            $this->pattern = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
         } else {
             // The Route use the (legacy) Unnamed Parameters.
-            list($this->pattern, $optionals, $requirements) = RouteParser::parse(
-                $this->uri,
-                $this->wheres
-            );
+            list($this->pattern, $optionals, $this->wheres) = RouteParser::parse($this->uri);
         }
 
         $this->compiled = with(
-            new SymfonyRoute($this->pattern, $optionals, $requirements, array(), $this->domain() ?: '')
+            new SymfonyRoute($this->pattern, $optionals, $this->wheres, array(), $this->domain() ?: '')
         )->compile();
     }
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -113,10 +113,8 @@ class Route
     {
         $this->namedParams = $namedParams;
 
-        $uri = trim($uri, '/');
-
         //
-        $this->uri = ! empty($uri) ? $uri : '/';
+        $this->uri = $uri;
 
         $this->methods = (array) $methods;
 
@@ -681,9 +679,7 @@ class Route
      */
     public function prefix($prefix)
     {
-        $uri = trim(trim($prefix, '/') .'/' .trim($this->uri, '/'), '/');
-
-        $this->uri = ! empty($uri) ? $uri : '/';
+        $this->uri = trim($prefix, '/') .'/' .trim($this->uri, '/');
 
         return $this;
     }

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -111,6 +111,8 @@ class Route
      */
     public function __construct($methods, $uri, $action, $namedParams = true)
     {
+        $this->namedParams = $namedParams;
+
         $uri = trim($uri, '/');
 
         //
@@ -126,13 +128,6 @@ class Route
 
         if (isset($this->action['prefix'])) {
             $this->prefix($this->action['prefix']);
-        }
-
-        if (! $namedParams) {
-            // The 'domain' option is not allowed while using Unnamed Parameters.
-            unset($this->action['domain']);
-
-            $this->namedParams = false;
         }
     }
 
@@ -175,6 +170,7 @@ class Route
      * Compile the Route pattern for matching and return it.
      *
      * @return string
+     * @throws \LogicException
      */
     public function compileRoute()
     {
@@ -185,6 +181,12 @@ class Route
             $this->pattern = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
         } else {
             // The Route use the (legacy) Unnamed Parameters.
+            $domain = $this->domain();
+
+            if (! is_null($domain)) {
+                throw new \LogicException("The domain option is not allowed while using Unnamed Parameters.");
+            }
+
             list($this->pattern, $optionals, $this->wheres) = RouteParser::parse($this->uri);
         }
 

--- a/system/Routing/Route.php
+++ b/system/Routing/Route.php
@@ -629,9 +629,14 @@ class Route
      * @param  array|string  $name
      * @param  string  $expression
      * @return $this
+     * @throws \BadMethodCallException
      */
     public function where($name, $expression = null)
     {
+        if (! $this->namedParams) {
+            throw new BadMethodCallException("Not available while using Unnamed Parameters.");
+        }
+
         foreach ($this->parseWhere($name, $expression) as $name => $expression) {
             $this->wheres[$name] = $expression;
         }


### PR DESCRIPTION
The Symfony's Route Compiler treat separately the domain and URI patterns, every on having the ability to contain (named) parameters, while on Unnamed Parameters mode, the Routing parse only the URI pattern, as supposed by the compatibility mode.

This pull request fix a possible logic issue while the Routing is on Unnamed Parameters mode, going Exception while is used the **domain** option or the `where()` command.

To note that the use of the classic SMVC-like pattern style (aka the Unnamed Parameters mode) is not influenced.

Also, this pull request introduce a bug-fix on **Database\ORM\Relations\BelongsToMany**.

No API changes, good for a micro version release.