### PR TITLE
Adding a small feature to View Service, offering the support for View::fetch()

### DIFF
--- a/system/Support/Facades/View.php
+++ b/system/Support/Facades/View.php
@@ -13,7 +13,8 @@ use Support\Facades\Facade;
 
 
 class View extends Facade
-{
+{ 
+
     /**
      * Get the registered name of the component.
      *

--- a/system/View/Factory.php
+++ b/system/View/Factory.php
@@ -7,6 +7,8 @@ use View\Engines\EngineResolver;
 use View\View;
 use View\ViewFinderInterface;
 
+use Closure;
+
 
 class Factory
 {
@@ -82,6 +84,18 @@ class Factory
         return new View($this, $engine, $view, $path, $data);
     }
 
+    /**
+     * Create a View instance and return its rendered content.
+     *
+     * @return string
+     */
+    public function render($view, $data = array(), $module = null, Closure $callback = null)
+    {
+        $instance = $this->make($view, $data, $module);
+    
+        return $instance->render($callback); 
+    }
+    
     /**
      * Parse the given data into a raw array.
      *

--- a/system/View/Factory.php
+++ b/system/View/Factory.php
@@ -89,7 +89,7 @@ class Factory
      *
      * @return string
      */
-    public function render($view, $data = array(), $module = null, Closure $callback = null)
+    public function fetch($view, $data = array(), $module = null, Closure $callback = null)
     {
         $instance = $this->make($view, $data, $module);
     

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -15,6 +15,7 @@ use View\Engines\EngineInterface;
 use View\Factory;
 
 use ArrayAccess;
+use Closure;
 use Exception;
 
 


### PR DESCRIPTION
This pull request add a small feature to View Service, offering the support for `View::fetch()` command, which, internally, create a View instance, then render it and returns the result.

As a side note, you will notice that this method, `View::fetch()` is similar with one offered by the Views Legacy Layer, which was previous removed. 

But this time, the command is one native integrated on **View\Factory** and considered being very useful for local rendering, was added back.

Finally, is introduced also a small fix on **View\View**, as in a missing `use`.