### PR TITLE
Implement the function vendor_url() and add the missing file app/Views/Error/500.php

### DIFF
--- a/app/Templates/AdminLTE/backend-rtl.php
+++ b/app/Templates/AdminLTE/backend-rtl.php
@@ -45,9 +45,9 @@ $langMenuLinks = ob_get_clean();
         // Theme style
         template_url('css/AdminLTE-rtl.min.css', 'AdminLTE'),
         // AdminLTE Skins
-        site_url('vendor/almasaeed2010/adminlte/dist/css/skins/_all-skins.min.css'),
+        vendor_url('dist/css/skins/_all-skins.min.css', 'almasaeed2010/adminlte'),
         // Select2
-        site_url('vendor/almasaeed2010/adminlte/plugins/select2/select2.min.css'),
+        vendor_url('plugins/select2/select2.min.css', 'almasaeed2010/adminlte'),
         // Custom CSS
         template_url('css/style-rtl.css', 'AdminLTE'),
     ));
@@ -68,7 +68,7 @@ $langMenuLinks = ob_get_clean();
 <?php
     //Add Controller specific JS files.
     Assets::js(array(
-        site_url('vendor/almasaeed2010/adminlte/plugins/jQuery/jquery-2.2.3.min.js'),
+        vendor_url('plugins/jQuery/jquery-2.2.3.min.js', 'almasaeed2010/adminlte'),
     ));
 
     ?>
@@ -118,14 +118,14 @@ $langMenuLinks = ob_get_clean();
             <!-- Menu Toggle Button -->
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               <!-- The user image in the navbar-->
-              <img src="<?= site_url('vendor/almasaeed2010/adminlte/dist/img/avatar5.png'); ?>" class="user-image" alt="User Image">
+              <img src="<?= vendor_url('dist/img/avatar5.png', 'almasaeed2010/adminlte'); ?>" class="user-image" alt="User Image">
               <!-- hidden-xs hides the username on small devices so only the image appears. -->
               <span class="hidden-xs"><?= $user->username; ?></span>
             </a>
             <ul class="dropdown-menu">
               <!-- The user image in the menu -->
               <li class="user-header">
-                <img src="<?= site_url('vendor/almasaeed2010/adminlte/dist/img/avatar5.png'); ?>" class="img-circle" alt="User Image">
+                <img src="<?= vendor_url('dist/img/avatar5.png', 'almasaeed2010/adminlte'); ?>" class="img-circle" alt="User Image">
 
                 <p>
                   <?= $user->realname; ?> - <?= $user->role->name; ?>
@@ -220,9 +220,9 @@ Assets::js(array(
     // Bootstrap 3.3.5
     template_url('js/bootstrap-rtl.min.js', 'Default'),
     // AdminLTE App
-    site_url('vendor/almasaeed2010/adminlte/dist/js/app.min.js'),
+    vendor_url('dist/js/app.min.js', 'almasaeed2010/adminlte'),
     // Select2
-    site_url('vendor/almasaeed2010/adminlte/plugins/select2/select2.full.min.js')
+    vendor_url('plugins/select2/select2.full.min.js', 'almasaeed2010/adminlte')
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data / plugable hook zone

--- a/app/Templates/AdminLTE/backend.php
+++ b/app/Templates/AdminLTE/backend.php
@@ -37,17 +37,17 @@ $langMenuLinks = ob_get_clean();
     <?php
     Assets::css(array(
         // Bootstrap 3.3.5
-        site_url('vendor/almasaeed2010/adminlte/bootstrap/css/bootstrap.min.css'),
+        vendor_url('bootstrap/css/bootstrap.min.css', 'almasaeed2010/adminlte'),
         // Font Awesome
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css',
         // Ionicons
         'https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css',
         // Theme style
-        site_url('vendor/almasaeed2010/adminlte/dist/css/AdminLTE.min.css'),
+        vendor_url('dist/css/AdminLTE.min.css', 'almasaeed2010/adminlte'),
         // AdminLTE Skins
-        site_url('vendor/almasaeed2010/adminlte/dist/css/skins/_all-skins.min.css'),
+        vendor_url('dist/css/skins/_all-skins.min.css', 'almasaeed2010/adminlte'),
         // Select2
-        site_url('vendor/almasaeed2010/adminlte/plugins/select2/select2.min.css'),
+        vendor_url('plugins/select2/select2.min.css', 'almasaeed2010/adminlte'),
         // Custom CSS
         template_url('css/style.css', 'AdminLTE'),
     ));
@@ -68,7 +68,7 @@ $langMenuLinks = ob_get_clean();
 <?php
     //Add Controller specific JS files.
     Assets::js(array(
-        site_url('vendor/almasaeed2010/adminlte/plugins/jQuery/jquery-2.2.3.min.js'),
+        vendor_url('plugins/jQuery/jquery-2.2.3.min.js', 'almasaeed2010/adminlte'),
     ));
 
     ?>
@@ -118,14 +118,14 @@ $langMenuLinks = ob_get_clean();
             <!-- Menu Toggle Button -->
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               <!-- The user image in the navbar-->
-              <img src="<?= site_url('vendor/almasaeed2010/adminlte/dist/img/avatar5.png'); ?>" class="user-image" alt="User Image">
+              <img src="<?= vendor_url('dist/img/avatar5.png', 'almasaeed2010/adminlte'); ?>" class="user-image" alt="User Image">
               <!-- hidden-xs hides the username on small devices so only the image appears. -->
               <span class="hidden-xs"><?= $user->username; ?></span>
             </a>
             <ul class="dropdown-menu">
               <!-- The user image in the menu -->
               <li class="user-header">
-                <img src="<?= site_url('vendor/almasaeed2010/adminlte/dist/img/avatar5.png'); ?>" class="img-circle" alt="User Image">
+                <img src="<?= vendor_url('dist/img/avatar5.png', 'almasaeed2010/adminlte'); ?>" class="img-circle" alt="User Image">
 
                 <p>
                   <?= $user->realname; ?> - <?= $user->role->name; ?>
@@ -218,11 +218,11 @@ $langMenuLinks = ob_get_clean();
 <?php
 Assets::js(array(
     // Bootstrap 3.3.5
-    site_url('vendor/almasaeed2010/adminlte/bootstrap/js/bootstrap.min.js'),
+    vendor_url('bootstrap/js/bootstrap.min.js', 'almasaeed2010/adminlte'),
     // AdminLTE App
-    site_url('vendor/almasaeed2010/adminlte/dist/js/app.min.js'),
+    vendor_url('dist/js/app.min.js', 'almasaeed2010/adminlte'),
     // Select2
-    site_url('vendor/almasaeed2010/adminlte/plugins/select2/select2.full.min.js')
+    vendor_url('plugins/select2/select2.full.min.js', 'almasaeed2010/adminlte')
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data / plugable hook zone

--- a/app/Templates/AdminLTE/default-rtl.php
+++ b/app/Templates/AdminLTE/default-rtl.php
@@ -42,9 +42,9 @@ $langMenuLinks = ob_get_clean();
         // Theme style
         template_url('css/AdminLTE-rtl.min.css', 'AdminLTE'),
         // AdminLTE Skins
-        site_url('vendor/almasaeed2010/adminlte/dist/css/skins/_all-skins.min.css'),
+        vendor_url('dist/css/skins/_all-skins.min.css', 'almasaeed2010/adminlte'),
         // iCheck
-        site_url('vendor/almasaeed2010/adminlte/plugins/iCheck/square/blue.css'),
+        vendor_url('plugins/iCheck/square/blue.css', 'almasaeed2010/adminlte'),
         // Custom CSS
         template_url('css/style-rtl.css', 'AdminLTE'),
     ));
@@ -53,7 +53,7 @@ $langMenuLinks = ob_get_clean();
 
     //Add Controller specific JS files.
     Assets::js(array(
-            site_url('vendor/almasaeed2010/adminlte/plugins/jQuery/jquery-2.2.3.min.js'),
+            vendor_url('plugins/jQuery/jquery-2.2.3.min.js', 'almasaeed2010/adminlte'),
         )
     );
 
@@ -143,9 +143,9 @@ Assets::js(array(
     // Bootstrap 3.3.5
     template_url('js/bootstrap-rtl.min.js', 'Default'),
     // AdminLTE App
-    site_url('vendor/almasaeed2010/adminlte/dist/js/app.min.js'),
+    vendor_url('dist/js/app.min.js', 'almasaeed2010/adminlte'),
     // iCheck
-    site_url('vendor/almasaeed2010/adminlte/plugins/iCheck/icheck.min.js'),
+    vendor_url('plugins/iCheck/icheck.min.js', 'almasaeed2010/adminlte'),
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data / plugable hook zone

--- a/app/Templates/AdminLTE/default.php
+++ b/app/Templates/AdminLTE/default.php
@@ -34,17 +34,17 @@ $langMenuLinks = ob_get_clean();
     <?php
     Assets::css(array(
         // Bootstrap 3.3.5
-        site_url('vendor/almasaeed2010/adminlte/bootstrap/css/bootstrap.min.css'),
+        vendor_url('bootstrap/css/bootstrap.min.css', 'almasaeed2010/adminlte'),
         // Font Awesome
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css',
         // Ionicons
         'https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css',
         // Theme style
-        site_url('vendor/almasaeed2010/adminlte/dist/css/AdminLTE.min.css'),
+        vendor_url('dist/css/AdminLTE.min.css', 'almasaeed2010/adminlte'),
         // AdminLTE Skins
-        site_url('vendor/almasaeed2010/adminlte/dist/css/skins/_all-skins.min.css'),
+        vendor_url('dist/css/skins/_all-skins.min.css', 'almasaeed2010/adminlte'),
         // iCheck
-        site_url('vendor/almasaeed2010/adminlte/plugins/iCheck/square/blue.css'),
+        vendor_url('plugins/iCheck/square/blue.css', 'almasaeed2010/adminlte'),
         // Custom CSS
         template_url('css/style.css', 'AdminLTE'),
     ));
@@ -53,7 +53,7 @@ $langMenuLinks = ob_get_clean();
 
     //Add Controller specific JS files.
     Assets::js(array(
-            site_url('vendor/almasaeed2010/adminlte/plugins/jQuery/jquery-2.2.3.min.js'),
+            vendor_url('plugins/jQuery/jquery-2.2.3.min.js', 'almasaeed2010/adminlte'),
         )
     );
 
@@ -141,11 +141,11 @@ $langMenuLinks = ob_get_clean();
 <?php
 Assets::js(array(
     // Bootstrap 3.3.5
-    site_url('vendor/almasaeed2010/adminlte/bootstrap/js/bootstrap.min.js'),
+    vendor_url('bootstrap/js/bootstrap.min.js', 'almasaeed2010/adminlte'),
     // AdminLTE App
-    site_url('vendor/almasaeed2010/adminlte/dist/js/app.min.js'),
+    vendor_url('dist/js/app.min.js', 'almasaeed2010/adminlte'),
     // iCheck
-    site_url('vendor/almasaeed2010/adminlte/plugins/iCheck/icheck.min.js'),
+    vendor_url('plugins/iCheck/icheck.min.js', 'almasaeed2010/adminlte'),
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data / plugable hook zone

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -30,8 +30,8 @@ $langMenuLinks = ob_get_clean();
 echo isset($meta) ? $meta : ''; // Place to pass data / plugable hook zone
 
 Assets::css([
-    site_url('vendor/twbs/bootstrap/dist/css/bootstrap.min.css'),
-    site_url('vendor/twbs/bootstrap/dist/css/bootstrap-theme.min.css'),
+    vendor_url('dist/css/bootstrap.min.css', 'twbs/bootstrap'),
+    vendor_url('dist/css/bootstrap-theme.min.css', 'twbs/bootstrap'),
     'https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css',
     template_url('css/style.css', 'Default'),
 ]);
@@ -81,7 +81,7 @@ echo isset($css) ? $css : ''; // Place to pass data / plugable hook zone
 <?php
 Assets::js([
     'https://code.jquery.com/jquery-1.12.4.min.js',
-    site_url('vendor/twbs/bootstrap/dist/js/bootstrap.min.js'),
+    vendor_url('dist/js/bootstrap.min.js', 'twbs/bootstrap'),
 ]);
 
 echo isset($js) ? $js : ''; // Place to pass data / plugable hook zone

--- a/app/Views/Error/500.php
+++ b/app/Views/Error/500.php
@@ -1,0 +1,14 @@
+<div class="container content">
+    <div class="row">
+        <div class="col-md-12">
+
+            <h1>500</h1>
+
+            <hr />
+
+            <h3><?= __('Internal Server Error'); ?></h3>
+            <p><?= __('Something has gone wrong on the Web Server.'); ?></p>
+
+        </div>
+    </div>
+</div>

--- a/system/functions.php
+++ b/system/functions.php
@@ -98,6 +98,7 @@ function template_url($path, $template = null)
 /**
  * Vendor URL helper
  * @param string $path
+ * @param string $vendor
  * @return string
  */
 function vendor_url($path, $vendor)

--- a/system/functions.php
+++ b/system/functions.php
@@ -96,6 +96,18 @@ function template_url($path, $template = null)
 }
 
 /**
+ * Vendor URL helper
+ * @param string $path
+ * @return string
+ */
+function vendor_url($path, $vendor)
+{
+    $path = sprintf('vendor/%s/%s', $vendor, $path);
+
+    return url($path);
+}
+
+/**
  * Get the path to the application folder.
  *
  * @param  string  $path


### PR DESCRIPTION
This pull request add a new helper function called `vendor_url()`, with a convenience role. 

Its usage is for Layouts and is simple as:
```php
vendor_url('dist/css/AdminLTE.min.css', 'almasaeed2010/adminlte'),
```

The rationale of adding it is that its logic expose better to the rogrammer logic the vendor files.