### PR TITLE
Improve the HTTP Exceptions handling

### DIFF
--- a/app/Filters.php
+++ b/app/Filters.php
@@ -45,9 +45,9 @@ Route::filter('csrf', function($route, $request) {
     // The CSRF Token is invalid, respond with Error 400 (Bad Request)
     else if ($ajaxRequest) {
         return Response::make('Bad Request', 400);
+    } else {
+        App::abort(400, 'Bad Request');
     }
-
-    App::abort(400, 'Bad Request');
 });
 
 // Referer checking Filter.

--- a/app/Filters.php
+++ b/app/Filters.php
@@ -45,9 +45,9 @@ Route::filter('csrf', function($route, $request) {
     // The CSRF Token is invalid, respond with Error 400 (Bad Request)
     else if ($ajaxRequest) {
         return Response::make('Bad Request', 400);
-    } else {
-        return Response::error(400);
     }
+
+    App::abort(400, 'Bad Request');
 });
 
 // Referer checking Filter.
@@ -56,8 +56,8 @@ Route::filter('referer', function($route, $request) {
     $referer = $request->header('referer');
 
     if(! str_starts_with($referer, Config::get('app.url'))) {
-        // When Referrer is invalid, respond with Error 400 Page (Bad Request)
-        return Response::error(400);
+        // When Referrer is invalid, respond with Error 400 (Bad Request)
+        App::abort(400, 'Bad Request');
     }
 });
 

--- a/app/Modules/System/Controllers/Authorize.php
+++ b/app/Modules/System/Controllers/Authorize.php
@@ -12,6 +12,7 @@ use Nova\Helpers\ReCaptcha;
 
 use App\Core\BackendController;
 
+use App;
 use Auth;
 use Hash;
 use Input;
@@ -116,7 +117,6 @@ class Authorize extends BackendController
      */
     public function remind()
     {
-
         return $this->getView()
             ->shares('title', __d('users', 'Password Recovery'));
     }
@@ -159,10 +159,8 @@ class Authorize extends BackendController
      * @param  string  $token
      * @return Response
      */
-    public function reset($token = null)
+    public function reset($token)
     {
-        if (is_null($token)) return Response::error(404);
-
         return $this->getView()
             ->shares('title', __d('users', 'Password Reset'))
             ->with('token', $token);

--- a/app/Modules/System/Routes.php
+++ b/app/Modules/System/Routes.php
@@ -26,8 +26,8 @@ Route::group(array('prefix' => '', 'namespace' => 'App\Modules\System\Controller
     Route::post('password/remind', array('before' => 'guest|csrf', 'uses' => 'Authorize@postRemind'));
 
     // The Password Reset.
-    Route::get( 'password/reset/{token?}', array('before' => 'guest',      'uses' => 'Authorize@reset'));
-    Route::post('password/reset',          array('before' => 'guest|csrf', 'uses' => 'Authorize@postReset'));
+    Route::get( 'password/reset/{token}', array('before' => 'guest',      'uses' => 'Authorize@reset'));
+    Route::post('password/reset',         array('before' => 'guest|csrf', 'uses' => 'Authorize@postReset'));
 });
 
 // The Adminstration Routes.

--- a/app/Modules/System/Views/Authorize/Reset.php
+++ b/app/Modules/System/Views/Authorize/Reset.php
@@ -38,7 +38,7 @@
                 </div>
 
                 <input type="hidden" name="csrfToken" value="<?= $csrfToken; ?>" />
-                <input type="hidden" name="token" value="<?= $token; ?>" />
+                <input type="hidden" name="token" value="<?= e($token); ?>" />
 
                 </form>
             </div>

--- a/system/Support/Facades/Response.php
+++ b/system/Support/Facades/Response.php
@@ -5,7 +5,6 @@ namespace Nova\Support\Facades;
 use Nova\Http\JsonResponse;
 use Nova\Http\Response as HttpResponse;
 use Nova\Support\Contracts\ArrayableInterface;
-use Nova\Support\Facades\Template;
 use Nova\Support\Facades\View;
 use Nova\Support\Str;
 
@@ -99,34 +98,6 @@ class Response
         }
 
         return $response;
-    }
-
-    /**
-     * Create a new Error Response instance.
-     *
-     * The Response Status code will be set using the specified code.
-     *
-     * The specified error should match a View in your Views/Error directory.
-     *
-     * <code>
-     *      // Create a 404 response.
-     *      return Response::error('404');
-     *
-     *      // Create a 404 response with data.
-     *      return Response::error('404', array('message' => 'Not Found'));
-     * </code>
-     *
-     * @param  int       $code
-     * @param  array     $data
-     * @return Response
-     */
-    public static function error($status, array $data = array(), $headers = array())
-    {
-        $view = Template::make('default')
-            ->shares('title', 'Error ' .$status)
-            ->nest('content', 'Error/' .$status, $data);
-
-        return static::make($view, $status, $headers);
     }
 
     /**


### PR DESCRIPTION
This pull request improve **the HTTP Exceptions handling**, simplifying and unifying the logic, making possible to expose the entire Error Pages generation to the end-user, them making possible their customization as Template, Layout, etc.

As a collateral consequence, the `Response::error()` was removed, not being useful anymore.

As usage, basically we will go back to roots, using for aborting of the processing, the `App::abort()` which exists there since ages. For example, if you want to go **Error 404** in your Controller's Action, you can use:
```php
App::abort(404, 'Page not found');
```
Same way for going i.e. **Error 400**
```php
App::abort(400, 'Bad Request');
```
