### PR TITLE
Implementation of the ORM File Field

### DIFF
--- a/app/Config/FileField.php
+++ b/app/Config/FileField.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * FileField configuration
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 3.0
+ */
+
+use Nova\Config\Config;
+
+
+Config::set('fileField', array(
+    'path'        => base_path('files/:class_slug/:attribute/:unique_id-:file_name'),
+    'defaultPath' => base_path('files/default.png')
+));
+

--- a/shared/Database/ORM/FileField.php
+++ b/shared/Database/ORM/FileField.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Shared\Database\ORM\FileField;
+
+use Nova\Database\ORM\Model;
+use Nova\Support\Str;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+use Exception;
+use JsonSerializable;
+
+
+class FileField implements JsonSerializable
+{
+    /**
+     * @var Nova\Database\ORM\Model The ORM model this field is in
+     */
+    protected $model;
+
+    /**
+     * @var \Nova\Filesystem\Filesystem The file system which handles files for this field
+     */
+    protected $files;
+
+    /**
+     * @var string Name of this field
+     */
+    protected $key;
+
+    /**
+     * @var array Disk and path config for this field
+     */
+    protected $options;
+
+    /**
+     * @var string path to the file on the disk
+     */
+    protected $path;
+
+    /**
+     * @var string
+     */
+    protected $fileName;
+
+
+    /**
+     * FileField constructor.
+     *
+     * @param Model $model
+     * @param $key
+     * @param null $fileName
+     */
+    public function __construct(Model $model, $key, $fileName = null)
+    {
+        $config = app('config');
+
+        // If filename wasn't given, take it from the model
+        if ($model->exists) {
+            $attributes = $model->getAttributes();
+
+            $this->path = isset($attributes[$key]) ? $attributes[$key] : null;
+
+            if (isset($this->path) && is_null($fileName)) {
+                $fileName = pathinfo($this->path, PATHINFO_FILENAME);
+            }
+        }
+
+        $this->model = $model;
+
+        $this->key = $key;
+
+        $this->options = array_merge(
+            $config->get('fileField', array()),
+            $this->model->files[$key]
+        );
+
+        $this->fileName = $fileName;
+
+        $this->files = app('files');
+    }
+
+    /**
+     * Substitute placeholders and return the path for the file
+     *
+     * @return string
+     */
+    protected function getPathForUpload()
+    {
+        $extension = pathinfo($this->fileName, PATHINFO_EXTENSION);
+
+        //
+        $className = class_basename($this->model);
+
+        $classSlug = Str::slug(snake_case(str_plural($className)));
+
+        //
+        $search = array(':extension', ':attribute', ':unique_id', ':class_slug', ':file_name');
+
+        $replace = array(
+            $extension,
+            $this->key,
+            uniqid(),
+            $classSlug,
+            $this->fileName
+        );
+
+        return str_replace($search, $replace, $this->options['path']);
+    }
+
+    /**
+     * @return \Nova\Filesystem\Filesystem
+     */
+    public function getFileSystem()
+    {
+        return $this->files;
+    }
+
+    /**
+     * Move the given file to appropriate directory
+     *
+     * @param UploadedFile $file
+     * @return mixed
+     */
+    public function uploadFile(UploadedFile $file)
+    {
+        $path = $this->getPathForUpload();
+
+        $this->files->makeDirectory(dirname($path), 0755, true, true);
+
+        if ($this->files->put($path, fopen($file->getRealPath(), 'r+'))) {
+            return $this->path = $path;
+        }
+    }
+
+    public function copyLocal($currentPath)
+    {
+        $path = $this->getPathForUpload();
+
+        $this->files->makeDirectory(dirname($path), 0755, true, true);
+
+        if ($this->files->copy($currentPath, $path)) {
+            return $this->path = $path;
+        }
+    }
+
+    /**
+     * Delete the file
+     *
+     * @return mixed
+     */
+    public function delete()
+    {
+        try {
+            return $this->files->delete($this->path);
+        }
+
+        // Catch all exceptions.
+        catch (Exception $e) {
+            app('log')->error($e->getMessage());
+        }
+    }
+
+    public function exists()
+    {
+        return ! empty($this->path);
+    }
+
+    /**
+     * Delegate properties to filesystem
+     *
+     * @param $name
+     * @return null|string
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'path':
+                return $this->path;
+
+            case 'name':
+                return $this->fileName;
+
+            default:
+                return $this->files->$name;
+        }
+    }
+
+    /**
+     * Delegate methods to filesystem
+     *
+     * @param $name
+     * @param $args
+     * @return mixed
+     */
+    public function __call($name, $args)
+    {
+        // Prepend filename to the arguments.
+        array_unshift($args, $this->path);
+
+        return call_user_func_array(array($this->files, $name), $args);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        if (! $this->exists()) {
+            return array('error' => 'File does not exist!');
+        }
+
+        try {
+            return array(
+                'name' => $this->fileName,
+                'path' => $this->path,
+                'size' => $this->size(),
+                'type' => $this->getMimetype()
+            );
+        }
+
+        // Catch all exceptions.
+        catch (Exception $e) {
+            return array('error' => $e->getMessage());
+        }
+    }
+
+    public function __toString()
+    {
+        return $this->path ?: $this->options['defaultPath'];
+    }
+}

--- a/shared/Database/ORM/FileFieldTrait.php
+++ b/shared/Database/ORM/FileFieldTrait.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Shared\Database\ORM\FileField;
+
+use Nova\Database\ORM\Model;
+use Nova\Support\Str;
+
+use Shared\Database\ORM\FileField\FileField;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+
+trait FileFieldTrait
+{
+    /**
+     * Listen to ORM events.
+     *
+     * Cleanup properly on update and delete
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        static::saving(function (Model $model)
+        {
+            $files = (array) $model->files;
+
+            if (count($files) > 0) {
+                foreach ($files as $key => $options) {
+                    $filePath = $model->getOriginal($key);
+
+                    if (is_null($filePath)) continue;
+
+                    $fileField = $model->getAttributeValue($key);
+
+                    if ($fileField->path == $filePath) {
+                        continue;
+                    }
+
+                    try {
+                        app('files')->delete($filePath);
+                    }
+
+                    // Catch all exceptions.
+                    catch (Exception $e) {
+                        app('log')->error($e->getMessage());
+                    }
+                }
+            }
+        });
+
+        static::deleting(function (Model $model)
+        {
+            // Don't delete the file if you are doing a soft delete!
+            if (! method_exists($model, 'restore') || $model->forceDeleting) {
+                $files = (array) $model->files;
+
+                if (count($files) > 0) {
+                    foreach ($files as $key => $options) {
+                        $file = $model->getAttribute($key);
+
+                        $file->delete();
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Instead of database column, return the FileField object.
+     *
+     * @param $key
+     * @return FileField
+     */
+    public function getAttributeValue($key)
+    {
+        if (in_array($key, array_keys($this->files))) {
+            return new FileField($this, $key);
+        }
+
+        return parent::getAttributeValue($key);
+    }
+
+    /**
+     * Determine if it is a URL upload or file upload.
+     * Upload the file and set file name
+     *
+     * @param $key
+     * @param $value
+     */
+    public function setAttribute($key, $value)
+    {
+        if (! in_array($key, array_keys($this->files)) || is_null($value)) {
+            parent::setAttribute($key, $value);
+        }
+
+        // Handle the values which are UploadedFile instances.
+        else if ($value instanceof UploadedFile) {
+            $name = Str::slug(pathinfo($value->getClientOriginalName(), PATHINFO_FILENAME));
+
+            $extension = $value->getClientOriginalExtension();
+
+            $fileName = join('.', array($name, $extension));
+
+            //
+            $fileField = new FileField($this, $key, $fileName);
+
+            $this->attributes[$key] = $fileField->uploadFile($value);
+        }
+
+        // Handle the string values - files specified by path.
+        else if (is_string($value)) {
+            $name = pathinfo($value, PATHINFO_FILENAME);
+
+            $extension = pathinfo($value, PATHINFO_EXTENSION);
+
+            $fileName = join('.', array($name, $extension));
+
+            //
+            $fileField = new FileField($this, $key, $fileName);
+
+            $this->attributes[$key] = $fileField->copyLocal($value);
+        }
+    }
+}

--- a/shared/Database/ORM/README.md
+++ b/shared/Database/ORM/README.md
@@ -1,0 +1,35 @@
+# ORM File Field
+
+Easily upload files to a directory and save the filename to database attribute.
+
+## Usage
+
+In your ORM Model:
+
+```php
+use Shared\Database\ORM\FileFieldTrait;
+
+public $files = (
+    'image' => array(),
+    'poster' => array(
+        'path' => 'uploads/:class_slug/:attribute/:unique_id-:file_name',
+        'defaultPath' => 'uploads/default.png'
+    )
+);
+```
+In your Controller:
+
+```php
+$model = new Poster();
+
+if (Input::hasFile('poster')) {
+    $model->poster = Input::file('poster');
+}
+
+$model->save();
+```
+Each field can have filesystem path pattern and default path options. If you don't specify any of them, they will be loaded from default config.
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/shared/Database/ORM/README.md
+++ b/shared/Database/ORM/README.md
@@ -9,7 +9,7 @@ In your ORM Model:
 ```php
 use Shared\Database\ORM\FileFieldTrait;
 
-public $files = (
+public $files = array(
     'image' => array(),
     'poster' => array(
         'path' => 'uploads/:class_slug/:attribute/:unique_id-:file_name',


### PR DESCRIPTION
# ORM File Field

Easily upload files to a directory and save the filename to database attribute.

## Usage

In your ORM Model:

```php
use Shared\Database\ORM\FileFieldTrait;

public $files = array(
    'image' => array(),
    'poster' => array(
        'path' => 'uploads/:class_slug/:attribute/:unique_id-:file_name',
        'defaultPath' => 'uploads/default.png'
    )
);
```
In your Controller:

```php
$model = new Poster();

if (Input::hasFile('poster')) {
    $model->poster = Input::file('poster');
}

$model->save();
```
Each field can have filesystem path pattern and default path options. If you don't specify any of them, they will be loaded from default config.