### PR TITLE
Adjust the application to support the renaming the Template Service as Layout

### DIFF
--- a/app/Boot/Global.php
+++ b/app/Boot/Global.php
@@ -41,7 +41,7 @@ App::error(function(HttpException $exception)
     }
 
     // We'll create the templated Error Page Response.
-    $response = Template::make('default')
+    $response = Layout::make('default')
         ->shares('title', 'Error ' .$code)
         ->nest('content', 'Error/' .$code);
 

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -94,7 +94,7 @@ Config::set('app', array(
         'Nova\Validation\ValidationServiceProvider',
         'Nova\Html\HtmlServiceProvider',
         'Nova\View\ViewServiceProvider',
-        'Nova\Template\TemplateServiceProvider',
+        'Nova\Layout\LayoutServiceProvider',
         'Nova\Cron\CronServiceProvider',
     ),
 
@@ -155,7 +155,7 @@ Config::set('app', array(
         'URL'           => 'Nova\Support\Facades\URL',
         'Form'          => 'Nova\Support\Facades\Form',
         'HTML'          => 'Nova\Support\Facades\HTML',
-        'Template'      => 'Nova\Support\Facades\Template',
+        'Layout'        => 'Nova\Support\Facades\Layout',
         'View'          => 'Nova\Support\Facades\View',
         'Cron'          => 'Nova\Support\Facades\Cron',
         'Module'        => 'Nova\Support\Facades\Module',

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -12,9 +12,9 @@ use Nova\Config\Config;
 use Nova\Http\Response;
 use Nova\Routing\Controller as BaseController;
 use Nova\Support\Contracts\RenderableInterface as Renderable;
-use Nova\Support\Facades\Template;
-use Nova\Support\Facades\View;
-use Nova\Template\Template as Layout;
+use Nova\Support\Facades\Layout as LayoutFactory;
+use Nova\Support\Facades\View as ViewFactory;
+use Nova\Layout\Layout;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
@@ -63,7 +63,7 @@ abstract class Controller extends BaseController
             // we will assume we want to render it using the Controller's templated environment.
 
             if (is_string($this->layout) && ! empty($this->layout) && (! $response instanceof Layout)) {
-                $response = Template::make($this->layout, array(), $this->template)
+                $response = LayoutFactory::make($this->layout, array(), $this->template)
                     ->with('content', $response);
             }
 
@@ -99,7 +99,7 @@ abstract class Controller extends BaseController
         if (preg_match('#^App/Controllers/(.*)$#i', $path, $matches)) {
             $view = $matches[1] .'/' .ucfirst($method);
 
-            return View::make($view, $data);
+            return ViewFactory::make($view, $data);
         }
 
         // Retrieve the Modules namespace from their configuration.
@@ -112,7 +112,7 @@ abstract class Controller extends BaseController
         if (preg_match('#^'. $basePath .'/(.+)/Controllers/(.*)$#i', $path, $matches)) {
             $view = $matches[2] .'/' .ucfirst($method);
 
-            return View::make($view, $data, $matches[1]);
+            return ViewFactory::make($view, $data, $matches[1]);
         }
 
         // If we arrived there, the called class is not a Controller; go Exception.
@@ -146,7 +146,7 @@ abstract class Controller extends BaseController
         if ($layout instanceof View) {
             return $layout->with($data);
         } else if (is_string($layout)) {
-            return Template::make($layout, $data, $this->template);
+            return LayoutFactory::make($layout, $data, $this->template);
         }
 
         throw new BadMethodCallException('Method not available for the current Layout');

--- a/app/Templates/AdminLTE/backend-rtl.php
+++ b/app/Templates/AdminLTE/backend-rtl.php
@@ -3,6 +3,8 @@
  * Backend Default RTL Layout
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Prepare the current User Info.
 $user = Auth::user();
 
@@ -208,7 +210,7 @@ $langMenuLinks = ob_get_clean();
       <?php } ?>
     </div>
     <!-- Default to the left -->
-    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a> - </strong> All rights reserved.
+    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a> - </strong> All rights reserved.
   </footer>
 
 </div>

--- a/app/Templates/AdminLTE/backend.php
+++ b/app/Templates/AdminLTE/backend.php
@@ -3,6 +3,8 @@
  * Backend Default Layout
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Prepare the current User Info.
 $user = Auth::user();
 
@@ -208,7 +210,7 @@ $langMenuLinks = ob_get_clean();
       <?php } ?>
     </div>
     <!-- Default to the left -->
-    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a> - </strong> All rights reserved.
+    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a> - </strong> All rights reserved.
   </footer>
 
 </div>

--- a/app/Templates/AdminLTE/default-rtl.php
+++ b/app/Templates/AdminLTE/default-rtl.php
@@ -3,6 +3,8 @@
  * Frontend Default RTL Layout
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Generate the Language Changer menu.
 $langCode = Language::code();
 $langName = Language::name();
@@ -132,7 +134,7 @@ $langMenuLinks = ob_get_clean();
       <?php } ?>
     </div>
     <!-- Default to the left -->
-    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a> - </strong> All rights reserved.
+    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a> - </strong> All rights reserved.
   </footer>
 </div>
 <!-- ./wrapper -->

--- a/app/Templates/AdminLTE/default.php
+++ b/app/Templates/AdminLTE/default.php
@@ -3,6 +3,8 @@
  * Frontend Default Layout
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Generate the Language Changer menu.
 $langCode = Language::code();
 $langName = Language::name();
@@ -132,7 +134,7 @@ $langMenuLinks = ob_get_clean();
       <?php } ?>
     </div>
     <!-- Default to the left -->
-    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a> - </strong> All rights reserved.
+    <strong>Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a> - </strong> All rights reserved.
   </footer>
 </div>
 <!-- ./wrapper -->

--- a/app/Templates/Default/default-rtl.php
+++ b/app/Templates/Default/default-rtl.php
@@ -3,6 +3,8 @@
  * Default RTL Layout - a Layout similar with the classic Header and Footer files.
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Generate the Language Changer menu.
 $language = Language::code();
 
@@ -65,7 +67,7 @@ echo isset($css) ? $css : ''; // Place to pass data / plugable hook zone
     <div class="container-fluid">
         <div class="row" style="margin: 15px 0 0;">
             <div class="col-lg-4">
-                <p class="text-muted">Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a></p>
+                <p class="text-muted">Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a></p>
             </div>
             <div class="col-lg-8">
                 <p class="text-muted pull-right">

--- a/app/Templates/Default/default.php
+++ b/app/Templates/Default/default.php
@@ -3,6 +3,8 @@
  * Default Layout - a Layout similar with the classic Header and Footer files.
  */
 
+$version = trim(file_get_contents(ROOTDIR .'VERSION.txt'));
+
 // Generate the Language Changer menu.
 $language = Language::code();
 
@@ -65,7 +67,7 @@ echo isset($css) ? $css : ''; // Place to pass data / plugable hook zone
     <div class="container-fluid">
         <div class="row" style="margin: 15px 0 0;">
             <div class="col-lg-4">
-                <p class="text-muted">Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= VERSION; ?></b></a></p>
+                <p class="text-muted">Copyright &copy; <?php echo date('Y'); ?> <a href="http://www.novaframework.com/" target="_blank"><b>Nova Framework <?= $version; ?> / Kernel <?= VERSION; ?></b></a></p>
             </div>
             <div class="col-lg-8">
                 <p class="text-muted pull-right">


### PR DESCRIPTION
For a better description, the **Template Service** was renamed as **Layout**, because what it handle really are the Layout files.

Also, this renaming leave room for a future **Template Service** for handling the whole Templates, similar with the Modules one.

Good for a micro version release.