### PR TITLE
[3.0] Implementation of the Template Engine

### DIFF
--- a/app/Boot/Global.php
+++ b/app/Boot/Global.php
@@ -42,7 +42,7 @@ App::error(function(HttpException $exception)
     }
 
     // We'll create the templated Error Page Response.
-    $response = Layout::make('default')
+    $response = View::makeLayout('default')
         ->shares('version', trim($version))
         ->shares('title', 'Error ' .$code)
         ->nest('content', 'Error/' .$code);

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -89,7 +89,6 @@ return array(
         'Nova\Validation\ValidationServiceProvider',
         'Nova\Html\HtmlServiceProvider',
         'Nova\View\ViewServiceProvider',
-        'Nova\Layout\LayoutServiceProvider',
         'Nova\Cron\CronServiceProvider',
 
         // The Application Providers.

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * View Configuration.
+ *
+ * @author Virgil-Adrian Teaca - virgil@giulianaeassociati.com
+ * @version 4.0
+ */
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Compiled View Path
+    |--------------------------------------------------------------------------
+    |
+    | This option determines where all the compiled Template files will be
+    | stored for your application. Typically, this is within the storage
+    | directory. However, as usual, you are free to change this value.
+    |
+    */
+
+    'compiled' => STORAGE_PATH .'views',
+
+);

--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -12,9 +12,9 @@ use Nova\Http\Response;
 use Nova\Routing\Controller as BaseController;
 use Nova\Support\Contracts\RenderableInterface as Renderable;
 use Nova\Support\Facades\Config;
-use Nova\Support\Facades\Layout as LayoutFactory;
 use Nova\Support\Facades\View as ViewFactory;
-use Nova\Layout\Layout;
+use Nova\View\Layout;
+use Nova\View\View;
 
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
@@ -62,8 +62,8 @@ abstract class Controller extends BaseController
             // If the response which is returned from the called Action is a Renderable instance,
             // we will assume we want to render it using the Controller's templated environment.
 
-            if (is_string($this->layout) && ! empty($this->layout) && (! $response instanceof Layout)) {
-                $response = LayoutFactory::make($this->layout, array(), $this->template)
+            if ((! $response instanceof Layout) && is_string($this->layout) && ! empty($this->layout)) {
+                $response = ViewFactory::makeLayout($this->layout, $this->template)
                     ->with('content', $response);
             }
 

--- a/app/Views/Welcome/SubPage.php
+++ b/app/Views/Welcome/SubPage.php
@@ -1,9 +1,0 @@
-<div class="page-header">
-	<h1><?=$title;?></h1>
-</div>
-
-<p><?=$welcomeMessage;?></p>
-
-<a class="btn btn-md btn-success" href="<?= site_url(); ?>">
-    <?= __('Home'); ?>
-</a>

--- a/app/Views/Welcome/SubPage.tpl
+++ b/app/Views/Welcome/SubPage.tpl
@@ -1,0 +1,9 @@
+<div class="page-header">
+    <h1>{{ $title }}</h1>
+</div>
+
+<p>{{ $welcomeMessage }}</p>
+
+<a class="btn btn-md btn-success" href="{{ site_url() }}">
+    {{ __('Home') }}
+</a>

--- a/app/Views/Welcome/Welcome.php
+++ b/app/Views/Welcome/Welcome.php
@@ -1,9 +1,0 @@
-<div class="page-header">
-	<h1><?=$title;?></h1>
-</div>
-
-<p><?=$welcomeMessage;?></p>
-
-<a class="btn btn-md btn-success" href="<?= site_url('subpage'); ?>">
-    <?= __('Open subpage'); ?>
-</a>

--- a/app/Views/Welcome/Welcome.tpl
+++ b/app/Views/Welcome/Welcome.tpl
@@ -1,0 +1,9 @@
+<div class="page-header">
+    <h1>{{ $title }}</h1>
+</div>
+
+<p>{{ $welcomeMessage }}</p>
+
+<a class="btn btn-md btn-success" href="{{ site_url('subpage') }}">
+    {{ __('Open subpage') }}
+</a>

--- a/storage/views/.gitignore
+++ b/storage/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This pull request introduce the native **Template Engine** which respond to View files with the extension `.tpl` and update the Views Service.

To note the that the `Layout Service` is removed, the equivalent API being included into `Views Service`.

Then, instead of:
```php
$template = Layout::make('default', $data, $template);
```
You should do:
```php
$template = View::makeLayout('default', $template);
```

This pull request introduce API breaks, good for a minor release.