### PR TITLE
[3.0] Rename the base Controllers

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -6,12 +6,13 @@
  * @version 3.0
  */
 
-namespace App\Core;
+namespace App\Controllers;
 
 use Nova\Foundation\Auth\Access\AuthorizeRequestsTrait;
 use Nova\Foundation\Validation\ValidateRequestsTrait;
-use Nova\Routing\Controller as BaseController;
+use Nova\Routing\Controller;
 use Nova\Support\Contracts\RenderableInterface as Renderable;
+use Nova\Support\Facades\App;
 use Nova\Support\Facades\Config;
 use Nova\Support\Facades\Response;
 use Nova\Support\Facades\View;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use BadMethodCallException;
 
 
-abstract class Controller extends BaseController
+abstract class BaseController extends Controller
 {
     use AuthorizeRequestsTrait, ValidateRequestsTrait;
 
@@ -92,24 +93,11 @@ abstract class Controller extends BaseController
          // Transform the complete class name on a path like variable.
         $path = str_replace('\\', '/', static::class);
 
-        // Check for a valid controller on Application.
-        if (preg_match('#^App/Controllers/(.*)$#i', $path, $matches)) {
-            $view = $matches[1] .'/' .ucfirst($method);
+        // Check for a valid controller on App and its Modules.
+        if (preg_match('#^App(?:/Modules/(.+))?/Controllers/(.*)$#', $path, $matches) === 1) {
+            $module = ! empty($matches[1]) ? $matches[1] : '';
 
-            return View::make($view, $data, '', $this->theme);
-        }
-
-        // Retrieve the Modules namespace from their configuration.
-        $namespace = Config::get('modules.namespace', 'App\Modules\\');
-
-        // Transform the Modules namespace on a path like variable.
-        $basePath = str_replace('\\', '/', rtrim($namespace, '\\'));
-
-        // Check for a valid controller on Modules.
-        if (preg_match('#^'. $basePath .'/(.+)/Controllers/(.*)$#i', $path, $matches)) {
-            $module = $matches[1];
-
-            $view = $matches[2] .'/' .ucfirst($method);
+            $view = sprintf('%s/%s', $matches[2], ucfirst($method));
 
             return View::make($view, $data, $module, $this->theme);
         }

--- a/app/Controllers/Welcome.php
+++ b/app/Controllers/Welcome.php
@@ -8,7 +8,7 @@
 
 namespace App\Controllers;
 
-use App\Core\Controller;
+use App\Controllers\BaseController;
 
 use View;
 
@@ -16,7 +16,7 @@ use View;
 /**
  * Sample controller showing 2 methods and their typical usage.
  */
-class Welcome extends Controller
+class Welcome extends BaseController
 {
     /**
      * The currently used Layout.
@@ -25,7 +25,7 @@ class Welcome extends Controller
      */
     protected $layout = 'Welcome';
 
-    
+
     /**
      * Create and return a View instance.
      */

--- a/app/Modules/Demos/Controllers/Demos.php
+++ b/app/Modules/Demos/Controllers/Demos.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\Demos\Controllers;
 
-use App\Core\Controller;
+use App\Controllers\BaseController;
 
 use Nova\Routing\Route;
 
@@ -30,7 +30,7 @@ use View;
 *
 * Demo controller
 */
-class Demos extends Controller
+class Demos extends BaseController
 {
     /**
      * Define Index method

--- a/app/Modules/Files/Controllers/Admin/Files.php
+++ b/app/Modules/Files/Controllers/Admin/Files.php
@@ -2,7 +2,7 @@
 
 namespace App\Modules\Files\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 
 use Nova\Http\Request;
 use Nova\Routing\Route;
@@ -13,7 +13,7 @@ use Response;
 use View;
 
 
-class Files extends BackendController
+class Files extends BaseController
 {
     /**
      * The IoC container instance.

--- a/app/Modules/System/Controllers/Admin/Dashboard.php
+++ b/app/Modules/System/Controllers/Admin/Dashboard.php
@@ -8,12 +8,12 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 
 use View;
 
 
-class Dashboard extends BackendController
+class Dashboard extends BaseController
 {
 
     public function index()

--- a/app/Modules/System/Controllers/Admin/Profile.php
+++ b/app/Modules/System/Controllers/Admin/Profile.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 use App\Models\User;
 
 use Auth;
@@ -19,7 +19,7 @@ use Validator;
 use View;
 
 
-class Profile extends BackendController
+class Profile extends BaseController
 {
 
     protected function validator(array $data, User $user)

--- a/app/Modules/System/Controllers/Admin/Settings.php
+++ b/app/Modules/System/Controllers/Admin/Settings.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\System\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 use App\Models\Option;
 
 use Cache;
@@ -19,7 +19,7 @@ use Validator;
 use View;
 
 
-class Settings extends BackendController
+class Settings extends BaseController
 {
 
     public function __construct()

--- a/app/Modules/System/Controllers/Authorize.php
+++ b/app/Modules/System/Controllers/Authorize.php
@@ -10,7 +10,7 @@ namespace App\Modules\System\Controllers;
 
 use Nova\Helpers\ReCaptcha;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 
 use App;
 use Auth;
@@ -23,7 +23,7 @@ use Session;
 use View;
 
 
-class Authorize extends BackendController
+class Authorize extends BaseController
 {
     protected $layout = 'Default';
 

--- a/app/Modules/System/Controllers/BaseController.php
+++ b/app/Modules/System/Controllers/BaseController.php
@@ -6,7 +6,7 @@
  * @version 3.0
  */
 
-namespace App\Core;
+namespace App\Modules\System\Controllers;
 
 use Nova\Http\Request;
 use Nova\Routing\Route;
@@ -16,10 +16,10 @@ use Nova\Support\Facades\Event;
 use Nova\Support\Facades\Redirect;
 use Nova\Support\Facades\View;
 
-use App\Core\Controller as BaseController;
+use App\Controllers\BaseController as Controller;
 
 
-abstract class BackendController extends BaseController
+abstract class BaseController extends Controller
 {
     /**
      * The currently used Theme.

--- a/app/Modules/System/Controllers/Registrar.php
+++ b/app/Modules/System/Controllers/Registrar.php
@@ -10,9 +10,10 @@ namespace App\Modules\System\Controllers;
 
 use Nova\Helpers\ReCaptcha;
 
-use App\Core\BackendController;
 use App\Models\Role;
 use App\Models\User;
+
+use App\Modules\System\Controllers\BaseController;
 
 use Auth;
 use Config;
@@ -25,7 +26,7 @@ use Validator;
 use View;
 
 
-class Registrar extends BackendController
+class Registrar extends BaseController
 {
     protected $layout = 'Default';
 

--- a/app/Modules/Users/Controllers/Admin/Roles.php
+++ b/app/Modules/Users/Controllers/Admin/Roles.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\Users\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 use App\Models\Role;
 
 use Carbon\Carbon;
@@ -22,7 +22,7 @@ use Validator;
 use View;
 
 
-class Roles extends BackendController
+class Roles extends BaseController
 {
 
     public function __construct()

--- a/app/Modules/Users/Controllers/Admin/Users.php
+++ b/app/Modules/Users/Controllers/Admin/Users.php
@@ -8,7 +8,7 @@
 
 namespace App\Modules\Users\Controllers\Admin;
 
-use App\Core\BackendController;
+use App\Modules\System\Controllers\BaseController;
 use App\Models\Role;
 use App\Models\User;
 
@@ -25,7 +25,7 @@ use View;
 
 
 
-class Users extends BackendController
+class Users extends BaseController
 {
 
     public function __construct()


### PR DESCRIPTION
This pull request renames the base Controllers for consistency, as following:

`App\Core\Controller` -> `App\Controllers\BaseController`
`App\Core\BackendController` -> `App\Modules\System\Controllers\BaseController`

Additionally, improvements are applied to `App\Controllers\BaseController@getView`