### PR TITLE
[3.0] Improve the API support

### DIFF
--- a/app/Database/Migrations/2017_09_15_074021_create_users_table.php
+++ b/app/Database/Migrations/2017_09_15_074021_create_users_table.php
@@ -25,6 +25,7 @@ class CreateUsersTable extends Migration
             $table->tinyInteger('activated')->unsigned()->default(0);
             $table->string('activation_code')->nullable();
             $table->string('remember_token')->nullable();
+            $table->string('api_token', 100)->unique();
             $table->timestamps();
         });
     }

--- a/app/Database/Migrations/2017_09_15_074021_create_users_table.php
+++ b/app/Database/Migrations/2017_09_15_074021_create_users_table.php
@@ -25,7 +25,7 @@ class CreateUsersTable extends Migration
             $table->tinyInteger('activated')->unsigned()->default(0);
             $table->string('activation_code')->nullable();
             $table->string('remember_token')->nullable();
-            $table->string('api_token', 100)->unique();
+            $table->string('api_token', 100)->unique()->nullable();
             $table->timestamps();
         });
     }

--- a/app/Database/Seeds/UsersTableSeeder.php
+++ b/app/Database/Seeds/UsersTableSeeder.php
@@ -5,12 +5,16 @@ namespace App\Database\Seeds;
 use Nova\Database\ORM\Model;
 use Nova\Database\Seeder;
 use Nova\Support\Facades\Hash;
+use Nova\Support\Str;
 
 use App\Models\User;
 
 
 class UsersTableSeeder extends Seeder
 {
+    protected $tokens = array();
+
+
     /**
      * Run the database seeds.
      *
@@ -30,6 +34,7 @@ class UsersTableSeeder extends Seeder
             'email'          => 'admin@novaframework.dev',
             'activated'      => 1,
             'remember_token' => '',
+            'api_token'      => $this->uniqueToken(),
         ));
 
         User::create(array(
@@ -41,6 +46,7 @@ class UsersTableSeeder extends Seeder
             'email'          => 'marcus@novaframework.dev',
             'activated'      => 1,
             'remember_token' => '',
+            'api_token'      => $this->uniqueToken(),
         ));
 
         User::create(array(
@@ -52,6 +58,7 @@ class UsersTableSeeder extends Seeder
             'email'          => 'michael@novaframework.dev',
             'activated'      => 1,
             'remember_token' => '',
+            'api_token'      => $this->uniqueToken(),
         ));
 
         User::create(array(
@@ -63,6 +70,7 @@ class UsersTableSeeder extends Seeder
             'email'          => 'john@novaframework.dev',
             'activated'      => 1,
             'remember_token' => '',
+            'api_token'      => $this->uniqueToken(),
         ));
 
         User::create(array(
@@ -74,6 +82,20 @@ class UsersTableSeeder extends Seeder
             'email'          => 'mark@novaframework.dev',
             'activated'      => 1,
             'remember_token' => '',
+            'api_token'      => $this->uniqueToken(),
         ));
+    }
+
+    protected function uniqueToken($length = 60)
+    {
+        while (true) {
+            $token = Str::random($length);
+
+            if (! in_array($token, $this->tokens)) {
+                array_push($this->tokens, $token);
+
+                return $token;
+            }
+        }
     }
 }

--- a/app/Filters.php
+++ b/app/Filters.php
@@ -63,11 +63,14 @@ Route::filter('auth', function ($route, $request, $guard = null)
     $guard = $guard ?: Config::get('auth.defaults.guard', 'web');
 
     if (Auth::guard($guard)->check()) {
+        // User authenticated with this Guard, then we will use it as default.
+        Auth::shouldUse($guard);
+
         return;
     }
 
     // The User is not authenticated.
-    else if ($request->ajax() || $request->wantsJson()) {
+    else if ($request->ajax() || $request->wantsJson() || $request->is('api/*')) {
         return Response::make('Unauthorized Access', 401);
     }
 

--- a/app/Filters.php
+++ b/app/Filters.php
@@ -94,7 +94,7 @@ Route::filter('guest', function ($route, $request, $guard = null)
     }
 
     // The User is authenticated.
-    else if ($request->ajax() || $request->wantsJson()) {
+    else if ($request->ajax() || $request->wantsJson() || $request->is('api/*')) {
         return Response::json(array('error' => 'Unauthorized Access'), 401);
     }
 

--- a/app/Filters.php
+++ b/app/Filters.php
@@ -71,7 +71,7 @@ Route::filter('auth', function ($route, $request, $guard = null)
 
     // The User is not authenticated.
     else if ($request->ajax() || $request->wantsJson() || $request->is('api/*')) {
-        return Response::make('Unauthorized Access', 401);
+        return Response::json(array('error' => 'Unauthorized Access'), 401);
     }
 
     // Get the Guard's authorize path from configuration.
@@ -95,7 +95,7 @@ Route::filter('guest', function ($route, $request, $guard = null)
 
     // The User is authenticated.
     else if ($request->ajax() || $request->wantsJson()) {
-        return Response::make('Unauthorized Access', 401);
+        return Response::json(array('error' => 'Unauthorized Access'), 401);
     }
 
     // Get the Guard's dashboard path from configuration.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,9 +27,9 @@ class User extends BaseModel implements UserInterface, RemindableInterface
 
     protected $primaryKey = 'id';
 
-    protected $fillable = array('role_id', 'username', 'password', 'realname', 'email', 'activated', 'image', 'activation_code');
+    protected $fillable = array('role_id', 'username', 'password', 'realname', 'email', 'activated', 'image', 'activation_code', 'api_token');
 
-    protected $hidden = array('password', 'activation_code', 'remember_token');
+    protected $hidden = array('password', 'activation_code', 'remember_token', 'api_token');
 
     public $files = array(
         'image' => array(

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -14,9 +14,16 @@ use Nova\Http\Request;
 
 /** Define static routes. */
 
-// The default Routing
+// The Web Routes
 Route::get('/',       'Welcome@index');
 Route::get('subpage', 'Welcome@subPage');
+
+
+// The API Routes
+Route::get('api/user', array('before' => 'auth:api', function (Request $request)
+{
+    return $request->user();
+}));
 
 
 // The Language Changer


### PR DESCRIPTION
This pull request improve the API support, and implements the Token-based Authentication infrastructure needed by APIs.

Also, now after a positive check of the User authentication over a Guard, it is set as default for the further use by the `auth` Filter.

Finally, was added an example of API Route:
```php
Route::get('api/user', array('before' => 'auth:api', function (Request $request)
{
    return $request->user();
}));
```
