### PR TITLE
Improve the Route Filters and the AdminLite theme

### DIFF
--- a/app/Themes/AdminLite/Layouts/Backend.php
+++ b/app/Themes/AdminLite/Layouts/Backend.php
@@ -216,12 +216,13 @@ Assets::js(array(
     vendor_url('bower_components/jquery-slimscroll/jquery.slimscroll.min.js', 'almasaeed2010/adminlte'),
     // FastClick
     vendor_url('bower_components/fastclick/lib/fastclick.js', 'almasaeed2010/adminlte'),
-    // AdminLTE App
-    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
     // Select2
     vendor_url('bower_components/select2/dist/js/select2.full.min.js', 'almasaeed2010/adminlte'),
+    vendor_url('bower_components/select2/dist/js/i18n/' .$langCode .'.js', 'almasaeed2010/adminlte'),
     // iCheck
     vendor_url('plugins/iCheck/icheck.min.js', 'almasaeed2010/adminlte'),
+    // AdminLTE App
+    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data

--- a/app/Themes/AdminLite/Layouts/Default.php
+++ b/app/Themes/AdminLite/Layouts/Default.php
@@ -144,10 +144,10 @@ $languages = Config::get('languages');
 Assets::js(array(
     // Bootstrap 3.3.5
     vendor_url('bower_components/bootstrap/dist/js/bootstrap.min.js', 'almasaeed2010/adminlte'),
-    // AdminLTE App
-    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
     // iCheck
     vendor_url('plugins/iCheck/icheck.min.js', 'almasaeed2010/adminlte'),
+    // AdminLTE App
+    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data

--- a/app/Themes/AdminLite/Layouts/Frontend.php
+++ b/app/Themes/AdminLite/Layouts/Frontend.php
@@ -199,10 +199,10 @@ if (isset($user->image) && $user->image->exists()) {
 Assets::js(array(
     // Bootstrap 3.3.5
     vendor_url('bower_components/bootstrap/dist/js/bootstrap.min.js', 'almasaeed2010/adminlte'),
-    // AdminLTE App
-    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
     // iCheck
     vendor_url('plugins/iCheck/icheck.min.js', 'almasaeed2010/adminlte'),
+    // AdminLTE App
+    vendor_url('dist/js/adminlte.min.js', 'almasaeed2010/adminlte'),
 ));
 
 echo isset($js) ? $js : ''; // Place to pass data


### PR DESCRIPTION
This pull request improve the `auth` Route Filter, now it permitting to specify multiple Authentication Guards for checking.

For example, for checking against either `web` or `students` guards:
```php
Route::get('attachments/{token}/{filename}', array(
    'before' => 'auth:web,students',
    'uses'   => 'Attachments@serve'
));
```
This is specially useful when the application use multiple Authentication Guards, aka **Multi-Auth**.

Also, some small changes into AdminLite theme are included.